### PR TITLE
Fix random range in eigen_utils tests

### DIFF
--- a/tests/test_eigen_utils.cpp
+++ b/tests/test_eigen_utils.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <cstdlib>
 #include <sycl_points/utils/eigen_utils.hpp>
 
 namespace sycl_points {
@@ -12,7 +13,44 @@ constexpr float DET_EPSILON = 1e-4f;
 constexpr float MATMUL_EPSILON = 1e-4f;
 constexpr float INVERSE_EPSILON = 1e-3f;
 constexpr size_t TEST_ITERATIONS = 1000;
-constexpr float RANDOM_SCALE = 10.0f;  // -10.0 ~ +10.0
+constexpr float RANDOM_SCALE = 10.0f;  // Range scale for random values
+
+// Generate a random floating-point number in [-RANDOM_SCALE, RANDOM_SCALE]
+inline float random_float() {
+    // rand()/RAND_MAX -> [0,1], scale to [-RANDOM_SCALE, RANDOM_SCALE]
+    return static_cast<float>(rand()) / static_cast<float>(RAND_MAX) * 2.0f * RANDOM_SCALE - RANDOM_SCALE;
+}
+
+// Generate a random matrix of size MxN with elements in [-RANDOM_SCALE, RANDOM_SCALE]
+template <int M, int N>
+Eigen::Matrix<float, M, N> random_matrix() {
+    Eigen::Matrix<float, M, N> m;
+    for (int i = 0; i < M; ++i) {
+        for (int j = 0; j < N; ++j) {
+            m(i, j) = random_float();
+        }
+    }
+    return m;
+}
+
+// Generate a random vector of size M with elements in [-RANDOM_SCALE, RANDOM_SCALE]
+template <int M>
+Eigen::Matrix<float, M, 1> random_vector() {
+    Eigen::Matrix<float, M, 1> v;
+    for (int i = 0; i < M; ++i) {
+        v(i) = random_float();
+    }
+    return v;
+}
+
+// Generate a random scalar in [-RANDOM_SCALE, RANDOM_SCALE]
+inline float random_scalar() {
+    return random_float();
+}
+
+#define RANDOM_MATRIX(M, N) random_matrix<M, N>()
+#define RANDOM_VECTOR(M) random_vector<M>()
+#define RANDOM_SCALAR() random_scalar()
 
 ::testing::AssertionResult AssertMatrixExactEqual(const char* expr1, const char* expr2, const Eigen::MatrixXf& m1,
                                                   const Eigen::MatrixXf& m2) {
@@ -154,8 +192,8 @@ TEST_F(EigenUtilsTest, add) {
         {
             constexpr size_t M = 3;
             constexpr size_t N = 3;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, M, N> B = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
+            const Eigen::Matrix<float, M, N> B = RANDOM_MATRIX(M, N);
             const Eigen::Matrix<float, M, N> expected = A + B;
             const Eigen::Matrix<float, M, N> result = add<M, N>(A, B);
 
@@ -165,8 +203,8 @@ TEST_F(EigenUtilsTest, add) {
         {
             constexpr size_t M = 4;
             constexpr size_t N = 4;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, M, N> B = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
+            const Eigen::Matrix<float, M, N> B = RANDOM_MATRIX(M, N);
             const Eigen::Matrix<float, M, N> expected = A + B;
             const Eigen::Matrix<float, M, N> result = add<M, N>(A, B);
 
@@ -175,8 +213,8 @@ TEST_F(EigenUtilsTest, add) {
         // vector3
         {
             constexpr size_t M = 3;
-            const Eigen::Vector<float, M> A = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
-            const Eigen::Vector<float, M> B = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
+            const Eigen::Vector<float, M> A = RANDOM_VECTOR(M);
+            const Eigen::Vector<float, M> B = RANDOM_VECTOR(M);
             const Eigen::Vector<float, M> expected = A + B;
             const Eigen::Vector<float, M> result = add<M, 1>(A, B);
 
@@ -185,8 +223,8 @@ TEST_F(EigenUtilsTest, add) {
         // vector4
         {
             constexpr size_t M = 4;
-            const Eigen::Vector<float, M> A = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
-            const Eigen::Vector<float, M> B = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
+            const Eigen::Vector<float, M> A = RANDOM_VECTOR(M);
+            const Eigen::Vector<float, M> B = RANDOM_VECTOR(M);
             const Eigen::Vector<float, M> expected = A + B;
             const Eigen::Vector<float, M> result = add<M, 1>(A, B);
 
@@ -201,8 +239,8 @@ TEST_F(EigenUtilsTest, add_inplace) {
         {
             constexpr size_t M = 3;
             constexpr size_t N = 3;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, M, N> B = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
+            const Eigen::Matrix<float, M, N> B = RANDOM_MATRIX(M, N);
             const Eigen::Matrix<float, M, N> expected = A + B;
             Eigen::Matrix<float, M, N> actual = A;
             add_inplace<M, N>(actual, B);
@@ -213,8 +251,8 @@ TEST_F(EigenUtilsTest, add_inplace) {
         {
             constexpr size_t M = 4;
             constexpr size_t N = 4;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, M, N> B = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
+            const Eigen::Matrix<float, M, N> B = RANDOM_MATRIX(M, N);
             const Eigen::Matrix<float, M, N> expected = A + B;
             Eigen::Matrix<float, M, N> actual = A;
             add_inplace<M, N>(actual, B);
@@ -225,8 +263,8 @@ TEST_F(EigenUtilsTest, add_inplace) {
         {
             constexpr size_t M = 3;
             constexpr size_t N = 1;
-            const Eigen::Vector<float, M> A = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
-            const Eigen::Vector<float, M> B = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
+            const Eigen::Vector<float, M> A = RANDOM_VECTOR(M);
+            const Eigen::Vector<float, M> B = RANDOM_VECTOR(M);
             const Eigen::Vector<float, M> expected = A + B;
             Eigen::Vector<float, M> actual = A;
             add_inplace<M, 1>(actual, B);
@@ -236,8 +274,8 @@ TEST_F(EigenUtilsTest, add_inplace) {
         // vector4
         {
             constexpr size_t M = 4;
-            const Eigen::Vector<float, M> A = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
-            const Eigen::Vector<float, M> B = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
+            const Eigen::Vector<float, M> A = RANDOM_VECTOR(M);
+            const Eigen::Vector<float, M> B = RANDOM_VECTOR(M);
             const Eigen::Vector<float, M> expected = A + B;
             Eigen::Vector<float, M> actual = A;
             add_inplace<M, 1>(actual, B);
@@ -253,8 +291,8 @@ TEST_F(EigenUtilsTest, subtract) {
         {
             constexpr size_t M = 3;
             constexpr size_t N = 3;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, M, N> B = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
+            const Eigen::Matrix<float, M, N> B = RANDOM_MATRIX(M, N);
             const Eigen::Matrix<float, M, N> expected = A - B;
             const Eigen::Matrix<float, M, N> result = subtract<M, N>(A, B);
 
@@ -264,8 +302,8 @@ TEST_F(EigenUtilsTest, subtract) {
         {
             constexpr size_t M = 4;
             constexpr size_t N = 4;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, M, N> B = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
+            const Eigen::Matrix<float, M, N> B = RANDOM_MATRIX(M, N);
             const Eigen::Matrix<float, M, N> expected = A - B;
             const Eigen::Matrix<float, M, N> result = subtract<M, N>(A, B);
 
@@ -274,8 +312,8 @@ TEST_F(EigenUtilsTest, subtract) {
         // vector3
         {
             constexpr size_t M = 3;
-            const Eigen::Vector<float, M> A = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
-            const Eigen::Vector<float, M> B = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
+            const Eigen::Vector<float, M> A = RANDOM_VECTOR(M);
+            const Eigen::Vector<float, M> B = RANDOM_VECTOR(M);
             const Eigen::Vector<float, M> expected = A - B;
             const Eigen::Vector<float, M> result = subtract<M, 1>(A, B);
 
@@ -284,8 +322,8 @@ TEST_F(EigenUtilsTest, subtract) {
         // vector4
         {
             constexpr size_t M = 4;
-            const Eigen::Vector<float, M> A = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
-            const Eigen::Vector<float, M> B = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
+            const Eigen::Vector<float, M> A = RANDOM_VECTOR(M);
+            const Eigen::Vector<float, M> B = RANDOM_VECTOR(M);
             const Eigen::Vector<float, M> expected = A - B;
             const Eigen::Vector<float, M> result = subtract<M, 1>(A, B);
 
@@ -301,44 +339,44 @@ TEST_F(EigenUtilsTest, multiply) {
             constexpr size_t M = 3;
             constexpr size_t K = 3;
             constexpr size_t N = 3;
-            const Eigen::Matrix<float, M, K> A = Eigen::Matrix<float, M, K>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, K, N> B = Eigen::Matrix<float, K, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, K> A = RANDOM_MATRIX(M, K);
+            const Eigen::Matrix<float, K, N> B = RANDOM_MATRIX(K, N);
             const Eigen::Matrix<float, M, N> expected = A * B;
             const Eigen::Matrix<float, M, N> result = multiply<M, K, N>(A, B);
 
-            EXPECT_MATRIX_NEAR(expected, result, BASE_EPSILON);
+            EXPECT_MATRIX_NEAR(expected, result, MATMUL_EPSILON);
         }
         // 4x4 * 4x4
         {
             constexpr size_t M = 4;
             constexpr size_t K = 4;
             constexpr size_t N = 4;
-            const Eigen::Matrix<float, M, K> A = Eigen::Matrix<float, M, K>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, K, N> B = Eigen::Matrix<float, K, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, K> A = RANDOM_MATRIX(M, K);
+            const Eigen::Matrix<float, K, N> B = RANDOM_MATRIX(K, N);
             const Eigen::Matrix<float, M, N> expected = A * B;
             const Eigen::Matrix<float, M, N> result = multiply<M, K, N>(A, B);
 
-            EXPECT_MATRIX_NEAR(expected, result, BASE_EPSILON);
+            EXPECT_MATRIX_NEAR(expected, result, MATMUL_EPSILON);
         }
         // 6x4 * 4x6
         {
             constexpr size_t M = 6;
             constexpr size_t K = 4;
             constexpr size_t N = 6;
-            const Eigen::Matrix<float, M, K> A = Eigen::Matrix<float, M, K>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, K, N> B = Eigen::Matrix<float, K, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, K> A = RANDOM_MATRIX(M, K);
+            const Eigen::Matrix<float, K, N> B = RANDOM_MATRIX(K, N);
             const Eigen::Matrix<float, M, N> expected = A * B;
             const Eigen::Matrix<float, M, N> result = multiply<M, K, N>(A, B);
 
-            EXPECT_MATRIX_NEAR(expected, result, BASE_EPSILON);
+            EXPECT_MATRIX_NEAR(expected, result, MATMUL_EPSILON);
         }
         // 6x4 * 4x4
         {
             constexpr size_t M = 6;
             constexpr size_t K = 4;
             constexpr size_t N = 4;
-            const Eigen::Matrix<float, M, K> A = Eigen::Matrix<float, M, K>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, K, N> B = Eigen::Matrix<float, K, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, K> A = RANDOM_MATRIX(M, K);
+            const Eigen::Matrix<float, K, N> B = RANDOM_MATRIX(K, N);
             const Eigen::Matrix<float, M, N> expected = A * B;
             const Eigen::Matrix<float, M, N> result = multiply<M, K, N>(A, B);
 
@@ -349,8 +387,8 @@ TEST_F(EigenUtilsTest, multiply) {
             constexpr size_t M = 6;
             constexpr size_t K = 4;
             constexpr size_t N = 1;
-            const Eigen::Matrix<float, M, K> A = Eigen::Matrix<float, M, K>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, K, N> B = Eigen::Matrix<float, K, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, K> A = RANDOM_MATRIX(M, K);
+            const Eigen::Matrix<float, K, N> B = RANDOM_MATRIX(K, N);
             const Eigen::Vector<float, M> expected = A * B;
             const Eigen::Vector<float, M> result = multiply<M, K, N>(A, B);
 
@@ -361,8 +399,8 @@ TEST_F(EigenUtilsTest, multiply) {
             constexpr size_t M = 10;
             constexpr size_t K = 20;
             constexpr size_t N = 30;
-            const Eigen::Matrix<float, M, K> A = Eigen::Matrix<float, M, K>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, K, N> B = Eigen::Matrix<float, K, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, K> A = RANDOM_MATRIX(M, K);
+            const Eigen::Matrix<float, K, N> B = RANDOM_MATRIX(K, N);
             const Eigen::Matrix<float, M, N> expected = A * B;
             const Eigen::Matrix<float, M, N> result = multiply<M, K, N>(A, B);
 
@@ -372,8 +410,8 @@ TEST_F(EigenUtilsTest, multiply) {
         {
             constexpr size_t M = 4;
             constexpr size_t N = 4;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
-            const float b = Eigen::Matrix<float, 1, 1>::Random()(0, 0);
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
+            const float b = RANDOM_SCALAR();
             const Eigen::Matrix<float, M, N> expected = A * b;
             const Eigen::Matrix<float, M, N> result = multiply<M, N>(A, b);
 
@@ -382,8 +420,8 @@ TEST_F(EigenUtilsTest, multiply) {
         // vector4 * scalar
         {
             constexpr size_t M = 4;
-            const Eigen::Vector<float, M> A = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
-            const float b = Eigen::Matrix<float, 1, 1>::Random()(0, 0);
+            const Eigen::Vector<float, M> A = RANDOM_VECTOR(M);
+            const float b = RANDOM_SCALAR();
             const Eigen::Vector<float, M> expected = A * b;
             const Eigen::Vector<float, M> result = multiply<M>(A, b);
 
@@ -399,8 +437,8 @@ TEST_F(EigenUtilsTest, multiply_inplace) {
         {
             constexpr size_t M = 3;
             constexpr size_t N = 3;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
-            const float scalar = Eigen::Matrix<float, 1, 1>::Random()(0, 0);
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
+            const float scalar = RANDOM_SCALAR();
             const Eigen::Matrix<float, M, N> expected = A * scalar;
             Eigen::Matrix<float, M, N> actual = A;
             multiply_inplace<M, N>(actual, scalar);
@@ -410,8 +448,8 @@ TEST_F(EigenUtilsTest, multiply_inplace) {
         {
             constexpr size_t M = 4;
             constexpr size_t N = 4;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
-            const float scalar = Eigen::Matrix<float, 1, 1>::Random()(0, 0);
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
+            const float scalar = RANDOM_SCALAR();
             const Eigen::Matrix<float, M, N> expected = A * scalar;
             Eigen::Matrix<float, M, N> actual = A;
             multiply_inplace<M, N>(actual, scalar);
@@ -426,8 +464,8 @@ TEST_F(EigenUtilsTest, element_wise_multiply) {
         {
             constexpr size_t M = 3;
             constexpr size_t N = 3;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, M, N> B = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
+            const Eigen::Matrix<float, M, N> B = RANDOM_MATRIX(M, N);
             const Eigen::Matrix<float, M, N> expected = A.cwiseProduct(B);
             const Eigen::Matrix<float, M, N> result = element_wise_multiply<M, N>(A, B);
             EXPECT_MATRIX_NEAR(expected, result, BASE_EPSILON);
@@ -436,8 +474,8 @@ TEST_F(EigenUtilsTest, element_wise_multiply) {
         {
             constexpr size_t M = 4;
             constexpr size_t N = 4;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
-            const Eigen::Matrix<float, M, N> B = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
+            const Eigen::Matrix<float, M, N> B = RANDOM_MATRIX(M, N);
             const Eigen::Matrix<float, M, N> expected = A.cwiseProduct(B);
             const Eigen::Matrix<float, M, N> result = element_wise_multiply<M, N>(A, B);
             EXPECT_MATRIX_NEAR(expected, result, BASE_EPSILON);
@@ -451,7 +489,7 @@ TEST_F(EigenUtilsTest, transpose) {
         {
             constexpr size_t M = 3;
             constexpr size_t N = 3;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
             const Eigen::Matrix<float, N, M> expected = A.transpose();
             const Eigen::Matrix<float, N, M> result = transpose<M, N>(A);
             EXPECT_MATRIX_EXACT_EQ(expected, result);
@@ -460,7 +498,7 @@ TEST_F(EigenUtilsTest, transpose) {
         {
             constexpr size_t M = 4;
             constexpr size_t N = 6;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
             const Eigen::Matrix<float, N, M> expected = A.transpose();
             const Eigen::Matrix<float, N, M> result = transpose<M, N>(A);
             EXPECT_MATRIX_EXACT_EQ(expected, result);
@@ -473,8 +511,8 @@ TEST_F(EigenUtilsTest, dot) {
         // size 3
         {
             constexpr size_t M = 3;
-            const Eigen::Vector<float, M> a = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
-            const Eigen::Vector<float, M> b = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
+            const Eigen::Vector<float, M> a = RANDOM_VECTOR(M);
+            const Eigen::Vector<float, M> b = RANDOM_VECTOR(M);
             const float expected = a.dot(b);
             const float result = dot<M>(a, b);
             EXPECT_SCALAR_NEAR(expected, result, BASE_EPSILON);
@@ -482,8 +520,8 @@ TEST_F(EigenUtilsTest, dot) {
         // size 4
         {
             constexpr size_t M = 4;
-            const Eigen::Vector<float, M> a = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
-            const Eigen::Vector<float, M> b = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
+            const Eigen::Vector<float, M> a = RANDOM_VECTOR(M);
+            const Eigen::Vector<float, M> b = RANDOM_VECTOR(M);
             const float expected = a.dot(b);
             const float result = dot<M>(a, b);
             EXPECT_SCALAR_NEAR(expected, result, BASE_EPSILON);
@@ -493,8 +531,8 @@ TEST_F(EigenUtilsTest, dot) {
 
 TEST_F(EigenUtilsTest, cross) {
     for (size_t iter = 0; iter < TEST_ITERATIONS; ++iter) {
-        const Eigen::Vector3f a = Eigen::Vector3f::Random() * RANDOM_SCALE;
-        const Eigen::Vector3f b = Eigen::Vector3f::Random() * RANDOM_SCALE;
+        const Eigen::Vector3f a = RANDOM_VECTOR(3);
+        const Eigen::Vector3f b = RANDOM_VECTOR(3);
         const Eigen::Vector3f expected = a.cross(b);
         const Eigen::Vector3f result = cross(a, b);
         EXPECT_VECTOR_NEAR(expected, result, BASE_EPSILON);
@@ -503,8 +541,8 @@ TEST_F(EigenUtilsTest, cross) {
 
 TEST_F(EigenUtilsTest, outer) {
     for (size_t iter = 0; iter < TEST_ITERATIONS; ++iter) {
-        const Eigen::Vector4f a = Eigen::Vector4f::Random() * RANDOM_SCALE;
-        const Eigen::Vector4f b = Eigen::Vector4f::Random() * RANDOM_SCALE;
+        const Eigen::Vector4f a = RANDOM_VECTOR(4);
+        const Eigen::Vector4f b = RANDOM_VECTOR(4);
         const Eigen::Matrix4f expected = a * b.transpose();
         const Eigen::Matrix4f result = outer<4>(a, b);
         EXPECT_MATRIX_NEAR(expected, result, BASE_EPSILON);
@@ -513,7 +551,7 @@ TEST_F(EigenUtilsTest, outer) {
 
 TEST_F(EigenUtilsTest, block3x3) {
     for (size_t iter = 0; iter < TEST_ITERATIONS; ++iter) {
-        const Eigen::Matrix4f A = Eigen::Matrix4f::Random() * RANDOM_SCALE;
+        const Eigen::Matrix4f A = RANDOM_MATRIX(4, 4);
         const Eigen::Matrix3f expected = A.block<3, 3>(0, 0);
         const Eigen::Matrix3f result = block3x3(A);
         EXPECT_MATRIX_EXACT_EQ(expected, result);
@@ -522,7 +560,7 @@ TEST_F(EigenUtilsTest, block3x3) {
 
 TEST_F(EigenUtilsTest, inverse) {
     for (size_t iter = 0; iter < TEST_ITERATIONS; ++iter) {
-        Eigen::Matrix3f A = Eigen::Matrix3f::Random() * RANDOM_SCALE;
+        Eigen::Matrix3f A = RANDOM_MATRIX(3, 3);
 
         const Eigen::Matrix3f expected = A.inverse();
         const Eigen::Matrix3f invA = inverse(A);
@@ -541,7 +579,7 @@ TEST_F(EigenUtilsTest, inverse) {
 
 TEST_F(EigenUtilsTest, ensure_symmetric) {
     for (size_t iter = 0; iter < TEST_ITERATIONS; ++iter) {
-        Eigen::Matrix3f A = Eigen::Matrix3f::Random() * RANDOM_SCALE;
+        Eigen::Matrix3f A = RANDOM_MATRIX(3, 3);
         const Eigen::Matrix3f expected = 0.5f * (A + A.transpose());
         const Eigen::Matrix3f result = ensure_symmetric<3>(A);
         EXPECT_MATRIX_NEAR(expected, result, BASE_EPSILON);
@@ -554,14 +592,14 @@ TEST_F(EigenUtilsTest, frobenius_norm) {
         {
             constexpr size_t M = 3;
             constexpr size_t N = 3;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
             const float expected = A.norm();
             const float result = frobenius_norm<M, N>(A);
             EXPECT_SCALAR_NEAR(expected, result, BASE_EPSILON);
         }
         {
             constexpr size_t M = 3;
-            const Eigen::Vector<float, M> v = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
+            const Eigen::Vector<float, M> v = RANDOM_VECTOR(M);
             const float expected = v.norm();
             const float result = frobenius_norm<M>(v);
             EXPECT_SCALAR_NEAR(expected, result, BASE_EPSILON);
@@ -572,7 +610,7 @@ TEST_F(EigenUtilsTest, frobenius_norm) {
 TEST_F(EigenUtilsTest, frobenius_norm_squared) {
     for (size_t iter = 0; iter < TEST_ITERATIONS; ++iter) {
         constexpr size_t M = 3;
-        const Eigen::Vector<float, M> v = Eigen::Vector<float, M>::Random() * RANDOM_SCALE;
+        const Eigen::Vector<float, M> v = RANDOM_VECTOR(M);
         const float expected = v.squaredNorm();
         const float result = frobenius_norm_squared<M>(v);
         EXPECT_SCALAR_NEAR(expected, result, BASE_EPSILON);
@@ -581,7 +619,7 @@ TEST_F(EigenUtilsTest, frobenius_norm_squared) {
 
 TEST_F(EigenUtilsTest, determinant) {
     for (size_t iter = 0; iter < TEST_ITERATIONS; ++iter) {
-        Eigen::Matrix3f A = Eigen::Matrix3f::Random() * RANDOM_SCALE;
+        Eigen::Matrix3f A = RANDOM_MATRIX(3, 3);
         const float expected = A.determinant();
         const float result = determinant(A);
         EXPECT_SCALAR_NEAR(expected, result, DET_EPSILON);
@@ -590,7 +628,7 @@ TEST_F(EigenUtilsTest, determinant) {
 
 TEST_F(EigenUtilsTest, as_diagonal) {
     for (size_t iter = 0; iter < TEST_ITERATIONS; ++iter) {
-        const Eigen::Vector3f diag = Eigen::Vector3f::Random() * RANDOM_SCALE;
+        const Eigen::Vector3f diag = RANDOM_VECTOR(3);
         Eigen::Matrix3f expected = Eigen::Matrix3f::Zero();
         expected.diagonal() = diag;
         const Eigen::Matrix3f result = as_diagonal<3>(diag);
@@ -610,7 +648,7 @@ TEST_F(EigenUtilsTest, symmetric_eigen_decomposition_3x3) {
 
 TEST_F(EigenUtilsTest, trace) {
     for (size_t iter = 0; iter < TEST_ITERATIONS; ++iter) {
-        const Eigen::Matrix3f A = Eigen::Matrix3f::Random() * RANDOM_SCALE;
+        const Eigen::Matrix3f A = RANDOM_MATRIX(3, 3);
         const float expected = A.trace();
         const float result = trace<3>(A);
         EXPECT_SCALAR_NEAR(expected, result, BASE_EPSILON);
@@ -622,7 +660,7 @@ TEST_F(EigenUtilsTest, copy_swap) {
         {
             constexpr size_t M = 3;
             constexpr size_t N = 3;
-            const Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
             Eigen::Matrix<float, M, N> B;
             copy<M, N>(A, B);
             EXPECT_MATRIX_EXACT_EQ(A, B);
@@ -630,8 +668,8 @@ TEST_F(EigenUtilsTest, copy_swap) {
         {
             constexpr size_t M = 4;
             constexpr size_t N = 4;
-            Eigen::Matrix<float, M, N> A = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
-            Eigen::Matrix<float, M, N> B = Eigen::Matrix<float, M, N>::Random() * RANDOM_SCALE;
+            Eigen::Matrix<float, M, N> A = RANDOM_MATRIX(M, N);
+            Eigen::Matrix<float, M, N> B = RANDOM_MATRIX(M, N);
             Eigen::Matrix<float, M, N> A_orig = A;
             Eigen::Matrix<float, M, N> B_orig = B;
             swap<M, N>(A, B);
@@ -643,7 +681,7 @@ TEST_F(EigenUtilsTest, copy_swap) {
 
 TEST_F(EigenUtilsTest, normalize) {
     for (size_t iter = 0; iter < TEST_ITERATIONS; ++iter) {
-        Eigen::Vector3f v = Eigen::Vector3f::Random() * RANDOM_SCALE;
+        Eigen::Vector3f v = RANDOM_VECTOR(3);
         if (v.norm() < 1e-3f) {
             v(0) += 1.0f;
         }
@@ -659,25 +697,25 @@ TEST_F(EigenUtilsTest, normalize) {
 TEST_F(EigenUtilsTest, to_from_sycl_vec) {
     for (size_t iter = 0; iter < TEST_ITERATIONS; ++iter) {
         {
-            const Eigen::Vector4f v = Eigen::Vector4f::Random() * RANDOM_SCALE;
+            const Eigen::Vector4f v = RANDOM_VECTOR(4);
             const sycl::float4 sv = to_sycl_vec(v);
             const Eigen::Vector4f back = from_sycl_vec(sv);
             EXPECT_VECTOR_NEAR(v, back, BASE_EPSILON);
         }
         {
-            const Eigen::Matrix4f m = Eigen::Matrix4f::Random() * RANDOM_SCALE;
+            const Eigen::Matrix4f m = RANDOM_MATRIX(4, 4);
             const auto sm = to_sycl_vec(m);
             const Eigen::Matrix4f back = from_sycl_vec(sm);
             EXPECT_MATRIX_NEAR(m, back, BASE_EPSILON);
         }
         {
-            const Eigen::Matrix<float, 6, 6> m = Eigen::Matrix<float, 6, 6>::Random() * RANDOM_SCALE;
+            const Eigen::Matrix<float, 6, 6> m = RANDOM_MATRIX(6, 6);
             const auto sm = to_sycl_vec(m);
             const Eigen::Matrix<float, 6, 6> back = from_sycl_vec(sm);
             EXPECT_MATRIX_NEAR(m, back, BASE_EPSILON);
         }
         {
-            const Eigen::Vector<float, 6> v = Eigen::Vector<float, 6>::Random() * RANDOM_SCALE;
+            const Eigen::Vector<float, 6> v = RANDOM_VECTOR(6);
             const auto sv = to_sycl_vec(v);
             const Eigen::Vector<float, 6> back = from_sycl_vec(sv);
             EXPECT_VECTOR_NEAR(v, back, BASE_EPSILON);


### PR DESCRIPTION
## Summary
- ensure eigen_utils tests use random values in [-10, 10]
- adjust multiply test tolerance for larger random values

## Testing
- `ctest -R test_eigen_utils`

------
https://chatgpt.com/codex/tasks/task_e_68c4c3bb24688322820504c0e658dd4f