### PR TITLE
PointCloud の ConstPtr を const pointee に修正

### DIFF
--- a/cpp/include/sycl_points/points/point_cloud.hpp
+++ b/cpp/include/sycl_points/points/point_cloud.hpp
@@ -11,7 +11,7 @@ namespace sycl_points {
 /// @brief CPU point cloud class with point and covariance container.
 struct PointCloudCPU {
     using Ptr = std::shared_ptr<PointCloudCPU>;
-    using ConstPtr = std::shared_ptr<PointCloudCPU>;
+    using ConstPtr = std::shared_ptr<const PointCloudCPU>;
 
     /// @brief point container
     std::shared_ptr<PointContainerCPU> points = nullptr;
@@ -86,7 +86,7 @@ struct PointCloudCPU {
 /// @brief Shared memory point cloud class with point and covariance container.
 struct PointCloudShared {
     using Ptr = std::shared_ptr<PointCloudShared>;
-    using ConstPtr = std::shared_ptr<PointCloudShared>;
+    using ConstPtr = std::shared_ptr<const PointCloudShared>;
 
     /// @brief SYCL queue
     sycl_utils::DeviceQueue queue;


### PR DESCRIPTION
### Motivation
- `PointCloudCPU` と `PointCloudShared` の `ConstPtr` が非 const pointee 型 (`std::shared_ptr<PointCloudCPU>` / `std::shared_ptr<PointCloudShared>`) になっていたため、既存の `ConstPtr` パターンに合わせて修正しました。

### Description
- `PointCloudCPU::ConstPtr` を `std::shared_ptr<const PointCloudCPU>` に、`PointCloudShared::ConstPtr` を `std::shared_ptr<const PointCloudShared>` に変更し、`cpp/include/sycl_points/points/point_cloud.hpp` を更新しました。

### Testing
- 実行した自動コマンドは `rg -n "using ConstPtr = std::shared_ptr[^;]+;" cpp/include/sycl_points | head -n 50`、`git status --short`、および `nl -ba cpp/include/sycl_points/points/point_cloud.hpp | sed -n '8,100p'` で、いずれも期待どおりに変更を確認でき、変更をコミットしました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b75492c8908322862239876ff1c68c)