### PR TITLE
GenZ: per-correspondence planarity classification and alpha weighting for ICP

### DIFF
--- a/cpp/include/sycl_points/algorithms/registration/factor.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/factor.hpp
@@ -267,7 +267,8 @@ SYCL_EXTERNAL inline LinearizedKernelResult linearize_gicp(const std::array<sycl
     // b = J.transpose() * mahalanobis * residual;
     ret.b = eigen_utils::multiply<6, 4>(J_T_mah, residual);
 
-    const float squared_norm = eigen_utils::dot<4>(residual, eigen_utils::multiply<4, 4>(mahalanobis_cov_inv, residual));
+    const float squared_norm =
+        eigen_utils::dot<4>(residual, eigen_utils::multiply<4, 4>(mahalanobis_cov_inv, residual));
     residual_norm = sycl::sqrt(squared_norm);
 
     ret.squared_error = squared_norm;
@@ -413,7 +414,8 @@ SYCL_EXTERNAL inline LinearizedKernelResult linearize_geometry(const std::array<
                                                                const PointType& source_pt, const Covariance& source_cov,
                                                                const PointType& target_pt, const Covariance& target_cov,
                                                                const Normal& target_normal, float& residual_norm,
-                                                               float genz_alpha, float genz_planarity_threshold = 0.2f) {
+                                                               float genz_alpha, float& genz_weight,
+                                                               float genz_planarity_threshold = 0.2f) {
     if constexpr (reg == RegType::POINT_TO_POINT) {
         return linearize_point_to_point(T, source_pt, target_pt, residual_norm);
     } else if constexpr (reg == RegType::POINT_TO_PLANE) {
@@ -422,20 +424,20 @@ SYCL_EXTERNAL inline LinearizedKernelResult linearize_geometry(const std::array<
         return linearize_gicp(T, source_pt, source_cov, target_pt, target_cov, residual_norm);
     } else if constexpr (reg == RegType::GENZ) {
         const bool is_planar = is_genz_planar_correspondence(target_cov, genz_planarity_threshold);
-        const float mode_weight = is_planar ? genz_alpha : (1.0f - genz_alpha);
+        genz_weight = is_planar ? genz_alpha : (1.0f - genz_alpha);
 
         float selected_residual_norm = 0.0f;
-        const auto selected_result = is_planar
-                                         ? linearize_point_to_plane(T, source_pt, target_pt, target_normal, selected_residual_norm)
-                                         : linearize_point_to_point(T, source_pt, target_pt, selected_residual_norm);
+        const auto selected_result =
+            is_planar ? linearize_point_to_plane(T, source_pt, target_pt, target_normal, selected_residual_norm)
+                      : linearize_point_to_point(T, source_pt, target_pt, selected_residual_norm);
 
         // Keep residual norm unweighted to avoid alpha being applied twice through robust weighting.
         residual_norm = selected_residual_norm;
 
         LinearizedKernelResult result;
-        result.H = eigen_utils::multiply<6, 6>(selected_result.H, mode_weight);
-        result.b = eigen_utils::multiply<6, 1>(selected_result.b, mode_weight);
-        result.squared_error = selected_result.squared_error * mode_weight;
+        result.H = eigen_utils::multiply<6, 6>(selected_result.H, genz_weight);
+        result.b = eigen_utils::multiply<6, 1>(selected_result.b, genz_weight);
+        result.squared_error = selected_result.squared_error * genz_weight;
         result.inlier = 1;
         return result;
     } else if constexpr (reg == RegType::POINT_TO_DISTRIBUTION) {
@@ -457,7 +459,8 @@ template <RegType reg = RegType::GICP>
 SYCL_EXTERNAL inline float calculate_geometry_error(const std::array<sycl::float4, 4>& T,                      //
                                                     const PointType& source_pt, const Covariance& source_cov,  //
                                                     const PointType& target_pt, const Covariance& target_cov,  //
-                                                    const Normal& target_normal, const float genz_alpha = 1.0f,
+                                                    const Normal& target_normal,                               //
+                                                    const float genz_alpha, float& genz_weight,
                                                     const float genz_planarity_threshold = 0.2f) {
     if constexpr (reg == RegType::POINT_TO_POINT) {
         return calculate_point_to_point_error(T, source_pt, target_pt);
@@ -467,6 +470,7 @@ SYCL_EXTERNAL inline float calculate_geometry_error(const std::array<sycl::float
         return calculate_gicp_error(T, source_pt, source_cov, target_pt, target_cov);
     } else if constexpr (reg == RegType::GENZ) {
         const bool is_planar = is_genz_planar_correspondence(target_cov, genz_planarity_threshold);
+        genz_weight = is_planar ? genz_alpha : (1.0f - genz_alpha);
         return is_planar ? calculate_point_to_plane_error(T, source_pt, target_pt, target_normal)
                          : calculate_point_to_point_error(T, source_pt, target_pt);
     } else if constexpr (reg == RegType::POINT_TO_DISTRIBUTION) {

--- a/cpp/include/sycl_points/algorithms/registration/factor.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/factor.hpp
@@ -370,23 +370,29 @@ SYCL_EXTERNAL inline float calculate_point_to_distribution_error(const std::arra
     return (eigen_utils::dot<4>(residual, eigen_utils::multiply<4, 4>(mahalanobis, residual)));
 }
 
-/// @brief Classify a correspondence as planar based on target covariance surface variation.
+/// @brief Compute PCA-based normalized curvature from target covariance.
 /// @param target_cov Target covariance matrix
-/// @param planarity_threshold Surface variation threshold for planar classification
-/// @return True when the correspondence is classified as planar
-SYCL_EXTERNAL inline bool is_genz_planar_correspondence(const Covariance& target_cov, float planarity_threshold) {
+/// @return Normalized curvature used for planar classification
+SYCL_EXTERNAL inline float compute_pca_normalized_curvature(const Covariance& target_cov) {
     Eigen::Vector3f eigenvalues;
     Eigen::Matrix3f eigenvectors;
     eigen_utils::symmetric_eigen_decomposition_3x3(target_cov.block<3, 3>(0, 0), eigenvalues, eigenvectors);
     const float sum_eigenvalues = eigenvalues(0) + eigenvalues(1) + eigenvalues(2);
-    const float surface_variation = (sum_eigenvalues > 1e-12f) ? eigenvalues(0) / sum_eigenvalues : 1.0f;
-    return surface_variation < planarity_threshold;
+    return (sum_eigenvalues > 1e-12f) ? eigenvalues(0) / sum_eigenvalues : 1.0f;
+}
+
+/// @brief Classify a correspondence as planar using PCA-based normalized curvature.
+/// @param target_cov Target covariance matrix
+/// @param planarity_threshold Normalized curvature threshold for planar classification
+/// @return True when the correspondence is classified as planar
+SYCL_EXTERNAL inline bool is_genz_planar_correspondence(const Covariance& target_cov, float planarity_threshold) {
+    return compute_pca_normalized_curvature(target_cov) < planarity_threshold;
 }
 
 /// @brief Compute the GenZ correspondence alpha weight from planar classification.
 /// @param target_cov Target covariance matrix
 /// @param genz_alpha Global GenZ alpha value
-/// @param planarity_threshold Surface variation threshold for planar classification
+/// @param planarity_threshold Normalized curvature threshold for planar classification
 /// @return Alpha weight for this correspondence
 SYCL_EXTERNAL inline float compute_genz_correspondence_alpha_weight(const Covariance& target_cov, float genz_alpha,
                                                                     float planarity_threshold) {

--- a/cpp/include/sycl_points/algorithms/registration/factor.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/factor.hpp
@@ -370,6 +370,29 @@ SYCL_EXTERNAL inline float calculate_point_to_distribution_error(const std::arra
     return (eigen_utils::dot<4>(residual, eigen_utils::multiply<4, 4>(mahalanobis, residual)));
 }
 
+/// @brief Classify a correspondence as planar based on target covariance surface variation.
+/// @param target_cov Target covariance matrix
+/// @param planarity_threshold Surface variation threshold for planar classification
+/// @return True when the correspondence is classified as planar
+SYCL_EXTERNAL inline bool is_genz_planar_correspondence(const Covariance& target_cov, float planarity_threshold) {
+    Eigen::Vector3f eigenvalues;
+    Eigen::Matrix3f eigenvectors;
+    eigen_utils::symmetric_eigen_decomposition_3x3(target_cov.block<3, 3>(0, 0), eigenvalues, eigenvectors);
+    const float sum_eigenvalues = eigenvalues(0) + eigenvalues(1) + eigenvalues(2);
+    const float surface_variation = (sum_eigenvalues > 1e-12f) ? eigenvalues(0) / sum_eigenvalues : 1.0f;
+    return surface_variation < planarity_threshold;
+}
+
+/// @brief Compute the GenZ correspondence alpha weight from planar classification.
+/// @param target_cov Target covariance matrix
+/// @param genz_alpha Global GenZ alpha value
+/// @param planarity_threshold Surface variation threshold for planar classification
+/// @return Alpha weight for this correspondence
+SYCL_EXTERNAL inline float compute_genz_correspondence_alpha_weight(const Covariance& target_cov, float genz_alpha,
+                                                                    float planarity_threshold) {
+    return is_genz_planar_correspondence(target_cov, planarity_threshold) ? genz_alpha : (1.0f - genz_alpha);
+}
+
 /// @brief Linearization
 /// @tparam reg registration type
 /// @param T transform matrix
@@ -384,7 +407,7 @@ SYCL_EXTERNAL inline LinearizedKernelResult linearize_geometry(const std::array<
                                                                const PointType& source_pt, const Covariance& source_cov,
                                                                const PointType& target_pt, const Covariance& target_cov,
                                                                const Normal& target_normal, float& residual_norm,
-                                                               float genz_alpha) {
+                                                               float genz_alpha, float genz_planarity_threshold = 0.2f) {
     if constexpr (reg == RegType::POINT_TO_POINT) {
         return linearize_point_to_point(T, source_pt, target_pt, residual_norm);
     } else if constexpr (reg == RegType::POINT_TO_PLANE) {
@@ -392,20 +415,21 @@ SYCL_EXTERNAL inline LinearizedKernelResult linearize_geometry(const std::array<
     } else if constexpr (reg == RegType::GICP) {
         return linearize_gicp(T, source_pt, source_cov, target_pt, target_cov, residual_norm);
     } else if constexpr (reg == RegType::GENZ) {
-        float pt2pt_residual_norm = 0.0f;
-        float pt2pl_residual_norm = 0.0f;
-        const auto pt2pt_result = linearize_point_to_point(T, source_pt, target_pt, pt2pt_residual_norm);
-        const auto pt2pl_result = linearize_point_to_plane(T, source_pt, target_pt, target_normal, pt2pl_residual_norm);
+        const bool is_planar = is_genz_planar_correspondence(target_cov, genz_planarity_threshold);
+        const float mode_weight = is_planar ? genz_alpha : (1.0f - genz_alpha);
 
-        residual_norm = pt2pt_residual_norm * (1.0f - genz_alpha) + pt2pl_residual_norm * genz_alpha;
+        float selected_residual_norm = 0.0f;
+        const auto selected_result = is_planar
+                                         ? linearize_point_to_plane(T, source_pt, target_pt, target_normal, selected_residual_norm)
+                                         : linearize_point_to_point(T, source_pt, target_pt, selected_residual_norm);
+
+        // Keep residual norm unweighted to avoid alpha being applied twice through robust weighting.
+        residual_norm = selected_residual_norm;
 
         LinearizedKernelResult result;
-        result.H = eigen_utils::add<6, 6>(eigen_utils::multiply<6, 6>(pt2pt_result.H, 1.0f - genz_alpha),
-                                          eigen_utils::multiply<6, 6>(pt2pl_result.H, genz_alpha));
-        result.b = eigen_utils::add<6, 1>(eigen_utils::multiply<6, 1>(pt2pt_result.b, 1.0f - genz_alpha),
-                                          eigen_utils::multiply<6, 1>(pt2pl_result.b, genz_alpha));
-        result.squared_error =
-            pt2pt_result.squared_error * (1.0f - genz_alpha) + pt2pl_result.squared_error * genz_alpha;
+        result.H = eigen_utils::multiply<6, 6>(selected_result.H, mode_weight);
+        result.b = eigen_utils::multiply<6, 1>(selected_result.b, mode_weight);
+        result.squared_error = selected_result.squared_error * mode_weight;
         result.inlier = 1;
         return result;
     } else if constexpr (reg == RegType::POINT_TO_DISTRIBUTION) {
@@ -427,7 +451,8 @@ template <RegType reg = RegType::GICP>
 SYCL_EXTERNAL inline float calculate_geometry_error(const std::array<sycl::float4, 4>& T,                      //
                                                     const PointType& source_pt, const Covariance& source_cov,  //
                                                     const PointType& target_pt, const Covariance& target_cov,  //
-                                                    const Normal& target_normal, const float genz_alpha = 1.0f) {
+                                                    const Normal& target_normal, const float genz_alpha = 1.0f,
+                                                    const float genz_planarity_threshold = 0.2f) {
     if constexpr (reg == RegType::POINT_TO_POINT) {
         return calculate_point_to_point_error(T, source_pt, target_pt);
     } else if constexpr (reg == RegType::POINT_TO_PLANE) {
@@ -435,9 +460,9 @@ SYCL_EXTERNAL inline float calculate_geometry_error(const std::array<sycl::float
     } else if constexpr (reg == RegType::GICP) {
         return calculate_gicp_error(T, source_pt, source_cov, target_pt, target_cov);
     } else if constexpr (reg == RegType::GENZ) {
-        const float pt2pt_err = calculate_point_to_point_error(T, source_pt, target_pt);
-        const float pt2pl_err = calculate_point_to_plane_error(T, source_pt, target_pt, target_normal);
-        return pt2pt_err * (1.0f - genz_alpha) + pt2pl_err * genz_alpha;
+        const bool is_planar = is_genz_planar_correspondence(target_cov, genz_planarity_threshold);
+        return is_planar ? calculate_point_to_plane_error(T, source_pt, target_pt, target_normal)
+                         : calculate_point_to_point_error(T, source_pt, target_pt);
     } else if constexpr (reg == RegType::POINT_TO_DISTRIBUTION) {
         return calculate_point_to_distribution_error(T, source_pt, target_pt, target_cov);
     } else {

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -373,9 +373,10 @@ private:
                     const auto target_cov = target_cov_ptr ? target_cov_ptr[target_idx] : Covariance::Identity();
                     const auto target_normal = target_normal_ptr ? target_normal_ptr[target_idx] : Normal::Zero();
 
+                    float genz_weight = 1.0f;  // compute, but not use
                     const float squared_error = kernel::calculate_geometry_error<reg>(
                         cur_T, source_ptr[index], source_cov, target_ptr[target_idx], target_cov, target_normal,
-                        genz_alpha, genz_planarity_threshold);
+                        genz_alpha, genz_weight, genz_planarity_threshold);
                     const float residual_norm = sycl::sqrt(squared_error);
 
                     if constexpr (reg == RegType::GICP || reg == RegType::POINT_TO_DISTRIBUTION) {
@@ -554,16 +555,13 @@ private:
                     // ICP term
                     {
                         float residual_norm = 0.0f;
-                        float geom_alpha_weight = 1.0f;
+                        float genz_weight = 1.0f;
                         const LinearizedKernelResult linearized =
                             kernel::linearize_geometry<reg>(cur_T,                                              //
                                                             source_ptr[index], source_cov,                      //
                                                             target_ptr[target_idx], target_cov, target_normal,  //
-                                                            residual_norm, genz_alpha, genz_planarity_threshold);
-                        if constexpr (reg == RegType::GENZ) {
-                            geom_alpha_weight = kernel::compute_genz_correspondence_alpha_weight(
-                                target_cov, genz_alpha, genz_planarity_threshold);
-                        }
+                                                            residual_norm,                                      //
+                                                            genz_alpha, genz_weight, genz_planarity_threshold);
 
                         if constexpr (reg == RegType::GICP || reg == RegType::POINT_TO_DISTRIBUTION) {
                             if (residual_norm > mahalanobis_dist_threshold) {
@@ -581,8 +579,13 @@ private:
                         total_H2 = robust_weight * H2;
                         total_b0 = robust_weight * b0;
                         total_b1 = robust_weight * b1;
-                        total_error =
-                            geom_alpha_weight * robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
+
+                        if constexpr (reg == RegType::GENZ) {
+                            total_error =
+                                genz_weight * robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
+                        } else {
+                            total_error = robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
+                        }
                     }
 
                     // Color term
@@ -761,25 +764,26 @@ private:
                     float total_error = 0.0f;
                     // ICP term
                     {
-                        float geom_alpha_weight = 1.0f;
+                        float genz_weight = 1.0f;
                         const float squared_error = kernel::calculate_geometry_error<reg>(
                             cur_T,                                              //
                             source_ptr[index], source_cov,                      // source
                             target_ptr[target_idx], target_cov, target_normal,  // target
-                            genz_alpha, genz_planarity_threshold);
+                            genz_alpha, genz_weight, genz_planarity_threshold);
                         const float residual_norm = sycl::sqrt(squared_error);
-                        if constexpr (reg == RegType::GENZ) {
-                            geom_alpha_weight = kernel::compute_genz_correspondence_alpha_weight(
-                                target_cov, genz_alpha, genz_planarity_threshold);
-                        }
 
                         if constexpr (reg == RegType::GICP || reg == RegType::POINT_TO_DISTRIBUTION) {
                             if (residual_norm > mahalanobis_dist_threshold) return;
                         }
 
                         // Apply robust kernel
-                        total_error =
-                            geom_alpha_weight * robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
+
+                        if constexpr (reg == RegType::GENZ) {
+                            total_error =
+                                genz_weight * robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
+                        } else {
+                            total_error = robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
+                        }
                     }
 
                     // Photometric term

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -428,16 +428,7 @@ private:
                     }
 
                     const auto target_idx = neighbors_index_ptr[index];
-                    const auto cov = target_cov_ptr[target_idx];
-
-                    Eigen::Vector3f eigenvalues;
-                    Eigen::Matrix3f eigenvectors;
-                    eigen_utils::symmetric_eigen_decomposition_3x3(cov.block<3, 3>(0, 0), eigenvalues, eigenvectors);
-                    const float sum_eigenvalues = eigenvalues(0) + eigenvalues(1) + eigenvalues(2);
-                    const float surface_variation = (sum_eigenvalues > std::numeric_limits<float>::epsilon())
-                                                        ? eigenvalues(0) / sum_eigenvalues
-                                                        : 1.0f;
-                    if (surface_variation < planarity_threshold) {
+                    if (kernel::is_genz_planar_correspondence(target_cov_ptr[target_idx], planarity_threshold)) {
                         ++sum_plane_arg;
                     }
                     ++sum_inlier_arg;

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -359,6 +359,7 @@ private:
                 this->params_.max_correspondence_distance * this->params_.max_correspondence_distance;
             const float mahalanobis_dist_threshold = this->params_.mahalanobis_distance_threshold;
             const float genz_alpha = this->genz_alpha_;
+            const float genz_planarity_threshold = this->params_.genz.planarity_threshold;
             auto weights_ptr = out.data();
 
             h.depends_on(depends);
@@ -374,7 +375,7 @@ private:
 
                     const float squared_error = kernel::calculate_geometry_error<reg>(
                         cur_T, source_ptr[index], source_cov, target_ptr[target_idx], target_cov, target_normal,
-                        genz_alpha);
+                        genz_alpha, genz_planarity_threshold);
                     const float residual_norm = sycl::sqrt(squared_error);
 
                     if constexpr (reg == RegType::GICP || reg == RegType::POINT_TO_DISTRIBUTION) {
@@ -502,6 +503,7 @@ private:
                 this->params_.max_correspondence_distance * this->params_.max_correspondence_distance;
             const float mahalanobis_dist_threshold = this->params_.mahalanobis_distance_threshold;
             const float genz_alpha = this->genz_alpha_;
+            const float genz_planarity_threshold = this->params_.genz.planarity_threshold;
 
             const bool rotation_constraint_enable = this->params_.rotation_constraint.enable;
             const float rotation_constraint_robust_scale = rotation_robust_scale;
@@ -561,11 +563,16 @@ private:
                     // ICP term
                     {
                         float residual_norm = 0.0f;
+                        float geom_alpha_weight = 1.0f;
                         const LinearizedKernelResult linearized =
                             kernel::linearize_geometry<reg>(cur_T,                                              //
                                                             source_ptr[index], source_cov,                      //
                                                             target_ptr[target_idx], target_cov, target_normal,  //
-                                                            residual_norm, genz_alpha);
+                                                            residual_norm, genz_alpha, genz_planarity_threshold);
+                        if constexpr (reg == RegType::GENZ) {
+                            geom_alpha_weight = kernel::compute_genz_correspondence_alpha_weight(
+                                target_cov, genz_alpha, genz_planarity_threshold);
+                        }
 
                         if constexpr (reg == RegType::GICP || reg == RegType::POINT_TO_DISTRIBUTION) {
                             if (residual_norm > mahalanobis_dist_threshold) {
@@ -583,7 +590,8 @@ private:
                         total_H2 = robust_weight * H2;
                         total_b0 = robust_weight * b0;
                         total_b1 = robust_weight * b1;
-                        total_error = robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
+                        total_error =
+                            geom_alpha_weight * robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
                     }
 
                     // Color term
@@ -720,6 +728,7 @@ private:
             const float mahalanobis_dist_threshold = this->params_.mahalanobis_distance_threshold;
 
             const float genz_alpha = this->genz_alpha_;
+            const float genz_planarity_threshold = this->params_.genz.planarity_threshold;
 
             const float photometric_weight = this->params_.photometric.enable ? this->params_.photometric.weight : 0.0f;
             const float photometric_robust_scale =
@@ -761,19 +770,25 @@ private:
                     float total_error = 0.0f;
                     // ICP term
                     {
+                        float geom_alpha_weight = 1.0f;
                         const float squared_error = kernel::calculate_geometry_error<reg>(
                             cur_T,                                              //
                             source_ptr[index], source_cov,                      // source
                             target_ptr[target_idx], target_cov, target_normal,  // target
-                            genz_alpha);
+                            genz_alpha, genz_planarity_threshold);
                         const float residual_norm = sycl::sqrt(squared_error);
+                        if constexpr (reg == RegType::GENZ) {
+                            geom_alpha_weight = kernel::compute_genz_correspondence_alpha_weight(
+                                target_cov, genz_alpha, genz_planarity_threshold);
+                        }
 
                         if constexpr (reg == RegType::GICP || reg == RegType::POINT_TO_DISTRIBUTION) {
                             if (residual_norm > mahalanobis_dist_threshold) return;
                         }
 
                         // Apply robust kernel
-                        total_error = robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
+                        total_error =
+                            geom_alpha_weight * robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
                     }
 
                     // Photometric term


### PR DESCRIPTION
### Motivation
- Improve GenZ registration by selecting point-to-plane or point-to-point per correspondence using target covariance surface variation instead of globally blending the two modes.

### Description
- Add `is_genz_planar_correspondence` to classify correspondences using the 3x3 covariance eigenvalues and a `planarity_threshold`, and add `compute_genz_correspondence_alpha_weight` to return the per-correspondence alpha weight.
- Extend function signatures with an optional `genz_planarity_threshold` (default `0.2f`) and use the planarity test to select between `linearize_point_to_plane` and `linearize_point_to_point`, keeping `residual_norm` from the selected mode unweighted and scaling `H`, `b`, and `squared_error` by the selected mode weight.
- Change `calculate_geometry_error` for `RegType::GENZ` to choose the appropriate geometric error by planarity instead of blending by `genz_alpha`.
- Propagate `genz_planarity_threshold` through `compute_icp_robust_weights_async`, the linearization/reduction kernel, and other callers, and apply the correspondence alpha weight to the per-correspondence robust error accumulation.

### Testing
- Built the project with `cmake --build .` and the build completed successfully.
- Ran the test suite with `ctest --output-on-failure` and the automated tests related to registration passed.
- Executed registration unit/integration tests exercising `RegType::GENZ` and observed no test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf4a65e470832292012c8bd6b1ac02)