### PR TITLE
feat: Add Barron's general adaptive robust loss function

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Platform: Intel(R) OpenCL Graphics
   - https://arxiv.org/abs/2411.06766
 - **Informed, Constrained, Aligned: A Field Analysis on Degeneracy-aware Point Cloud Registration in the Wild (2024)**
   - https://arxiv.org/abs/2408.11809
-
+- **A General and Adaptive Robust Loss Function (2017)**
+  - https://arxiv.org/abs/1701.03077
 ## License
 This library is released under Apache License 2.0

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -341,6 +341,7 @@ private:
                                                         shared_vector<float>& out,
                                                         const std::vector<sycl::event>& depends) const {
         sycl_utils::events events;
+        const float barron_alpha = this->params_.robust.barron_alpha;
         events += this->queue_.ptr->submit([&](sycl::handler& h) {
             const size_t N = source.size();
             const auto cur_T = eigen_utils::to_sycl_vec(transT);
@@ -381,10 +382,10 @@ private:
 
                     if constexpr (reg == RegType::GICP || reg == RegType::POINT_TO_DISTRIBUTION) {
                         if (residual_norm <= mahalanobis_dist_threshold) {
-                            weight = robust::kernel::compute_robust_weight<loss>(residual_norm, robust_scale);
+                            weight = robust::kernel::compute_robust_weight<loss>(residual_norm, robust_scale, barron_alpha);
                         }
                     } else {
-                        weight = robust::kernel::compute_robust_weight<loss>(residual_norm, robust_scale);
+                        weight = robust::kernel::compute_robust_weight<loss>(residual_norm, robust_scale, barron_alpha);
                     }
                 }
 
@@ -456,6 +457,7 @@ private:
         }
 
         // The robust_scale argument controls the influence of the robust loss inside the reduction kernel.
+        const float barron_alpha = this->params_.robust.barron_alpha;
         sycl_utils::events events;
         events += this->queue_.ptr->submit([&](sycl::handler& h) {
             const size_t N = source.size();
@@ -571,7 +573,7 @@ private:
 
                         // Apply robust kernel
                         const float robust_weight =
-                            robust::kernel::compute_robust_weight<loss>(residual_norm, robust_scale);
+                            robust::kernel::compute_robust_weight<loss>(residual_norm, robust_scale, barron_alpha);
                         const auto& [H0, H1, H2] = eigen_utils::to_sycl_vec(linearized.H);
                         const auto& [b0, b1] = eigen_utils::to_sycl_vec(linearized.b);
                         total_H0 = robust_weight * H0;
@@ -582,9 +584,9 @@ private:
 
                         if constexpr (reg == RegType::GENZ) {
                             total_error =
-                                genz_weight * robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
+                                genz_weight * robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale, barron_alpha);
                         } else {
-                            total_error = robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
+                            total_error = robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale, barron_alpha);
                         }
                     }
 
@@ -595,7 +597,7 @@ private:
                                                     target_rgb, target_normal, target_grad);
                         float residual_norm_color = sycl::sqrt(linearized_color.squared_error);
                         const float robust_weight_color =
-                            robust::kernel::compute_robust_weight<loss>(residual_norm_color, photometric_robust_scale);
+                            robust::kernel::compute_robust_weight<loss>(residual_norm_color, photometric_robust_scale, barron_alpha);
 
                         const auto& [H0_color, H1_color, H2_color] = eigen_utils::to_sycl_vec(linearized_color.H);
                         const auto& [b0_color, b1_color] = eigen_utils::to_sycl_vec(linearized_color.b);
@@ -606,7 +608,7 @@ private:
                         total_b0 += photometric_weight * robust_weight_color * b0_color;
                         total_b1 += photometric_weight * robust_weight_color * b1_color;
                         total_error += photometric_weight * robust::kernel::compute_robust_error<loss>(
-                                                                residual_norm_color, photometric_robust_scale);
+                                                                residual_norm_color, photometric_robust_scale, barron_alpha);
                     }
 
                     // Intensity term
@@ -616,7 +618,7 @@ private:
                             target_normal, target_intensity_grad);
                         float residual_norm_intensity = sycl::sqrt(linearized_intensity.squared_error);
                         const float robust_weight_intensity = robust::kernel::compute_robust_weight<loss>(
-                            residual_norm_intensity, photometric_robust_scale);
+                            residual_norm_intensity, photometric_robust_scale, barron_alpha);
 
                         const auto& [H0_intensity, H1_intensity, H2_intensity] =
                             eigen_utils::to_sycl_vec(linearized_intensity.H);
@@ -628,7 +630,7 @@ private:
                         total_b0 += photometric_weight * robust_weight_intensity * b0_intensity;
                         total_b1 += photometric_weight * robust_weight_intensity * b1_intensity;
                         total_error += photometric_weight * robust::kernel::compute_robust_error<loss>(
-                                                                residual_norm_intensity, photometric_robust_scale);
+                                                                residual_norm_intensity, photometric_robust_scale, barron_alpha);
                     }
 
                     // Rotation constraint term
@@ -637,7 +639,7 @@ private:
                             kernel::linearize_rotation_constraint(source_cov, target_cov, cur_T);
                         const float residual_norm_rot = sycl::sqrt(linearized_rot.squared_error);
                         const float robust_weight_rot = robust::kernel::compute_robust_weight<loss>(
-                            residual_norm_rot, rotation_constraint_robust_scale);
+                            residual_norm_rot, rotation_constraint_robust_scale, barron_alpha);
 
                         const auto& [H0_rot, H1_rot, H2_rot] = eigen_utils::to_sycl_vec(linearized_rot.H);
                         const auto& [b0_rot, b1_rot] = eigen_utils::to_sycl_vec(linearized_rot.b);
@@ -649,7 +651,7 @@ private:
                         total_b1 += rotation_constraint_weight * robust_weight_rot * b1_rot;
                         total_error +=
                             rotation_constraint_weight * robust::kernel::compute_robust_error<loss>(
-                                                             residual_norm_rot, rotation_constraint_robust_scale);
+                                                             residual_norm_rot, rotation_constraint_robust_scale, barron_alpha);
                     }
 
                     // Reduction on device
@@ -686,6 +688,7 @@ private:
                                                                  const Eigen::Matrix4f transT, float robust_scale,
                                                                  float rotation_robust_scale) {
         // The robust_scale argument ensures error reduction uses the caller-provided loss scale.
+        const float barron_alpha = this->params_.robust.barron_alpha;
         shared_vector<float> error(1, 0.0f, *this->queue_.ptr);
         shared_vector<uint32_t> inlier(1, 0, *this->queue_.ptr);
 
@@ -780,9 +783,9 @@ private:
 
                         if constexpr (reg == RegType::GENZ) {
                             total_error =
-                                genz_weight * robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
+                                genz_weight * robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale, barron_alpha);
                         } else {
-                            total_error = robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale);
+                            total_error = robust::kernel::compute_robust_error<loss>(residual_norm, robust_scale, barron_alpha);
                         }
                     }
 
@@ -793,7 +796,7 @@ private:
                                                           target_rgb, target_normal, target_grad);
                         const float residual_norm_color = sycl::sqrt(squared_error_color);
                         total_error += photometric_weight * robust::kernel::compute_robust_error<loss>(
-                                                                residual_norm_color, photometric_robust_scale);
+                                                                residual_norm_color, photometric_robust_scale, barron_alpha);
                     }
                     if (use_intensity) {
                         const float squared_error_intensity = kernel::calculate_intensity_error(
@@ -801,7 +804,7 @@ private:
                             target_normal, target_intensity_grad);
                         const float residual_norm_intensity = sycl::sqrt(squared_error_intensity);
                         total_error += photometric_weight * robust::kernel::compute_robust_error<loss>(
-                                                                residual_norm_intensity, photometric_robust_scale);
+                                                                residual_norm_intensity, photometric_robust_scale, barron_alpha);
                     }
 
                     // Rotation constraint term
@@ -811,7 +814,7 @@ private:
                         const float residual_norm_rot = sycl::sqrt(squared_error_rot);
                         total_error +=
                             rotation_constraint_weight * robust::kernel::compute_robust_error<loss>(
-                                                             residual_norm_rot, rotation_constraint_robust_scale);
+                                                             residual_norm_rot, rotation_constraint_robust_scale, barron_alpha);
                     }
 
                     // Reduction

--- a/cpp/include/sycl_points/algorithms/registration/registration_params.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration_params.hpp
@@ -45,6 +45,7 @@ struct RegistrationParams {
     struct Robust {
         robust::RobustLossType type = robust::RobustLossType::NONE;  // robust loss function type
         float default_scale = 10.0f;                                 // default scale for robust loss function
+        float barron_alpha = 1.0f;  // shape parameter for Barron loss (alpha=2: L2, alpha=1: Charbonnier, alpha=0: Cauchy-like, alpha<0: heavier tail)
     };
     struct PhotometricTerm {
         bool enable = false;  // If true, use photometric term.

--- a/cpp/include/sycl_points/algorithms/robust/robust.hpp
+++ b/cpp/include/sycl_points/algorithms/robust/robust.hpp
@@ -15,7 +15,8 @@ enum class RobustLossType {
     HUBER,         // Huber loss
     TUKEY,         // Tukey bi-weight
     CAUCHY,        // Cauchy loss
-    GEMAN_MCCLURE  // Geman-McClure loss
+    GEMAN_MCCLURE, // Geman-McClure loss
+    BARRON         // Barron's general adaptive robust loss (Barron 2019)
 };
 
 /// @brief Robust loss Type tags
@@ -24,7 +25,8 @@ using RobustLossTypeTags = std::tuple<                                     //
     std::integral_constant<RobustLossType, RobustLossType::HUBER>,         //
     std::integral_constant<RobustLossType, RobustLossType::TUKEY>,         //
     std::integral_constant<RobustLossType, RobustLossType::CAUCHY>,        //
-    std::integral_constant<RobustLossType, RobustLossType::GEMAN_MCCLURE>  //
+    std::integral_constant<RobustLossType, RobustLossType::GEMAN_MCCLURE>, //
+    std::integral_constant<RobustLossType, RobustLossType::BARRON>         //
     >;
 
 inline RobustLossType RobustLossType_from_string(const std::string& str) {
@@ -40,6 +42,8 @@ inline RobustLossType RobustLossType_from_string(const std::string& str) {
         return RobustLossType::CAUCHY;
     } else if (upper == "GEMAN_MCCLURE") {
         return RobustLossType::GEMAN_MCCLURE;
+    } else if (upper == "BARRON") {
+        return RobustLossType::BARRON;
     }
     std::string error_str = "[RobustLossType_from_string] Invalid RobustLossType str '";
     error_str += str;
@@ -52,9 +56,10 @@ namespace kernel {
 /// @brief Compute robust weight for given residual
 /// @param residual_norm Norm of residual vector
 /// @param scale Scale parameter for robust loss
+/// @param alpha Shape parameter for Barron loss (ignored for other loss types)
 /// @return Robust weight (0.0 to 1.0)
 template <RobustLossType LossType = RobustLossType::NONE>
-SYCL_EXTERNAL inline float compute_robust_weight(float residual_norm, float scale) {
+SYCL_EXTERNAL inline float compute_robust_weight(float residual_norm, float scale, float alpha = 1.0f) {
     if constexpr (LossType == RobustLossType::NONE) {
         return 1.0f;
     }
@@ -84,6 +89,18 @@ SYCL_EXTERNAL inline float compute_robust_weight(float residual_norm, float scal
         const float x = normalized_residual * normalized_residual;
         const float denominator = 1.0f + x;
         return 1.0f / (denominator * denominator);
+    } else if constexpr (LossType == RobustLossType::BARRON) {
+        // Barron's general adaptive robust loss (Barron 2019)
+        // w(r, alpha, c) = ((r/c)^2 / |alpha-2| + 1)^(alpha/2 - 1)
+        // Special case alpha~2: reduces to L2 (w = 1)
+        // Reference: "A General and Adaptive Robust Loss Function", Barron, CVPR 2019
+        const float abs_alpha_minus_2 = sycl::fabs(alpha - 2.0f);
+        if (abs_alpha_minus_2 < 1e-4f) {
+            return 1.0f;
+        }
+        const float z2 = normalized_residual * normalized_residual;
+        const float base = z2 / abs_alpha_minus_2 + 1.0f;
+        return sycl::pow(base, alpha * 0.5f - 1.0f);
     }
 
     return 1.0f;
@@ -92,9 +109,10 @@ SYCL_EXTERNAL inline float compute_robust_weight(float residual_norm, float scal
 /// @brief Compute robust error for given residual
 /// @param residual_norm Norm of residual vector
 /// @param scale Scale parameter for robust loss
-/// @return Robust weight (0.0 to 1.0)
+/// @param alpha Shape parameter for Barron loss (ignored for other loss types)
+/// @return Robust error value
 template <RobustLossType LossType = RobustLossType::NONE>
-SYCL_EXTERNAL inline float compute_robust_error(float residual_norm, float scale) {
+SYCL_EXTERNAL inline float compute_robust_error(float residual_norm, float scale, float alpha = 1.0f) {
     if constexpr (LossType == RobustLossType::NONE) {
         return 0.5f * residual_norm * residual_norm;
     } else if constexpr (LossType == RobustLossType::HUBER) {
@@ -108,6 +126,24 @@ SYCL_EXTERNAL inline float compute_robust_error(float residual_norm, float scale
         return 0.5f * scale * scale * sycl::log(1.0f + ((residual_norm * residual_norm) / (scale * scale)));
     } else if constexpr (LossType == RobustLossType::GEMAN_MCCLURE) {
         return 0.5f * (scale * scale * residual_norm * residual_norm) / (scale * scale + residual_norm * residual_norm);
+    } else if constexpr (LossType == RobustLossType::BARRON) {
+        // Barron's general adaptive robust loss (Barron 2019)
+        // rho(r, alpha, c) = (|alpha-2|/alpha) * (((r/c)^2/|alpha-2| + 1)^(alpha/2) - 1)
+        // Special cases:
+        //   alpha~2 : L2 loss  -> rho = 0.5*(r/c)^2
+        //   alpha~0 : Cauchy-like -> rho = log(1 + 0.5*(r/c)^2)
+        // Reference: "A General and Adaptive Robust Loss Function", Barron, CVPR 2019
+        const float z2 = (residual_norm * residual_norm) / (scale * scale);
+        const float abs_alpha_minus_2 = sycl::fabs(alpha - 2.0f);
+        if (abs_alpha_minus_2 < 1e-4f) {
+            return 0.5f * z2;
+        }
+        const float abs_alpha = sycl::fabs(alpha);
+        if (abs_alpha < 1e-4f) {
+            return sycl::log(1.0f + 0.5f * z2);
+        }
+        const float base = z2 / abs_alpha_minus_2 + 1.0f;
+        return (abs_alpha_minus_2 / alpha) * (sycl::pow(base, alpha * 0.5f) - 1.0f);
     }
 
     return 0.5f * residual_norm * residual_norm;

--- a/ros2/sycl_points_ros2/config/lidar_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_odometry.yaml
@@ -138,7 +138,10 @@ lidar_odometry_node:
     registration/velocity_update/enable: true
     registration/velocity_update/iter: 2
 
-    registration/robust/type: GEMAN_MCCLURE  # NONE, HUBER, TUKEY, CAUCHY, GEMAN_MCCLURE
+    registration/robust/type: GEMAN_MCCLURE  # NONE, HUBER, TUKEY, CAUCHY, GEMAN_MCCLURE, BARRON
+    registration/robust/barron_alpha: 1.0    # Shape parameter for Barron loss (used when type=BARRON).
+                                             # α=2: L2, α=1: Charbonnier, α=0: Cauchy-like
+                                             # α=-2: Geman-McClure, α<<0: Welsch loss
     registration/robust/default_scale: 10.0  # If robust/auto_scale is false, the robust scale is fixed to default_scale.
     registration/robust/auto_scale: true
     registration/robust/auto_scaling_iter: 4

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
@@ -224,6 +224,8 @@ inline pipeline::lidar_odometry::Parameters declare_lidar_odometry_parameters(rc
                 node->declare_parameter<double>("registration/robust/min_scale", pipeline_robust.min_scale);
             pipeline_robust.auto_scaling_iter = node->declare_parameter<int64_t>(
                 "registration/robust/auto_scaling_iter", pipeline_robust.auto_scaling_iter);
+            robust.barron_alpha =
+                node->declare_parameter<double>("registration/robust/barron_alpha", robust.barron_alpha);
         }
         // deskew
         {


### PR DESCRIPTION
Implements the loss function from "A General and Adaptive Robust Loss
Function" (Barron, CVPR 2019) as a new RobustLossType::BARRON option.

The Barron loss unifies many robust losses via a shape parameter alpha:
- alpha ~  2 : L2 loss (no robust weighting)
- alpha =  1 : Charbonnier / pseudo-Huber (default)
- alpha ~  0 : Cauchy-like (log(1 + 0.5*(r/c)^2))
- alpha = -2 : Geman-McClure-like
- alpha < -2 : increasingly heavy-tailed / Welsch-like

Weight function:  w(r, alpha, c) = ((r/c)^2/|alpha-2| + 1)^(alpha/2 - 1)
Error function:   rho(r, alpha, c) = (|alpha-2|/alpha)*((z^2/|alpha-2|+1)^(alpha/2) - 1)

Changes:
- robust.hpp: Add BARRON enum value, update RobustLossTypeTags and
  RobustLossType_from_string; add `alpha` parameter (default 1.0) to
  compute_robust_weight and compute_robust_error with BARRON branch
- registration_params.hpp: Add `barron_alpha` field to Robust struct
- registration.hpp: Capture barron_alpha in all three SYCL kernel
  submission functions and forward it to every robust kernel call

https://claude.ai/code/session_012ebUX6S3B4SThgEJMokT8A