### PR TITLE
Add Anderson acceleration to Registration optimization loop

### DIFF
--- a/cpp/include/sycl_points/algorithms/registration/anderson_acceleration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/anderson_acceleration.hpp
@@ -58,15 +58,17 @@ public:
         const Eigen::Vector<float, 6> f_new = x_new - x_hist_.back();
         f_hist_.push_back(f_new);
 
-        // Keep history bounded to window_size
-        while (x_hist_.size() > window_size_) {
+        // Keep history bounded.  To construct m_k = window_size_ columns in F_k / X_k
+        // we need window_size_+1 residuals (to form window_size_ differences), so allow
+        // f_hist_ to hold up to window_size_+1 entries before trimming.
+        while (x_hist_.size() > window_size_ + 1) {
             x_hist_.pop_front();
         }
-        while (f_hist_.size() > window_size_) {
+        while (f_hist_.size() > window_size_ + 1) {
             f_hist_.pop_front();
         }
 
-        // Store current iterate AFTER trimming (so x_hist_ has at most window_size_ entries)
+        // Store current iterate AFTER trimming
         x_hist_.push_back(x_new);
 
         const int m_k = static_cast<int>(f_hist_.size()) - 1;
@@ -77,12 +79,13 @@ public:
 
         // Build F_k (6 x m_k): column differences of residuals
         // Build X_k (6 x m_k): column differences of iterates
-        // We index: f_hist_[0..m_k] (size = m_k+1), x_hist_[0..m_k+1] (size = m_k+2)
+        // Since f_hist_[j] = x_hist_[j+1] - x_hist_[j], X_k can be built directly
+        // from f_hist_ without recomputing differences from x_hist_.
         Eigen::MatrixXf F_k(6, m_k);
         Eigen::MatrixXf X_k(6, m_k);
         for (int j = 0; j < m_k; ++j) {
             F_k.col(j) = f_hist_[j + 1] - f_hist_[j];
-            X_k.col(j) = x_hist_[j + 1] - x_hist_[j];
+            X_k.col(j) = f_hist_[j];
         }
 
         // Solve unconstrained LS: gamma* = argmin ||f_k - F_k * gamma||_2

--- a/cpp/include/sycl_points/algorithms/registration/anderson_acceleration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/anderson_acceleration.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <deque>
+
+#include "sycl_points/utils/eigen_utils.hpp"
+
+namespace sycl_points {
+namespace algorithms {
+namespace registration {
+
+/// @brief Anderson acceleration for fixed-point iterations on SE(3).
+///
+/// Applies Anderson(m) acceleration (Walker & Ni 2011, Type 2) to the
+/// outer Registration optimization loop.  Each call to apply() takes the
+/// T proposed by the underlying optimizer and returns an extrapolated T
+/// that should converge faster.
+///
+/// The iterate is represented in the Lie algebra se(3) relative to the
+/// initial guess:  x_k = se3_log(T_k * T_initial^{-1}).
+/// The residual is f_k = x_{k+1} - x_k (effective update step).
+///
+/// Anderson mixing step (window size m_k = min(m, k)):
+///   F_k = [f_{k-m_k+1}-f_{k-m_k}, ..., f_k-f_{k-1}]  (6 x m_k)
+///   X_k = [x_{k-m_k+1}-x_{k-m_k}, ..., x_{k+1}-x_k]  (6 x m_k)
+///   gamma* = argmin_gamma ||f_k - F_k * gamma||_2^2
+///   x_{k+1}^AA = x_{k+1} - (beta * F_k + X_k) * gamma*
+///   T_{k+1}^AA = se3_exp(x_{k+1}^AA) * T_initial
+class AndersonAcceleration {
+public:
+    AndersonAcceleration() = default;
+
+    /// @brief Reset the acceleration state.
+    /// @param window_size History window size m (Anderson(m))
+    /// @param beta Mixing parameter: 1.0 = pure Anderson acceleration
+    void reset(size_t window_size, float beta) {
+        window_size_ = window_size;
+        beta_ = beta;
+        x_hist_.clear();
+        f_hist_.clear();
+    }
+
+    /// @brief Apply Anderson acceleration to the current iterate.
+    /// @param input_T  Transformation proposed by the underlying optimizer this iteration
+    /// @param initial_T  The initial guess passed to Registration::align()
+    /// @return Accelerated transformation
+    Eigen::Isometry3f apply(const Eigen::Isometry3f& input_T, const Eigen::Isometry3f& initial_T) {
+        // Compute relative transform in Lie algebra: x_{k+1} = log(input_T * initial_T^{-1})
+        const Eigen::Isometry3f rel = input_T * initial_T.inverse();
+        const Eigen::Vector<float, 6> x_new = eigen_utils::lie::se3_log(rel);
+
+        if (x_hist_.empty()) {
+            // First iteration: just store and return as-is
+            x_hist_.push_back(x_new);
+            return input_T;
+        }
+
+        // Compute residual f_k = x_{k+1} - x_k
+        const Eigen::Vector<float, 6> f_new = x_new - x_hist_.back();
+        f_hist_.push_back(f_new);
+
+        // Keep history bounded to window_size
+        while (x_hist_.size() > window_size_) {
+            x_hist_.pop_front();
+        }
+        while (f_hist_.size() > window_size_) {
+            f_hist_.pop_front();
+        }
+
+        // Store current iterate AFTER trimming (so x_hist_ has at most window_size_ entries)
+        x_hist_.push_back(x_new);
+
+        const int m_k = static_cast<int>(f_hist_.size()) - 1;
+        if (m_k <= 0) {
+            // Not enough history yet for mixing
+            return input_T;
+        }
+
+        // Build F_k (6 x m_k): column differences of residuals
+        // Build X_k (6 x m_k): column differences of iterates
+        // We index: f_hist_[0..m_k] (size = m_k+1), x_hist_[0..m_k+1] (size = m_k+2)
+        Eigen::MatrixXf F_k(6, m_k);
+        Eigen::MatrixXf X_k(6, m_k);
+        for (int j = 0; j < m_k; ++j) {
+            F_k.col(j) = f_hist_[j + 1] - f_hist_[j];
+            X_k.col(j) = x_hist_[j + 1] - x_hist_[j];
+        }
+
+        // Solve unconstrained LS: gamma* = argmin ||f_k - F_k * gamma||_2
+        // Use Householder QR for numerical stability with rank-deficient systems
+        const Eigen::Vector<float, 6>& f_k = f_hist_.back();
+        const Eigen::VectorXf gamma = F_k.householderQr().solve(f_k);
+
+        // Accelerated iterate: x_acc = x_{k+1} - (beta * F_k + X_k) * gamma
+        const Eigen::Vector<float, 6> x_acc = x_new - (beta_ * F_k + X_k) * gamma;
+
+        // Retract back to SE(3): T_acc = se3_exp(x_acc) * initial_T
+        const Eigen::Isometry3f T_acc =
+            Eigen::Isometry3f(eigen_utils::lie::se3_exp(x_acc)) * initial_T;
+        return T_acc;
+    }
+
+private:
+    size_t window_size_ = 5;
+    float beta_ = 1.0f;
+
+    // x_hist_[i] = se3_log(T_i * T_initial^{-1})
+    std::deque<Eigen::Vector<float, 6>> x_hist_;
+    // f_hist_[i] = x_hist_[i+1] - x_hist_[i]
+    std::deque<Eigen::Vector<float, 6>> f_hist_;
+};
+
+}  // namespace registration
+}  // namespace algorithms
+}  // namespace sycl_points

--- a/cpp/include/sycl_points/algorithms/registration/anderson_acceleration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/anderson_acceleration.hpp
@@ -23,7 +23,7 @@ namespace registration {
 ///   F_k = [f_{k-m_k+1}-f_{k-m_k}, ..., f_k-f_{k-1}]  (6 x m_k)
 ///   X_k = [x_{k-m_k+1}-x_{k-m_k}, ..., x_{k+1}-x_k]  (6 x m_k)
 ///   gamma* = argmin_gamma ||f_k - F_k * gamma||_2^2
-///   x_{k+1}^AA = x_{k+1} - (beta * F_k + X_k) * gamma*
+///   x_{k+1}^AA = x_{k+1} - (1 - beta) * f_k - (beta * F_k + X_k) * gamma*
 ///   T_{k+1}^AA = se3_exp(x_{k+1}^AA) * T_initial
 class AndersonAcceleration {
 public:
@@ -37,6 +37,7 @@ public:
         beta_ = beta;
         x_hist_.clear();
         f_hist_.clear();
+        initial_T_inv_cached_ = false;
     }
 
     /// @brief Apply Anderson acceleration to the current iterate.
@@ -44,8 +45,14 @@ public:
     /// @param initial_T  The initial guess passed to Registration::align()
     /// @return Accelerated transformation
     Eigen::Isometry3f apply(const Eigen::Isometry3f& input_T, const Eigen::Isometry3f& initial_T) {
+        // Cache initial_T^{-1} on the first call (constant throughout the align() loop)
+        if (!initial_T_inv_cached_) {
+            initial_T_inv_ = initial_T.inverse();
+            initial_T_inv_cached_ = true;
+        }
+
         // Compute relative transform in Lie algebra: x_{k+1} = log(input_T * initial_T^{-1})
-        const Eigen::Isometry3f rel = input_T * initial_T.inverse();
+        const Eigen::Isometry3f rel = input_T * initial_T_inv_;
         const Eigen::Vector<float, 6> x_new = eigen_utils::lie::se3_log(rel);
 
         if (x_hist_.empty()) {
@@ -89,12 +96,18 @@ public:
         }
 
         // Solve unconstrained LS: gamma* = argmin ||f_k - F_k * gamma||_2
-        // Use Householder QR for numerical stability with rank-deficient systems
+        // Use column-pivoting QR for robustness against rank-deficient F_k
         const Eigen::Vector<float, 6>& f_k = f_hist_.back();
-        const Eigen::VectorXf gamma = F_k.householderQr().solve(f_k);
+        const Eigen::VectorXf gamma = F_k.colPivHouseholderQr().solve(f_k);
 
-        // Accelerated iterate: x_acc = x_{k+1} - (beta * F_k + X_k) * gamma
-        const Eigen::Vector<float, 6> x_acc = x_new - (beta_ * F_k + X_k) * gamma;
+        // Guard against numerical failures (NaN/Inf) that can arise in degenerate cases
+        if (!gamma.allFinite()) {
+            return input_T;
+        }
+
+        // Accelerated iterate (Walker & Ni 2011, Type 2 with damping beta):
+        //   x_acc = x_{k+1} - (1 - beta) * f_k - (beta * F_k + X_k) * gamma*
+        const Eigen::Vector<float, 6> x_acc = x_new - (1.0f - beta_) * f_k - (beta_ * F_k + X_k) * gamma;
 
         // Retract back to SE(3): T_acc = se3_exp(x_acc) * initial_T
         const Eigen::Isometry3f T_acc =
@@ -105,6 +118,10 @@ public:
 private:
     size_t window_size_ = 5;
     float beta_ = 1.0f;
+
+    // Cached inverse of initial_T (constant throughout an align() call)
+    Eigen::Isometry3f initial_T_inv_;
+    bool initial_T_inv_cached_ = false;
 
     // x_hist_[i] = se3_log(T_i * T_initial^{-1})
     std::deque<Eigen::Vector<float, 6>> x_hist_;

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -265,13 +265,12 @@ public:
                         this->optimize_gauss_newton(result, regularized_result, iter);
                         break;
                 }
-
-                // Apply safeguarded Anderson acceleration to the outer iteration
-                this->apply_anderson_acceleration(source, target, result, T_initial, robust_scale,
-                                                  rotation_robust_scale);
-
                 if (result.converged) {
                     break;
+                } else {
+                    // Apply safeguarded Anderson acceleration to the outer iteration
+                    this->apply_anderson_acceleration(source, target, result, T_initial, robust_scale,
+                                                      rotation_robust_scale);
                 }
             }
         }

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -9,6 +9,7 @@
 #include "sycl_points/algorithms/deskew/relative_pose_deskew.hpp"
 #include "sycl_points/algorithms/feature/covariance.hpp"
 #include "sycl_points/algorithms/knn/knn.hpp"
+#include "sycl_points/algorithms/registration/anderson_acceleration.hpp"
 #include "sycl_points/algorithms/registration/degenerate_regularization.hpp"
 #include "sycl_points/algorithms/registration/factor.hpp"
 #include "sycl_points/algorithms/registration/linearized_result.hpp"
@@ -228,6 +229,12 @@ public:
                                                     : this->params_.rotation_constraint.robust.default_scale;
 
             float lm_lambda = this->params_.lm.init_lambda;
+
+            if (this->params_.anderson.enabled) {
+                this->anderson_acc_.reset(this->params_.anderson.window_size, this->params_.anderson.beta);
+            }
+            const Eigen::Isometry3f T_initial(initial_guess);
+
             for (size_t iter = 0; iter < this->params_.max_iterations; ++iter) {
                 // Nearest neighbor search on device
                 auto knn_event =
@@ -242,7 +249,7 @@ public:
 
                 // Regularization
                 const LinearizedResult regularized_result =
-                    this->degenerate_reg_.regularize(linearized_result, result.T, Eigen::Isometry3f(initial_guess));
+                    this->degenerate_reg_.regularize(linearized_result, result.T, T_initial);
 
                 // Optimize on Host
                 switch (this->params_.optimization_method) {
@@ -258,6 +265,12 @@ public:
                         this->optimize_gauss_newton(result, regularized_result, iter);
                         break;
                 }
+
+                // Apply Anderson acceleration to the outer iteration (on top of any optimizer)
+                if (this->params_.anderson.enabled) {
+                    result.T = this->anderson_acc_.apply(result.T, T_initial);
+                }
+
                 if (result.converged) {
                     break;
                 }
@@ -294,6 +307,7 @@ private:
 
     DegenerateRegularization degenerate_reg_;
     float genz_alpha_ = 1.0f;
+    AndersonAcceleration anderson_acc_;
 
     template <typename Func>
     sycl_utils::events dispatch(Func&& exec) const {

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -868,19 +868,30 @@ private:
         if (!this->params_.anderson.enabled) {
             return;
         }
+        // Compute the baseline error at the optimizer's proposed pose.  This is necessary
+        // because different optimizers leave result.error in different states: Gauss-Newton
+        // stores the pre-step error (linearized_result.error), while Levenberg-Marquardt
+        // and Powell's Dogleg store the post-step error.  Recomputing here ensures a fair
+        // comparison against the Anderson-accelerated pose for all methods.
+        const auto [baseline_error, baseline_inlier] =
+            compute_error(source, target, this->neighbors_->at(0), result.T.matrix(),
+                          robust_scale, rotation_robust_scale);
         const Eigen::Isometry3f T_anderson = this->anderson_acc_.apply(result.T, T_initial);
         const auto [anderson_error, anderson_inlier] =
             compute_error(source, target, this->neighbors_->at(0), T_anderson.matrix(),
                           robust_scale, rotation_robust_scale);
-        const bool accepted = anderson_error <= result.error;
+        const bool accepted = anderson_error <= baseline_error;
         if (this->params_.verbose) {
             std::cout << "  anderson: " << (accepted ? "accepted" : "rejected")
-                      << ", error: " << result.error << " -> " << anderson_error << std::endl;
+                      << ", error: " << baseline_error << " -> " << anderson_error << std::endl;
         }
         if (accepted) {
             result.T = T_anderson;
             result.error = anderson_error;
             result.inlier = anderson_inlier;
+        } else {
+            result.error = baseline_error;
+            result.inlier = baseline_inlier;
         }
     }
 

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -267,19 +267,8 @@ public:
                 }
 
                 // Apply safeguarded Anderson acceleration to the outer iteration
-                if (this->params_.anderson.enabled) {
-                    const Eigen::Isometry3f T_anderson = this->anderson_acc_.apply(result.T, T_initial);
-                    // Recompute error with the accelerated pose (reusing existing neighbors)
-                    const auto [anderson_error, anderson_inlier] =
-                        compute_error(source, target, this->neighbors_->at(0), T_anderson.matrix(),
-                                      robust_scale, rotation_robust_scale);
-                    // Accept only if Anderson pose reduces error
-                    if (anderson_error <= result.error) {
-                        result.T = T_anderson;
-                        result.error = anderson_error;
-                        result.inlier = anderson_inlier;
-                    }
-                }
+                this->apply_anderson_acceleration(source, target, result, T_initial, robust_scale,
+                                                   rotation_robust_scale);
 
                 if (result.converged) {
                     break;
@@ -871,6 +860,28 @@ private:
         }
         solution.setZero();
         return false;
+    }
+
+    void apply_anderson_acceleration(const PointCloudShared& source, const PointCloudShared& target,
+                                     RegistrationResult& result, const Eigen::Isometry3f& T_initial,
+                                     float robust_scale, float rotation_robust_scale) {
+        if (!this->params_.anderson.enabled) {
+            return;
+        }
+        const Eigen::Isometry3f T_anderson = this->anderson_acc_.apply(result.T, T_initial);
+        const auto [anderson_error, anderson_inlier] =
+            compute_error(source, target, this->neighbors_->at(0), T_anderson.matrix(),
+                          robust_scale, rotation_robust_scale);
+        const bool accepted = anderson_error <= result.error;
+        if (this->params_.verbose) {
+            std::cout << "  anderson: " << (accepted ? "accepted" : "rejected")
+                      << ", error: " << result.error << " -> " << anderson_error << std::endl;
+        }
+        if (accepted) {
+            result.T = T_anderson;
+            result.error = anderson_error;
+            result.inlier = anderson_inlier;
+        }
     }
 
     void optimize_gauss_newton(RegistrationResult& result, const LinearizedResult& linearized_result, size_t iter) {

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -268,7 +268,7 @@ public:
 
                 // Apply safeguarded Anderson acceleration to the outer iteration
                 this->apply_anderson_acceleration(source, target, result, T_initial, robust_scale,
-                                                   rotation_robust_scale);
+                                                  rotation_robust_scale);
 
                 if (result.converged) {
                     break;
@@ -863,26 +863,29 @@ private:
     }
 
     void apply_anderson_acceleration(const PointCloudShared& source, const PointCloudShared& target,
-                                     RegistrationResult& result, const Eigen::Isometry3f& T_initial,
-                                     float robust_scale, float rotation_robust_scale) {
+                                     RegistrationResult& result, const Eigen::Isometry3f& T_initial, float robust_scale,
+                                     float rotation_robust_scale) {
         if (!this->params_.anderson.enabled) {
             return;
         }
-        // Compute the baseline error at the optimizer's proposed pose.  This is necessary
-        // because different optimizers leave result.error in different states: Gauss-Newton
-        // stores the pre-step error (linearized_result.error), while Levenberg-Marquardt
-        // and Powell's Dogleg store the post-step error.  Recomputing here ensures a fair
-        // comparison against the Anderson-accelerated pose for all methods.
-        const auto [baseline_error, baseline_inlier] =
-            compute_error(source, target, this->neighbors_->at(0), result.T.matrix(),
-                          robust_scale, rotation_robust_scale);
+
+        // Gauss-Newton leaves result.error as the pre-step linearized error,
+        // so recompute the baseline at result.T for a fair Anderson comparison.
+        // LM/Dogleg already store the post-step error, so no recomputation needed.
+        float baseline_error = result.error;
+        int baseline_inlier = result.inlier;
+        if (this->params_.optimization_method == OptimizationMethod::GAUSS_NEWTON) {
+            std::tie(baseline_error, baseline_inlier) = compute_error(
+                source, target, this->neighbors_->at(0), result.T.matrix(), robust_scale, rotation_robust_scale);
+        }
+
         const Eigen::Isometry3f T_anderson = this->anderson_acc_.apply(result.T, T_initial);
-        const auto [anderson_error, anderson_inlier] =
-            compute_error(source, target, this->neighbors_->at(0), T_anderson.matrix(),
-                          robust_scale, rotation_robust_scale);
+        const auto [anderson_error, anderson_inlier] = compute_error(
+            source, target, this->neighbors_->at(0), T_anderson.matrix(), robust_scale, rotation_robust_scale);
+
         const bool accepted = anderson_error <= baseline_error;
         if (this->params_.verbose) {
-            std::cout << "  anderson: " << (accepted ? "accepted" : "rejected")
+            std::cout << "  anderson: " << (accepted ? "accepted" : "rejected")  //
                       << ", error: " << baseline_error << " -> " << anderson_error << std::endl;
         }
         if (accepted) {
@@ -909,7 +912,7 @@ private:
         result.iterations = iter;
         result.H = linearized_result.H;
         result.b = linearized_result.b;
-        result.error = linearized_result.error;
+        result.error = linearized_result.error;  // previous pose error
         result.inlier = linearized_result.inlier;
 
         if (this->params_.verbose) {

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -266,9 +266,19 @@ public:
                         break;
                 }
 
-                // Apply Anderson acceleration to the outer iteration (on top of any optimizer)
+                // Apply safeguarded Anderson acceleration to the outer iteration
                 if (this->params_.anderson.enabled) {
-                    result.T = this->anderson_acc_.apply(result.T, T_initial);
+                    const Eigen::Isometry3f T_anderson = this->anderson_acc_.apply(result.T, T_initial);
+                    // Recompute error with the accelerated pose (reusing existing neighbors)
+                    const auto [anderson_error, anderson_inlier] =
+                        compute_error(source, target, this->neighbors_->at(0), T_anderson.matrix(),
+                                      robust_scale, rotation_robust_scale);
+                    // Accept only if Anderson pose reduces error
+                    if (anderson_error <= result.error) {
+                        result.T = T_anderson;
+                        result.error = anderson_error;
+                        result.inlier = anderson_inlier;
+                    }
                 }
 
                 if (result.converged) {

--- a/cpp/include/sycl_points/algorithms/registration/registration_params.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration_params.hpp
@@ -84,6 +84,12 @@ struct RegistrationParams {
         float gamma_increase = 2.0f;               // Expand factor for trust region (for Powell's dogleg method)
     };
 
+    struct AndersonAcceleration {
+        bool enabled = false;     // If true, apply Anderson acceleration to the outer iteration
+        size_t window_size = 5;   // History window size m (Anderson(m))
+        float beta = 1.0f;        // Mixing parameter: 1.0 = pure Anderson acceleration
+    };
+
     RegType reg_type = RegType::GICP;          // Registration Type
     size_t max_iterations = 20;                // max iteration
     float lambda = 1e-6f;                      // damping factor
@@ -99,6 +105,7 @@ struct RegistrationParams {
     GaussNewton gn;
     LevenbergMarquardt lm;
     Dogleg dogleg;
+    AndersonAcceleration anderson;
     OptimizationMethod optimization_method = OptimizationMethod::GAUSS_NEWTON;  // Optimization method selector
 
     DegenerateRegularizationParams degenerate_reg;  // Degenerate Regularization

--- a/ros2/sycl_points_ros2/config/lidar_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_odometry.yaml
@@ -169,6 +169,11 @@ lidar_odometry_node:
 
     registration/genz/planarity_threshold: 0.2
 
+    # Anderson Acceleration
+    registration/anderson/enabled: false    # If true, apply Anderson acceleration to the outer iteration
+    registration/anderson/window_size: 5    # History window size m (Anderson(m))
+    registration/anderson/beta: 1.0         # Mixing parameter: 1.0 = pure Anderson acceleration
+
     # Registration Optimizer
     registration/optimization_method: LM  # GN, LM, DOGLEG
     registration/gn/lambda: 1.0  # small value -> fast convergence, but not stable.

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
@@ -268,6 +268,18 @@ inline pipeline::lidar_odometry::Parameters declare_lidar_odometry_parameters(rc
                 "registration/rotation_constraint/robust/min_scale", pipeline_robust.rotation_min_scale);
         }
 
+        // Anderson Acceleration
+        {
+            auto& anderson = solver.anderson;
+
+            anderson.enabled =
+                node->declare_parameter<bool>("registration/anderson/enabled", anderson.enabled);
+            anderson.window_size = node->declare_parameter<int64_t>(
+                "registration/anderson/window_size", anderson.window_size);
+            anderson.beta =
+                node->declare_parameter<double>("registration/anderson/beta", anderson.beta);
+        }
+
         // Optimization
         {
             auto& gn = solver.gn;


### PR DESCRIPTION
Implements Anderson(m) acceleration (Walker & Ni 2011, Type 2) as an
add-on to the existing Gauss-Newton / Levenberg-Marquardt / Powell Dogleg
optimizers.  The outer ICP iteration is treated as a fixed-point map in
se(3) Lie algebra space; past iterates and residuals are mixed optimally
to reduce the number of outer iterations required for convergence.

Key changes:
- anderson_acceleration.hpp: new AndersonAcceleration class
- registration_params.hpp: new AndersonAccelerationParams struct (enabled,
  window_size, beta) added to RegistrationParams::anderson
- registration.hpp: include new header, add anderson_acc_ member, reset
  at align() start, apply after each optimizer step when enabled

https://claude.ai/code/session_01Vi84zEXjDTURoWp9AkkqR3