### PR TITLE
Replace LM lambda update with Nielsen's rule

### DIFF
--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -228,6 +228,7 @@ public:
                                                     : this->params_.rotation_constraint.robust.default_scale;
 
             float lm_lambda = this->params_.lm.init_lambda;
+            float lm_nu = 2.0f;  // Nielsen's rule: initial nu
             for (size_t iter = 0; iter < this->params_.max_iterations; ++iter) {
                 // Nearest neighbor search on device
                 auto knn_event =
@@ -247,8 +248,8 @@ public:
                 // Optimize on Host
                 switch (this->params_.optimization_method) {
                     case OptimizationMethod::LEVENBERG_MARQUARDT:
-                        this->optimize_levenberg_marquardt(source, target, result, regularized_result, lm_lambda, iter,
-                                                           robust_scale, rotation_robust_scale);
+                        this->optimize_levenberg_marquardt(source, target, result, regularized_result, lm_lambda,
+                                                           lm_nu, iter, robust_scale, rotation_robust_scale);
                         break;
                     case OptimizationMethod::POWELL_DOGLEG:
                         this->optimize_powell_dogleg(source, target, result, regularized_result, trust_region_radius,
@@ -877,7 +878,8 @@ private:
 
     bool optimize_levenberg_marquardt(const PointCloudShared& source, const PointCloudShared& target,
                                       RegistrationResult& result, const LinearizedResult& linearized_result,
-                                      float& lambda, size_t iter, float robust_scale, float rotation_robust_scale) {
+                                      float& lambda, float& nu, size_t iter, float robust_scale,
+                                      float rotation_robust_scale) {
         const auto& H = linearized_result.H;
         const auto& g = linearized_result.b;
         const float current_error = linearized_result.error;
@@ -908,28 +910,36 @@ private:
                 std::cout << "dt: " << delta.tail<3>().norm() << ", ";
                 std::cout << "dr: " << delta.head<3>().norm() << std::endl;
             }
-            if (new_error <= current_error) {
+
+            // Nielsen's rule: compute gain ratio rho = actual / predicted reduction
+            // predicted = 0.5 * delta^T * (lambda * delta - g)  [undamped quadratic model]
+            const float predicted = 0.5f * delta.dot(lambda * delta - g);
+            const float rho = (predicted > 0.0f) ? (current_error - new_error) / predicted : -1.0f;
+
+            if (rho > 0.0f) {
+                // Step accepted
                 result.converged = this->is_converged(delta);
                 result.T = new_T;
                 result.error = new_error;
                 result.inlier = inlier;
                 updated = true;
 
-                lambda = std::clamp(lambda / this->params_.lm.lambda_factor, this->params_.lm.min_lambda,
-                                    this->params_.lm.max_lambda);
-
+                const float scale = std::max(1.0f / 3.0f, 1.0f - std::pow(2.0f * rho - 1.0f, 3.0f));
+                lambda = std::clamp(lambda * scale, this->params_.lm.min_lambda, this->params_.lm.max_lambda);
+                nu = 2.0f;
                 break;
             } else if (std::fabs(new_error - last_error) <= 1e-6f) {
+                // Stagnation safety check
                 result.converged = this->is_converged(delta);
                 result.T = new_T;
                 result.error = new_error;
                 result.inlier = inlier;
                 updated = false;
-
                 break;
             } else {
-                lambda = std::clamp(lambda * this->params_.lm.lambda_factor, this->params_.lm.min_lambda,
-                                    this->params_.lm.max_lambda);
+                // Step rejected: increase lambda with doubling nu
+                lambda = std::clamp(lambda * nu, this->params_.lm.min_lambda, this->params_.lm.max_lambda);
+                nu *= 2.0f;
             }
             last_error = new_error;
         }

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -929,12 +929,7 @@ private:
                 nu = 2.0f;
                 break;
             } else if (std::fabs(new_error - last_error) <= 1e-6f) {
-                // Stagnation safety check
-                result.converged = this->is_converged(delta);
-                result.T = new_T;
-                result.error = new_error;
-                result.inlier = inlier;
-                updated = false;
+                // Stagnation safety check: break without updating pose (step was rejected)
                 break;
             } else {
                 // Step rejected: increase lambda with doubling nu

--- a/cpp/include/sycl_points/algorithms/registration/registration_params.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration_params.hpp
@@ -69,8 +69,7 @@ struct RegistrationParams {
     };
     struct LevenbergMarquardt {
         size_t max_inner_iterations = 10;  // (for LM method)
-        float lambda_factor = 2.0f;        // lambda increase factor (for LM method)
-        float init_lambda = 1.0f;          // initial lambda (for LM method)
+        float init_lambda = 1.0f;          // initial lambda (for LM method, Nielsen's rule)
         float max_lambda = 1e3f;           // max lambda (for LM method)
         float min_lambda = 1e-6f;          // min lambda (for LM method)
     };

--- a/ros2/sycl_points_ros2/config/lidar_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_odometry.yaml
@@ -173,7 +173,6 @@ lidar_odometry_node:
     registration/optimization_method: LM  # GN, LM, DOGLEG
     registration/gn/lambda: 1.0  # small value -> fast convergence, but not stable.
     registration/lm/max_inner_iterations: 5
-    registration/lm/lambda_factor: 2.0
     registration/lm/init_lambda: 1.0
     registration/lm/max_lambda: 1.0e+3
     registration/lm/min_lambda: 1.0e-3

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
@@ -282,7 +282,6 @@ inline pipeline::lidar_odometry::Parameters declare_lidar_odometry_parameters(rc
 
             lm.max_inner_iterations =
                 node->declare_parameter<int64_t>("registration/lm/max_inner_iterations", lm.max_inner_iterations);
-            lm.lambda_factor = node->declare_parameter<double>("registration/lm/lambda_factor", lm.lambda_factor);
             lm.init_lambda = node->declare_parameter<double>("registration/lm/init_lambda", lm.init_lambda);
             lm.max_lambda = node->declare_parameter<double>("registration/lm/max_lambda", lm.max_lambda);
             lm.min_lambda = node->declare_parameter<double>("registration/lm/min_lambda", lm.min_lambda);


### PR DESCRIPTION
Replace simple factor-based lambda scaling with Nielsen's gain-ratio rule:
- Compute gain ratio rho = actual_reduction / predicted_reduction
  where predicted = 0.5 * delta^T * (lambda*delta - g)
- If rho > 0 (step accepted): lambda *= max(1/3, 1 - (2*rho-1)^3), nu reset to 2
- If rho <= 0 (step rejected): lambda *= nu, nu doubles

Add nu state variable alongside lambda across outer iterations.
Remove lambda_factor parameter from LevenbergMarquardt struct and ROS2 config.

https://claude.ai/code/session_01UZ1wnjz9sefRwGhNoo8Pgq