### PR TITLE
Add 15x15 covariance matrix propagation to IMUPreintegration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,9 @@
 *.app
 
 build/*
+build_test/*
 cpp/build/*
+cpp/build_test/*
 cpp/build_dpcpp/*
 cpp/build_acpp/*
 cpp/build_cuda/*

--- a/cpp/include/sycl_points/imu/imu_factor.hpp
+++ b/cpp/include/sycl_points/imu/imu_factor.hpp
@@ -40,17 +40,17 @@ namespace imu {
 /// in the 15-D error-state vector and should be used instead of magic numbers.
 struct State {
     /// Start indices of each 3-D block in the 15-D error-state / tangent vector.
-    static constexpr int kIdxPos      = 0;   ///< position    (indices  0– 2)
-    static constexpr int kIdxRot      = 3;   ///< rotation    (indices  3– 5)
-    static constexpr int kIdxVel      = 6;   ///< velocity    (indices  6– 8)
-    static constexpr int kIdxAccBias  = 9;   ///< accel bias  (indices  9–11)
-    static constexpr int kIdxGyrBias  = 12;  ///< gyro bias   (indices 12–14)
+    static constexpr int kIdxPos = 0;       ///< position    (indices  0– 2)
+    static constexpr int kIdxRot = 3;       ///< rotation    (indices  3– 5)
+    static constexpr int kIdxVel = 6;       ///< velocity    (indices  6– 8)
+    static constexpr int kIdxAccBias = 9;   ///< accel bias  (indices  9–11)
+    static constexpr int kIdxGyrBias = 12;  ///< gyro bias   (indices 12–14)
 
-    Eigen::Vector3f position   = Eigen::Vector3f::Zero();      ///< World-frame position [m]
-    Eigen::Matrix3f rotation   = Eigen::Matrix3f::Identity();  ///< Body-to-world rotation R ∈ SO(3)
-    Eigen::Vector3f velocity   = Eigen::Vector3f::Zero();      ///< World-frame velocity [m/s]
-    Eigen::Vector3f accel_bias = Eigen::Vector3f::Zero();      ///< Accelerometer bias [m/s²]
-    Eigen::Vector3f gyro_bias  = Eigen::Vector3f::Zero();      ///< Gyroscope bias [rad/s]
+    Eigen::Vector3f position = Eigen::Vector3f::Zero();      ///< World-frame position [m]
+    Eigen::Matrix3f rotation = Eigen::Matrix3f::Identity();  ///< Body-to-world rotation R ∈ SO(3)
+    Eigen::Vector3f velocity = Eigen::Vector3f::Zero();      ///< World-frame velocity [m/s]
+    Eigen::Vector3f accel_bias = Eigen::Vector3f::Zero();    ///< Accelerometer bias [m/s²]
+    Eigen::Vector3f gyro_bias = Eigen::Vector3f::Zero();     ///< Gyroscope bias [rad/s]
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
@@ -88,13 +88,9 @@ struct State {
 /// @param[out] b_imu  15×1  gradient vector     (= H_imu · r).
 /// @return true on success; false if P_pred is ill-conditioned (H_imu and
 ///         b_imu are set to zero in that case).
-inline bool compute_imu_hessian_gradient(
-    const State&                          x_pred,
-    const State&                          x_op,
-    const Eigen::Matrix<float, 15, 15>&   P_pred,
-    Eigen::Matrix<float, 15, 15>&         H_imu,
-    Eigen::Matrix<float, 15, 1>&          b_imu)
-{
+inline bool compute_imu_hessian_gradient(const State& x_pred, const State& x_op,
+                                         const Eigen::Matrix<float, 15, 15>& P_pred,
+                                         Eigen::Matrix<float, 15, 15>& H_imu, Eigen::Matrix<float, 15, 1>& b_imu) {
     // ------------------------------------------------------------------
     // 1. Information matrix  H_imu = P_pred⁻¹
     //

--- a/cpp/include/sycl_points/imu/imu_preintegration.hpp
+++ b/cpp/include/sycl_points/imu/imu_preintegration.hpp
@@ -86,9 +86,9 @@ struct IMUPreintegrationParams {
     ///   gyro_bias_rw_density  ≈ 1e-5  rad/s²/√Hz
     ///   accel_bias_rw_density ≈ 1e-4  m/s³/√Hz
     /// @{
-    float gyro_noise_density    = 0.0f;  ///< Gyroscope white noise density [rad/s/√Hz]
-    float accel_noise_density   = 0.0f;  ///< Accelerometer white noise density [m/s²/√Hz]
-    float gyro_bias_rw_density  = 0.0f;  ///< Gyroscope bias random-walk density [rad/s²/√Hz]
+    float gyro_noise_density = 0.0f;     ///< Gyroscope white noise density [rad/s/√Hz]
+    float accel_noise_density = 0.0f;    ///< Accelerometer white noise density [m/s²/√Hz]
+    float gyro_bias_rw_density = 0.0f;   ///< Gyroscope bias random-walk density [rad/s²/√Hz]
     float accel_bias_rw_density = 0.0f;  ///< Accelerometer bias random-walk density [m/s³/√Hz]
     /// @}
 
@@ -348,7 +348,7 @@ private:
             F.block<3, 3>(0, 9) = -0.5f * Delta_R_mid * dt_f * dt_f;
 
             // δφ row  (Jr applies only to the bias term)
-            F.block<3, 3>(3, 3)  = R_step.transpose();
+            F.block<3, 3>(3, 3) = R_step.transpose();
             F.block<3, 3>(3, 12) = -Jr * dt_f;
 
             // δv row  (Jr is NOT used here)
@@ -362,8 +362,8 @@ private:
             Eigen::Matrix<float, 15, 15> Q = Eigen::Matrix<float, 15, 15>::Zero();
 
             if (has_noise) {
-                const float sa2  = params_.accel_noise_density * params_.accel_noise_density;
-                const float sg2  = params_.gyro_noise_density * params_.gyro_noise_density;
+                const float sa2 = params_.accel_noise_density * params_.accel_noise_density;
+                const float sg2 = params_.gyro_noise_density * params_.gyro_noise_density;
                 const float sba2 = params_.accel_bias_rw_density * params_.accel_bias_rw_density;
                 const float sbg2 = params_.gyro_bias_rw_density * params_.gyro_bias_rw_density;
 
@@ -381,7 +381,7 @@ private:
                 Q.block<3, 3>(3, 3) += (sg2 * dt_f) * (Jr * Jr.transpose());
 
                 // Bias random-walk contributions (Q_nba = sba2·dt·I, Q_nbg = sbg2·dt·I):
-                Q.block<3, 3>(9,  9 ) += (sba2 * dt_f) * Eigen::Matrix3f::Identity();
+                Q.block<3, 3>(9, 9) += (sba2 * dt_f) * Eigen::Matrix3f::Identity();
                 Q.block<3, 3>(12, 12) += (sbg2 * dt_f) * Eigen::Matrix3f::Identity();
             }
 

--- a/cpp/include/sycl_points/imu/imu_preintegration.hpp
+++ b/cpp/include/sycl_points/imu/imu_preintegration.hpp
@@ -332,10 +332,13 @@ private:
         //     G[δba, nba] = I,  Q_nba = σ_ba²·dt · I
         //     G[δbg, nbg] = I,  Q_nbg = σ_bg²·dt · I
         //
-        // Skip if all noise parameters are zero (keeps covariance at its initial value).
-        if (params_.gyro_noise_density > 0.0f || params_.accel_noise_density > 0.0f ||
-            params_.gyro_bias_rw_density > 0.0f || params_.accel_bias_rw_density > 0.0f) {
-
+        // F is always applied so that existing uncertainty (e.g. velocity error from
+        // initial_covariance) propagates through state dynamics even when all noise
+        // parameters are zero.  Q is only non-zero when noise parameters are set.
+        // Skip the entire block only when both covariance and Q are trivially zero.
+        const bool has_noise = (params_.gyro_noise_density > 0.0f || params_.accel_noise_density > 0.0f ||
+                                params_.gyro_bias_rw_density > 0.0f || params_.accel_bias_rw_density > 0.0f);
+        if (has_noise || !result_.covariance.isZero()) {
             // --- Build F (15×15) ---
             Eigen::Matrix<float, 15, 15> F = Eigen::Matrix<float, 15, 15>::Identity();
 
@@ -353,32 +356,34 @@ private:
             F.block<3, 3>(6, 9) = -Delta_R_mid * dt_f;
 
             // --- Build process noise Q = G·Q_d·G^T (sparse, closed-form) ---
-            const float sa2  = params_.accel_noise_density * params_.accel_noise_density;
-            const float sg2  = params_.gyro_noise_density * params_.gyro_noise_density;
-            const float sba2 = params_.accel_bias_rw_density * params_.accel_bias_rw_density;
-            const float sbg2 = params_.gyro_bias_rw_density * params_.gyro_bias_rw_density;
-
             const float dt2 = dt_f * dt_f;
             const float dt3 = dt2 * dt_f;
 
             Eigen::Matrix<float, 15, 15> Q = Eigen::Matrix<float, 15, 15>::Zero();
 
-            // Accel noise contributions (Q_na = sa2/dt·I):
-            //   [δp,δp]: G[δp,na]·Q_na·G[δp,na]^T = 0.5·dt²·(sa2/dt)·0.5·dt²·I = sa2·dt³/4·I
-            //   [δp,δv]: G[δp,na]·Q_na·G[δv,na]^T = 0.5·dt²·(sa2/dt)·dt·I      = sa2·dt²/2·I
-            //   [δv,δv]: G[δv,na]·Q_na·G[δv,na]^T = dt·(sa2/dt)·dt·I            = sa2·dt·I
-            Q.block<3, 3>(0, 0) += (sa2 * dt3 / 4.0f) * Eigen::Matrix3f::Identity();
-            Q.block<3, 3>(0, 6) += (sa2 * dt2 / 2.0f) * Eigen::Matrix3f::Identity();
-            Q.block<3, 3>(6, 0) += (sa2 * dt2 / 2.0f) * Eigen::Matrix3f::Identity();
-            Q.block<3, 3>(6, 6) += (sa2 * dt_f) * Eigen::Matrix3f::Identity();
+            if (has_noise) {
+                const float sa2  = params_.accel_noise_density * params_.accel_noise_density;
+                const float sg2  = params_.gyro_noise_density * params_.gyro_noise_density;
+                const float sba2 = params_.accel_bias_rw_density * params_.accel_bias_rw_density;
+                const float sbg2 = params_.gyro_bias_rw_density * params_.gyro_bias_rw_density;
 
-            // Gyro noise contribution (Q_ng = sg2/dt·I):
-            //   [δφ,δφ]: Jr·dt·(sg2/dt)·dt·Jr^T = sg2·dt·Jr·Jr^T
-            Q.block<3, 3>(3, 3) += (sg2 * dt_f) * (Jr * Jr.transpose());
+                // Accel noise contributions (Q_na = sa2/dt·I):
+                //   [δp,δp]: G[δp,na]·Q_na·G[δp,na]^T = 0.5·dt²·(sa2/dt)·0.5·dt²·I = sa2·dt³/4·I
+                //   [δp,δv]: G[δp,na]·Q_na·G[δv,na]^T = 0.5·dt²·(sa2/dt)·dt·I      = sa2·dt²/2·I
+                //   [δv,δv]: G[δv,na]·Q_na·G[δv,na]^T = dt·(sa2/dt)·dt·I            = sa2·dt·I
+                Q.block<3, 3>(0, 0) += (sa2 * dt3 / 4.0f) * Eigen::Matrix3f::Identity();
+                Q.block<3, 3>(0, 6) += (sa2 * dt2 / 2.0f) * Eigen::Matrix3f::Identity();
+                Q.block<3, 3>(6, 0) += (sa2 * dt2 / 2.0f) * Eigen::Matrix3f::Identity();
+                Q.block<3, 3>(6, 6) += (sa2 * dt_f) * Eigen::Matrix3f::Identity();
 
-            // Bias random-walk contributions (Q_nba = sba2·dt·I, Q_nbg = sbg2·dt·I):
-            Q.block<3, 3>(9,  9 ) += (sba2 * dt_f) * Eigen::Matrix3f::Identity();
-            Q.block<3, 3>(12, 12) += (sbg2 * dt_f) * Eigen::Matrix3f::Identity();
+                // Gyro noise contribution (Q_ng = sg2/dt·I):
+                //   [δφ,δφ]: Jr·dt·(sg2/dt)·dt·Jr^T = sg2·dt·Jr·Jr^T
+                Q.block<3, 3>(3, 3) += (sg2 * dt_f) * (Jr * Jr.transpose());
+
+                // Bias random-walk contributions (Q_nba = sba2·dt·I, Q_nbg = sbg2·dt·I):
+                Q.block<3, 3>(9,  9 ) += (sba2 * dt_f) * Eigen::Matrix3f::Identity();
+                Q.block<3, 3>(12, 12) += (sbg2 * dt_f) * Eigen::Matrix3f::Identity();
+            }
 
             // Propagate: Σ_{k+1} = F·Σ_k·F^T + Q
             // Enforce symmetry explicitly to prevent numerical drift in single precision.

--- a/cpp/include/sycl_points/imu/imu_preintegration.hpp
+++ b/cpp/include/sycl_points/imu/imu_preintegration.hpp
@@ -313,11 +313,15 @@ private:
         // Error-state ordering: [δp(0:3), δφ(3:6), δv(6:9), δba(9:12), δbg(12:15)]
         //
         // Discrete state-transition matrix F (15×15):
-        //   δp_{k+1} = δp_k + δv_k·dt  − 0.5·ΔRm·[am×]·Jr·dt²·δφ_k − 0.5·ΔRm·dt²·δba
+        //   δp_{k+1} = δp_k + δv_k·dt  − 0.5·ΔRm·[am×]·dt²·δφ_k − 0.5·ΔRm·dt²·δba
         //   δφ_{k+1} = R_step^T·δφ_k   − Jr·dt·δbg
-        //   δv_{k+1} = δv_k             − ΔRm·[am×]·Jr·dt·δφ_k − ΔRm·dt·δba
+        //   δv_{k+1} = δv_k             − ΔRm·[am×]·dt·δφ_k − ΔRm·dt·δba
         //   δba_{k+1}= δba_k
         //   δbg_{k+1}= δbg_k
+        //
+        // Note: Jr only appears in F[δφ, δbg].  The rotation-error effect on position
+        // and velocity (F[δp,δφ] and F[δv,δφ]) arises from the rotation of the
+        // accelerometer measurement, which does not involve the exponential-map Jacobian.
         //
         // Process noise Q = G·Q_d·G^T (computed analytically, sparse):
         //   Accel white noise (σ_a, PSD σ_a²):
@@ -335,19 +339,17 @@ private:
             // --- Build F (15×15) ---
             Eigen::Matrix<float, 15, 15> F = Eigen::Matrix<float, 15, 15>::Identity();
 
-            const Eigen::Matrix3f skew_a_Jr = skew_a * Jr;
-
-            // δp row
-            F.block<3, 3>(0, 3) = -0.5f * Delta_R_mid * skew_a_Jr * dt_f * dt_f;
+            // δp row  (Jr is NOT used here; only needed for the bias→rotation block)
+            F.block<3, 3>(0, 3) = -0.5f * Delta_R_mid * skew_a * dt_f * dt_f;
             F.block<3, 3>(0, 6) = Eigen::Matrix3f::Identity() * dt_f;
             F.block<3, 3>(0, 9) = -0.5f * Delta_R_mid * dt_f * dt_f;
 
-            // δφ row
+            // δφ row  (Jr applies only to the bias term)
             F.block<3, 3>(3, 3)  = R_step.transpose();
             F.block<3, 3>(3, 12) = -Jr * dt_f;
 
-            // δv row
-            F.block<3, 3>(6, 3) = -Delta_R_mid * skew_a_Jr * dt_f;
+            // δv row  (Jr is NOT used here)
+            F.block<3, 3>(6, 3) = -Delta_R_mid * skew_a * dt_f;
             F.block<3, 3>(6, 9) = -Delta_R_mid * dt_f;
 
             // --- Build process noise Q = G·Q_d·G^T (sparse, closed-form) ---
@@ -379,7 +381,8 @@ private:
             Q.block<3, 3>(12, 12) += (sbg2 * dt_f) * Eigen::Matrix3f::Identity();
 
             // Propagate: Σ_{k+1} = F·Σ_k·F^T + Q
-            result_.covariance = F * result_.covariance * F.transpose() + Q;
+            // Enforce symmetry explicitly to prevent numerical drift in single precision.
+            result_.covariance = eigen_utils::ensure_symmetric<15>(F * result_.covariance * F.transpose() + Q);
         }
 
         // --- Periodically renormalize Delta_R to stay on SO(3) ---

--- a/cpp/include/sycl_points/imu/imu_preintegration.hpp
+++ b/cpp/include/sycl_points/imu/imu_preintegration.hpp
@@ -47,6 +47,24 @@ struct PreintegrationResult {
     double dt_total = 0.0;                                  ///< Total integrated duration [s]
     PreintegrationJacobians J;
 
+    /// @brief 15×15 covariance matrix of the navigation state.
+    ///
+    /// Propagated from the initial_covariance supplied to reset() by the
+    /// discrete error-state dynamics:
+    ///
+    ///   Σ_{k+1} = F_k · Σ_k · F_k^T  +  G_k · Q_d · G_k^T
+    ///
+    /// State-vector ordering (matches imu::State in imu_factor.hpp):
+    ///   indices  0– 2  position           (world frame)
+    ///   indices  3– 5  rotation           (so(3) tangent, right-perturbation)
+    ///   indices  6– 8  velocity           (world frame)
+    ///   indices  9–11  accelerometer bias (body frame)
+    ///   indices 12–14  gyroscope bias     (body frame)
+    ///
+    /// Pass directly as P_pred to compute_imu_hessian_gradient().
+    /// Remains zero if all IMUPreintegrationParams noise densities are zero.
+    Eigen::Matrix<float, 15, 15> covariance = Eigen::Matrix<float, 15, 15>::Zero();
+
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
@@ -54,6 +72,25 @@ struct PreintegrationResult {
 struct IMUPreintegrationParams {
     /// Gravity vector in the world frame [m/s^2]. Default: z-down.
     Eigen::Vector3f gravity = Eigen::Vector3f(0.0f, 0.0f, -9.81f);
+
+    /// @name IMU noise parameters for 15×15 covariance propagation.
+    ///
+    /// Set non-zero values to enable covariance propagation.  The noise model
+    /// follows the standard IMU calibration convention (e.g. Kalibr):
+    ///   - Measurement noise  PSD: σ²  → discrete variance = σ² / dt per step.
+    ///   - Bias random-walk   PSD: σ²  → discrete variance = σ² * dt per step.
+    ///
+    /// Typical MEMS IMU values (order-of-magnitude):
+    ///   gyro_noise_density    ≈ 1e-3  rad/s/√Hz
+    ///   accel_noise_density   ≈ 1e-2  m/s²/√Hz
+    ///   gyro_bias_rw_density  ≈ 1e-5  rad/s²/√Hz
+    ///   accel_bias_rw_density ≈ 1e-4  m/s³/√Hz
+    /// @{
+    float gyro_noise_density    = 0.0f;  ///< Gyroscope white noise density [rad/s/√Hz]
+    float accel_noise_density   = 0.0f;  ///< Accelerometer white noise density [m/s²/√Hz]
+    float gyro_bias_rw_density  = 0.0f;  ///< Gyroscope bias random-walk density [rad/s²/√Hz]
+    float accel_bias_rw_density = 0.0f;  ///< Accelerometer bias random-walk density [m/s³/√Hz]
+    /// @}
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
@@ -77,12 +114,20 @@ public:
     explicit IMUPreintegration(const IMUPreintegrationParams& params = IMUPreintegrationParams()) : params_(params) {}
 
     /// @brief Reset the integrator (call at every new LiDAR keyframe).
-    /// @param bias           Current bias estimate used as the linearization point.
-    /// @param R_world_body_i Rotation from body to world frame at the window start.
-    ///                       Required to compensate gravity in predict_relative_transform().
-    void reset(const IMUBias& bias = IMUBias(), const Eigen::Matrix3f& R_world_body_i = Eigen::Matrix3f::Identity()) {
+    /// @param bias               Current bias estimate used as the linearization point.
+    /// @param R_world_body_i     Rotation from body to world frame at the window start.
+    ///                           Required to compensate gravity in predict_relative_transform().
+    /// @param initial_covariance 15×15 state covariance at the window start.
+    ///                           Typically the posterior covariance P from the previous
+    ///                           keyframe optimisation.  Propagated forward together with
+    ///                           the IMU process noise; pass as P_pred to
+    ///                           compute_imu_hessian_gradient().
+    ///                           Defaults to zero (uncertainty from IMU noise only).
+    void reset(const IMUBias& bias = IMUBias(), const Eigen::Matrix3f& R_world_body_i = Eigen::Matrix3f::Identity(),
+               const Eigen::Matrix<float, 15, 15>& initial_covariance = Eigen::Matrix<float, 15, 15>::Zero()) {
         bias_lin_ = bias;
         result_ = PreintegrationResult{};
+        result_.covariance = initial_covariance;
         has_prev_ = false;
         num_measurements_ = 0;
         step_count_ = 0;
@@ -262,6 +307,80 @@ private:
         result_.J.J_p_bg =
             result_.J.J_p_bg + J_v_bg_old * dt_f - 0.5f * Delta_R_mid * skew_a * J_R_bg_old * dt_f * dt_f;
         result_.J.J_p_ba = result_.J.J_p_ba + J_v_ba_old * dt_f - 0.5f * Delta_R_mid * dt_f * dt_f;
+
+        // --- 15×15 covariance propagation ---
+        //
+        // Error-state ordering: [δp(0:3), δφ(3:6), δv(6:9), δba(9:12), δbg(12:15)]
+        //
+        // Discrete state-transition matrix F (15×15):
+        //   δp_{k+1} = δp_k + δv_k·dt  − 0.5·ΔRm·[am×]·Jr·dt²·δφ_k − 0.5·ΔRm·dt²·δba
+        //   δφ_{k+1} = R_step^T·δφ_k   − Jr·dt·δbg
+        //   δv_{k+1} = δv_k             − ΔRm·[am×]·Jr·dt·δφ_k − ΔRm·dt·δba
+        //   δba_{k+1}= δba_k
+        //   δbg_{k+1}= δbg_k
+        //
+        // Process noise Q = G·Q_d·G^T (computed analytically, sparse):
+        //   Accel white noise (σ_a, PSD σ_a²):
+        //     G[δp, na] = 0.5·ΔRm·dt²,  G[δv, na] = ΔRm·dt,  Q_na = σ_a²/dt · I
+        //   Gyro white noise (σ_g, PSD σ_g²):
+        //     G[δφ, ng] = Jr·dt,                              Q_ng = σ_g²/dt · I
+        //   Bias random-walk noise:
+        //     G[δba, nba] = I,  Q_nba = σ_ba²·dt · I
+        //     G[δbg, nbg] = I,  Q_nbg = σ_bg²·dt · I
+        //
+        // Skip if all noise parameters are zero (keeps covariance at its initial value).
+        if (params_.gyro_noise_density > 0.0f || params_.accel_noise_density > 0.0f ||
+            params_.gyro_bias_rw_density > 0.0f || params_.accel_bias_rw_density > 0.0f) {
+
+            // --- Build F (15×15) ---
+            Eigen::Matrix<float, 15, 15> F = Eigen::Matrix<float, 15, 15>::Identity();
+
+            const Eigen::Matrix3f skew_a_Jr = skew_a * Jr;
+
+            // δp row
+            F.block<3, 3>(0, 3) = -0.5f * Delta_R_mid * skew_a_Jr * dt_f * dt_f;
+            F.block<3, 3>(0, 6) = Eigen::Matrix3f::Identity() * dt_f;
+            F.block<3, 3>(0, 9) = -0.5f * Delta_R_mid * dt_f * dt_f;
+
+            // δφ row
+            F.block<3, 3>(3, 3)  = R_step.transpose();
+            F.block<3, 3>(3, 12) = -Jr * dt_f;
+
+            // δv row
+            F.block<3, 3>(6, 3) = -Delta_R_mid * skew_a_Jr * dt_f;
+            F.block<3, 3>(6, 9) = -Delta_R_mid * dt_f;
+
+            // --- Build process noise Q = G·Q_d·G^T (sparse, closed-form) ---
+            const float sa2  = params_.accel_noise_density * params_.accel_noise_density;
+            const float sg2  = params_.gyro_noise_density * params_.gyro_noise_density;
+            const float sba2 = params_.accel_bias_rw_density * params_.accel_bias_rw_density;
+            const float sbg2 = params_.gyro_bias_rw_density * params_.gyro_bias_rw_density;
+
+            const float dt2 = dt_f * dt_f;
+            const float dt3 = dt2 * dt_f;
+
+            Eigen::Matrix<float, 15, 15> Q = Eigen::Matrix<float, 15, 15>::Zero();
+
+            // Accel noise contributions (Q_na = sa2/dt·I):
+            //   [δp,δp]: G[δp,na]·Q_na·G[δp,na]^T = 0.5·dt²·(sa2/dt)·0.5·dt²·I = sa2·dt³/4·I
+            //   [δp,δv]: G[δp,na]·Q_na·G[δv,na]^T = 0.5·dt²·(sa2/dt)·dt·I      = sa2·dt²/2·I
+            //   [δv,δv]: G[δv,na]·Q_na·G[δv,na]^T = dt·(sa2/dt)·dt·I            = sa2·dt·I
+            Q.block<3, 3>(0, 0) += (sa2 * dt3 / 4.0f) * Eigen::Matrix3f::Identity();
+            Q.block<3, 3>(0, 6) += (sa2 * dt2 / 2.0f) * Eigen::Matrix3f::Identity();
+            Q.block<3, 3>(6, 0) += (sa2 * dt2 / 2.0f) * Eigen::Matrix3f::Identity();
+            Q.block<3, 3>(6, 6) += (sa2 * dt_f) * Eigen::Matrix3f::Identity();
+
+            // Gyro noise contribution (Q_ng = sg2/dt·I):
+            //   [δφ,δφ]: Jr·dt·(sg2/dt)·dt·Jr^T = sg2·dt·Jr·Jr^T
+            Q.block<3, 3>(3, 3) += (sg2 * dt_f) * (Jr * Jr.transpose());
+
+            // Bias random-walk contributions (Q_nba = sba2·dt·I, Q_nbg = sbg2·dt·I):
+            Q.block<3, 3>(9,  9 ) += (sba2 * dt_f) * Eigen::Matrix3f::Identity();
+            Q.block<3, 3>(12, 12) += (sbg2 * dt_f) * Eigen::Matrix3f::Identity();
+
+            // Propagate: Σ_{k+1} = F·Σ_k·F^T + Q
+            result_.covariance = F * result_.covariance * F.transpose() + Q;
+        }
 
         // --- Periodically renormalize Delta_R to stay on SO(3) ---
         ++step_count_;

--- a/cpp/tests/test_imu_factor.cpp
+++ b/cpp/tests/test_imu_factor.cpp
@@ -1,8 +1,7 @@
 #include <gtest/gtest.h>
 
-#include <cmath>
-
 #include <Eigen/Dense>
+#include <cmath>
 
 #include "sycl_points/imu/imu_factor.hpp"
 #include "sycl_points/utils/eigen_utils.hpp"
@@ -11,7 +10,7 @@ namespace imu = sycl_points::imu;
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
-static constexpr float kEps      = 1e-5f;  // general tolerance
+static constexpr float kEps = 1e-5f;       // general tolerance
 static constexpr float kEpsTight = 1e-6f;  // tight tolerance for algebraic checks
 
 /// Build a diagonal 15×15 covariance matrix from a scalar (σ² for all).
@@ -24,9 +23,7 @@ static Eigen::Matrix3f rot_z(float angle_rad) {
     const float c = std::cos(angle_rad);
     const float s = std::sin(angle_rad);
     Eigen::Matrix3f R;
-    R << c, -s, 0,
-         s,  c, 0,
-         0,  0, 1;
+    R << c, -s, 0, s, c, 0, 0, 0, 1;
     return R;
 }
 
@@ -40,13 +37,12 @@ TEST(ImuFactor, HessianIsInverseOfCovariance) {
     imu::State x_pred, x_op;  // identical states → residual = 0
 
     Eigen::Matrix<float, 15, 15> H;
-    Eigen::Matrix<float, 15, 1>  b;
+    Eigen::Matrix<float, 15, 1> b;
     EXPECT_TRUE(imu::compute_imu_hessian_gradient(x_pred, x_op, P_pred, H, b));
 
     // H · P_pred should equal the identity matrix
     const Eigen::Matrix<float, 15, 15> product = H * P_pred;
-    EXPECT_TRUE(product.isApprox(Eigen::Matrix<float, 15, 15>::Identity(), kEpsTight))
-        << "H * P_pred =\n" << product;
+    EXPECT_TRUE(product.isApprox(Eigen::Matrix<float, 15, 15>::Identity(), kEpsTight)) << "H * P_pred =\n" << product;
 }
 
 // 2. When x_op == x_pred (zero error) the gradient b_imu must be zero.
@@ -54,7 +50,7 @@ TEST(ImuFactor, ZeroResidualGivesZeroGradient) {
     imu::State x_pred, x_op;
 
     Eigen::Matrix<float, 15, 15> H;
-    Eigen::Matrix<float, 15, 1>  b;
+    Eigen::Matrix<float, 15, 1> b;
     EXPECT_TRUE(imu::compute_imu_hessian_gradient(x_pred, x_op, diag_cov(0.01f), H, b));
 
     EXPECT_TRUE(b.isZero(kEpsTight)) << "b =\n" << b.transpose();
@@ -69,7 +65,7 @@ TEST(ImuFactor, PositionResidualOnlyAffectsPositionBlock) {
     const auto P = diag_cov(sigma_sq);
 
     Eigen::Matrix<float, 15, 15> H;
-    Eigen::Matrix<float, 15, 1>  b;
+    Eigen::Matrix<float, 15, 1> b;
     EXPECT_TRUE(imu::compute_imu_hessian_gradient(x_pred, x_op, P, H, b));
 
     // For a diagonal covariance H = (1/σ²) I, so b[0:3] = (1/σ²) * Δp
@@ -92,13 +88,13 @@ TEST(ImuFactor, VelocityResidualOnly) {
     const auto P = diag_cov(sigma_sq);
 
     Eigen::Matrix<float, 15, 15> H;
-    Eigen::Matrix<float, 15, 1>  b;
+    Eigen::Matrix<float, 15, 1> b;
     EXPECT_TRUE(imu::compute_imu_hessian_gradient(x_pred, x_op, P, H, b));
 
     // H = I for σ²=1, so b[6:9] = Δv
-    EXPECT_NEAR(b(6),  0.5f, kEps);
+    EXPECT_NEAR(b(6), 0.5f, kEps);
     EXPECT_NEAR(b(7), -1.0f, kEps);
-    EXPECT_NEAR(b(8),  0.0f, kEps);
+    EXPECT_NEAR(b(8), 0.0f, kEps);
 
     // All other blocks must be zero
     EXPECT_TRUE(b.segment<6>(0).isZero(kEpsTight));
@@ -109,18 +105,18 @@ TEST(ImuFactor, VelocityResidualOnly) {
 TEST(ImuFactor, BiasResiduals) {
     imu::State x_pred, x_op;
     x_op.accel_bias = Eigen::Vector3f(0.1f, 0.2f, 0.3f);
-    x_op.gyro_bias  = Eigen::Vector3f(0.4f, 0.5f, 0.6f);
+    x_op.gyro_bias = Eigen::Vector3f(0.4f, 0.5f, 0.6f);
 
     const float sigma_sq = 2.0f;
     const auto P = diag_cov(sigma_sq);
 
     Eigen::Matrix<float, 15, 15> H;
-    Eigen::Matrix<float, 15, 1>  b;
+    Eigen::Matrix<float, 15, 1> b;
     EXPECT_TRUE(imu::compute_imu_hessian_gradient(x_pred, x_op, P, H, b));
 
     const float inv_s2 = 1.0f / sigma_sq;
     // Accel bias block (indices 9-11)
-    EXPECT_NEAR(b(9),  inv_s2 * 0.1f, kEps);
+    EXPECT_NEAR(b(9), inv_s2 * 0.1f, kEps);
     EXPECT_NEAR(b(10), inv_s2 * 0.2f, kEps);
     EXPECT_NEAR(b(11), inv_s2 * 0.3f, kEps);
     // Gyro bias block (indices 12-14)
@@ -137,18 +133,18 @@ TEST(ImuFactor, RotationResidualSO3Log) {
     const float angle = static_cast<float>(M_PI) / 6.0f;  // 30 degrees
 
     x_pred.rotation = Eigen::Matrix3f::Identity();  // R_pred = I
-    x_op.rotation   = rot_z(angle);                 // R_op   = Rz(30°)
+    x_op.rotation = rot_z(angle);                   // R_op   = Rz(30°)
 
     // Expected: Log(I^T * Rz(30°)) = Log(Rz(30°)) = (0, 0, 30°)
     const auto P = diag_cov(1.0f);
 
     Eigen::Matrix<float, 15, 15> H;
-    Eigen::Matrix<float, 15, 1>  b;
+    Eigen::Matrix<float, 15, 1> b;
     EXPECT_TRUE(imu::compute_imu_hessian_gradient(x_pred, x_op, P, H, b));
 
     // H = I (σ²=1), so b[3:6] = rotation vector
-    EXPECT_NEAR(b(3), 0.0f,  kEps);
-    EXPECT_NEAR(b(4), 0.0f,  kEps);
+    EXPECT_NEAR(b(3), 0.0f, kEps);
+    EXPECT_NEAR(b(4), 0.0f, kEps);
     EXPECT_NEAR(b(5), angle, kEps);
 
     // Non-rotation blocks must be zero
@@ -166,7 +162,7 @@ TEST(ImuFactor, RotationResidualAntisymmetry) {
 
     const auto P = diag_cov(1.0f);
     Eigen::Matrix<float, 15, 15> H;
-    Eigen::Matrix<float, 15, 1>  b_ab, b_ba;
+    Eigen::Matrix<float, 15, 1> b_ab, b_ba;
 
     // r = Log(R_a^T R_b)
     EXPECT_TRUE(imu::compute_imu_hessian_gradient(x_a, x_b, P, H, b_ab));
@@ -175,15 +171,14 @@ TEST(ImuFactor, RotationResidualAntisymmetry) {
 
     // The two rotation residuals should be negatives of each other
     EXPECT_TRUE(b_ab.segment<3>(3).isApprox(-b_ba.segment<3>(3), kEps))
-        << "b_ab_rot = " << b_ab.segment<3>(3).transpose()
-        << "\nb_ba_rot = " << b_ba.segment<3>(3).transpose();
+        << "b_ab_rot = " << b_ab.segment<3>(3).transpose() << "\nb_ba_rot = " << b_ba.segment<3>(3).transpose();
 }
 
 // 8. H_imu is symmetric positive-definite (Cholesky succeeds, eigenvalues > 0).
 TEST(ImuFactor, HessianIsSymmetricPositiveDefinite) {
     imu::State x_pred, x_op;
-    x_op.position  = Eigen::Vector3f(1.0f, -0.5f, 0.2f);
-    x_op.velocity  = Eigen::Vector3f(0.3f, 0.1f, -0.4f);
+    x_op.position = Eigen::Vector3f(1.0f, -0.5f, 0.2f);
+    x_op.velocity = Eigen::Vector3f(0.3f, 0.1f, -0.4f);
     x_op.gyro_bias = Eigen::Vector3f(0.01f, -0.02f, 0.005f);
 
     // Non-diagonal P (a small perturbation to make it interesting)
@@ -192,7 +187,7 @@ TEST(ImuFactor, HessianIsSymmetricPositiveDefinite) {
     P(6, 7) = P(7, 6) = 0.003f;
 
     Eigen::Matrix<float, 15, 15> H;
-    Eigen::Matrix<float, 15, 1>  b;
+    Eigen::Matrix<float, 15, 1> b;
     EXPECT_TRUE(imu::compute_imu_hessian_gradient(x_pred, x_op, P, H, b));
 
     // Symmetry
@@ -206,32 +201,31 @@ TEST(ImuFactor, HessianIsSymmetricPositiveDefinite) {
 // 9. b_imu = H_imu * r  (definition check via manual residual).
 TEST(ImuFactor, GradientEqualsHTimesResidual) {
     imu::State x_pred, x_op;
-    x_op.position   = Eigen::Vector3f(0.3f, -0.1f, 0.5f);
-    x_op.rotation   = rot_z(0.2f);
-    x_op.velocity   = Eigen::Vector3f(-0.2f, 0.4f, 0.0f);
+    x_op.position = Eigen::Vector3f(0.3f, -0.1f, 0.5f);
+    x_op.rotation = rot_z(0.2f);
+    x_op.velocity = Eigen::Vector3f(-0.2f, 0.4f, 0.0f);
     x_op.accel_bias = Eigen::Vector3f(0.01f, -0.02f, 0.03f);
-    x_op.gyro_bias  = Eigen::Vector3f(0.005f, 0.003f, -0.001f);
+    x_op.gyro_bias = Eigen::Vector3f(0.005f, 0.003f, -0.001f);
 
     const auto P = diag_cov(0.05f);
 
     Eigen::Matrix<float, 15, 15> H;
-    Eigen::Matrix<float, 15, 1>  b;
+    Eigen::Matrix<float, 15, 1> b;
     EXPECT_TRUE(imu::compute_imu_hessian_gradient(x_pred, x_op, P, H, b));
 
     // Reconstruct the residual via the same eigen_utils path and verify b = H * r
     Eigen::Matrix<float, 15, 1> r;
-    r.segment<3>(imu::State::kIdxPos)     = x_op.position  - x_pred.position;
+    r.segment<3>(imu::State::kIdxPos) = x_op.position - x_pred.position;
     const Eigen::Matrix3f R_rel = x_pred.rotation.transpose() * x_op.rotation;
     const Eigen::Vector4f q_rel = sycl_points::eigen_utils::geometry::rotation_matrix_to_quaternion(R_rel);
-    r.segment<3>(imu::State::kIdxRot)     = sycl_points::eigen_utils::lie::so3_log(q_rel);
-    r.segment<3>(imu::State::kIdxVel)     = x_op.velocity   - x_pred.velocity;
+    r.segment<3>(imu::State::kIdxRot) = sycl_points::eigen_utils::lie::so3_log(q_rel);
+    r.segment<3>(imu::State::kIdxVel) = x_op.velocity - x_pred.velocity;
     r.segment<3>(imu::State::kIdxAccBias) = x_op.accel_bias - x_pred.accel_bias;
-    r.segment<3>(imu::State::kIdxGyrBias) = x_op.gyro_bias  - x_pred.gyro_bias;
+    r.segment<3>(imu::State::kIdxGyrBias) = x_op.gyro_bias - x_pred.gyro_bias;
 
     const Eigen::Matrix<float, 15, 1> b_expected = H * r;
     EXPECT_TRUE(b.isApprox(b_expected, kEpsTight))
-        << "b        = " << b.transpose()
-        << "\nb_expected = " << b_expected.transpose();
+        << "b        = " << b.transpose() << "\nb_expected = " << b_expected.transpose();
 }
 
 // 10. Near-zero rotation produces a near-zero rotation residual (no NaN/Inf).
@@ -242,7 +236,7 @@ TEST(ImuFactor, NearIdentityRotationIsNumericallyStable) {
     x_op.rotation = rot_z(tiny);
 
     Eigen::Matrix<float, 15, 15> H;
-    Eigen::Matrix<float, 15, 1>  b;
+    Eigen::Matrix<float, 15, 1> b;
     EXPECT_TRUE(imu::compute_imu_hessian_gradient(x_pred, x_op, diag_cov(1.0f), H, b));
 
     EXPECT_TRUE(b.allFinite()) << "b contains NaN or Inf";
@@ -251,9 +245,9 @@ TEST(ImuFactor, NearIdentityRotationIsNumericallyStable) {
 
 // 11. kIdx* constants match the expected state-vector layout.
 TEST(ImuFactor, StateIndexConstantsAreCorrect) {
-    EXPECT_EQ(imu::State::kIdxPos,     0);
-    EXPECT_EQ(imu::State::kIdxRot,     3);
-    EXPECT_EQ(imu::State::kIdxVel,     6);
+    EXPECT_EQ(imu::State::kIdxPos, 0);
+    EXPECT_EQ(imu::State::kIdxRot, 3);
+    EXPECT_EQ(imu::State::kIdxVel, 6);
     EXPECT_EQ(imu::State::kIdxAccBias, 9);
     EXPECT_EQ(imu::State::kIdxGyrBias, 12);
 }
@@ -267,7 +261,7 @@ TEST(ImuFactor, IllConditionedCovarianceReturnsZero) {
     const Eigen::Matrix<float, 15, 15> P_zero = Eigen::Matrix<float, 15, 15>::Zero();
 
     Eigen::Matrix<float, 15, 15> H;
-    Eigen::Matrix<float, 15, 1>  b;
+    Eigen::Matrix<float, 15, 1> b;
     EXPECT_FALSE(imu::compute_imu_hessian_gradient(x_pred, x_op, P_zero, H, b));
 
     EXPECT_TRUE(H.isZero()) << "H should be zero for ill-conditioned P";

--- a/cpp/tests/test_imu_preintegration.cpp
+++ b/cpp/tests/test_imu_preintegration.cpp
@@ -1,33 +1,30 @@
 #include <gtest/gtest.h>
 
-#include <cmath>
-
 #include <Eigen/Dense>
+#include <cmath>
 
 #include "sycl_points/imu/imu_preintegration.hpp"
 #include "sycl_points/utils/eigen_utils.hpp"
 
-namespace sp  = sycl_points;
+namespace sp = sycl_points;
 namespace imu = sycl_points::imu;
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
-static constexpr float kEps     = 1e-4f;   // loose tolerance for float integration
+static constexpr float kEps = 1e-4f;       // loose tolerance for float integration
 static constexpr float kEpsTight = 1e-5f;  // tight tolerance for algebraic checks
 
 /// Build a batch of IMU measurements with constant gyro/accel over [t0, t0+T].
-static std::vector<imu::IMUMeasurement, Eigen::aligned_allocator<imu::IMUMeasurement>>
-make_constant_imu(double t0, double T, int n_steps,
-                  const Eigen::Vector3f& gyro,
-                  const Eigen::Vector3f& accel) {
+static std::vector<imu::IMUMeasurement, Eigen::aligned_allocator<imu::IMUMeasurement>> make_constant_imu(
+    double t0, double T, int n_steps, const Eigen::Vector3f& gyro, const Eigen::Vector3f& accel) {
     std::vector<imu::IMUMeasurement, Eigen::aligned_allocator<imu::IMUMeasurement>> meas;
     meas.reserve(n_steps + 1);
     const double dt = T / n_steps;
     for (int i = 0; i <= n_steps; ++i) {
         imu::IMUMeasurement m;
         m.timestamp = t0 + i * dt;
-        m.gyro      = gyro;
-        m.accel     = accel;
+        m.gyro = gyro;
+        m.accel = accel;
         meas.push_back(m);
     }
     return meas;
@@ -38,9 +35,7 @@ static Eigen::Matrix3f rot_z(float angle_rad) {
     const float c = std::cos(angle_rad);
     const float s = std::sin(angle_rad);
     Eigen::Matrix3f R;
-    R << c, -s, 0,
-         s,  c, 0,
-         0,  0, 1;
+    R << c, -s, 0, s, c, 0, 0, 0, 1;
     return R;
 }
 
@@ -62,9 +57,7 @@ TEST(IMUPreintegration, InitialStateIsIdentity) {
 // 2. reset() clears state.
 TEST(IMUPreintegration, ResetClearsState) {
     imu::IMUPreintegration integ;
-    auto meas = make_constant_imu(0.0, 1.0, 100,
-                                  Eigen::Vector3f(0.1f, 0.0f, 0.0f),
-                                  Eigen::Vector3f(0.0f, 0.0f, 9.81f));
+    auto meas = make_constant_imu(0.0, 1.0, 100, Eigen::Vector3f(0.1f, 0.0f, 0.0f), Eigen::Vector3f(0.0f, 0.0f, 9.81f));
     integ.integrate_batch(meas);
     EXPECT_TRUE(integ.has_measurements());
 
@@ -83,7 +76,7 @@ TEST(IMUPreintegration, SingleMeasurementNoIntegration) {
     imu::IMUPreintegration integ;
     imu::IMUMeasurement m;
     m.timestamp = 1.0;
-    m.gyro  = Eigen::Vector3f(0.1f, 0.2f, 0.3f);
+    m.gyro = Eigen::Vector3f(0.1f, 0.2f, 0.3f);
     m.accel = Eigen::Vector3f(0.0f, 0.0f, 9.81f);
     integ.integrate(m);
 
@@ -97,9 +90,7 @@ TEST(IMUPreintegration, ZeroMotionIdentityResult) {
     imu::IMUPreintegration integ;
     // gravity-compensated accel = 0 because no real accelerometer in free fall, but
     // for zero motion test with zero accel and zero gyro bias:
-    auto meas = make_constant_imu(0.0, 1.0, 200,
-                                  Eigen::Vector3f::Zero(),
-                                  Eigen::Vector3f::Zero());
+    auto meas = make_constant_imu(0.0, 1.0, 200, Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero());
     integ.integrate_batch(meas);
 
     const auto& r = integ.get_raw();
@@ -113,13 +104,11 @@ TEST(IMUPreintegration, ZeroMotionIdentityResult) {
 //    Delta_R should be rot_z(ω_z * T).
 TEST(IMUPreintegration, ConstantRotationZ) {
     const float omega_z = static_cast<float>(M_PI / 4.0);  // 45 deg/s
-    const double T      = 2.0;                              // 2 seconds
-    const int n_steps   = 400;
+    const double T = 2.0;                                  // 2 seconds
+    const int n_steps = 400;
 
     imu::IMUPreintegration integ;
-    auto meas = make_constant_imu(0.0, T, n_steps,
-                                  Eigen::Vector3f(0.0f, 0.0f, omega_z),
-                                  Eigen::Vector3f::Zero());
+    auto meas = make_constant_imu(0.0, T, n_steps, Eigen::Vector3f(0.0f, 0.0f, omega_z), Eigen::Vector3f::Zero());
     integ.integrate_batch(meas);
 
     const Eigen::Matrix3f expected = rot_z(omega_z * static_cast<float>(T));
@@ -129,30 +118,27 @@ TEST(IMUPreintegration, ConstantRotationZ) {
 // 6. Constant linear acceleration along X (no rotation): after T seconds,
 //    Delta_p ≈ 0.5 * a * T².
 TEST(IMUPreintegration, ConstantAccelerationX) {
-    const float ax    = 2.0f;   // m/s^2
-    const double T    = 1.5;
+    const float ax = 2.0f;  // m/s^2
+    const double T = 1.5;
     const int n_steps = 300;
 
     imu::IMUPreintegration integ;
-    auto meas = make_constant_imu(0.0, T, n_steps,
-                                  Eigen::Vector3f::Zero(),
-                                  Eigen::Vector3f(ax, 0.0f, 0.0f));
+    auto meas = make_constant_imu(0.0, T, n_steps, Eigen::Vector3f::Zero(), Eigen::Vector3f(ax, 0.0f, 0.0f));
     integ.integrate_batch(meas);
 
     const float expected_px = 0.5f * ax * static_cast<float>(T * T);
     const auto& r = integ.get_raw();
 
     EXPECT_NEAR(r.Delta_p.x(), expected_px, kEps);
-    EXPECT_NEAR(r.Delta_p.y(), 0.0f,        kEps);
-    EXPECT_NEAR(r.Delta_p.z(), 0.0f,        kEps);
+    EXPECT_NEAR(r.Delta_p.y(), 0.0f, kEps);
+    EXPECT_NEAR(r.Delta_p.z(), 0.0f, kEps);
     EXPECT_NEAR(r.Delta_v.x(), ax * static_cast<float>(T), kEps);
 }
 
 // 7. Batch integration produces the same result as incremental integration.
 TEST(IMUPreintegration, BatchAndIncrementalAreEqual) {
-    const auto meas = make_constant_imu(0.0, 1.0, 100,
-                                        Eigen::Vector3f(0.05f, -0.03f, 0.08f),
-                                        Eigen::Vector3f(0.3f, -0.1f, 9.5f));
+    const auto meas =
+        make_constant_imu(0.0, 1.0, 100, Eigen::Vector3f(0.05f, -0.03f, 0.08f), Eigen::Vector3f(0.3f, -0.1f, 9.5f));
 
     imu::IMUPreintegration incremental;
     for (const auto& m : meas) incremental.integrate(m);
@@ -173,20 +159,20 @@ TEST(IMUPreintegration, BatchAndIncrementalAreEqual) {
 //    first-order get_corrected(b1) after integrating with b0,
 //    for small bias changes.
 TEST(IMUPreintegration, BiasCorrection_SmallChange) {
-    const Eigen::Vector3f gyro  = Eigen::Vector3f(0.1f, -0.05f, 0.08f);
-    const Eigen::Vector3f accel = Eigen::Vector3f(0.2f,  0.1f,  9.7f);
+    const Eigen::Vector3f gyro = Eigen::Vector3f(0.1f, -0.05f, 0.08f);
+    const Eigen::Vector3f accel = Eigen::Vector3f(0.2f, 0.1f, 9.7f);
     const int n_steps = 100;
-    const double T    = 0.5;
+    const double T = 0.5;
 
     // Linearization bias
     imu::IMUBias b0;
-    b0.gyro_bias  = Eigen::Vector3f(0.005f, -0.003f,  0.002f);
-    b0.accel_bias = Eigen::Vector3f(0.01f,   0.005f, -0.008f);
+    b0.gyro_bias = Eigen::Vector3f(0.005f, -0.003f, 0.002f);
+    b0.accel_bias = Eigen::Vector3f(0.01f, 0.005f, -0.008f);
 
     // Small bias perturbation
     imu::IMUBias b1;
-    b1.gyro_bias  = b0.gyro_bias  + Eigen::Vector3f(0.001f, -0.001f, 0.001f);
-    b1.accel_bias = b0.accel_bias + Eigen::Vector3f(0.002f,  0.001f, -0.001f);
+    b1.gyro_bias = b0.gyro_bias + Eigen::Vector3f(0.001f, -0.001f, 0.001f);
+    b1.accel_bias = b0.accel_bias + Eigen::Vector3f(0.002f, 0.001f, -0.001f);
 
     // Reference: integrate directly with b1
     imu::IMUPreintegration ref;
@@ -214,13 +200,11 @@ TEST(IMUPreintegration, BiasCorrection_SmallChange) {
 //    predict_relative_transform cancels that contribution, yielding identity.
 TEST(IMUPreintegration, PredictRelativeTransformZeroMotion) {
     imu::IMUPreintegration integ;
-    auto meas = make_constant_imu(0.0, 0.5, 50,
-                                  Eigen::Vector3f::Zero(),
+    auto meas = make_constant_imu(0.0, 0.5, 50, Eigen::Vector3f::Zero(),
                                   Eigen::Vector3f(0.0f, 0.0f, 9.81f));  // stationary: reacts against gravity
     integ.integrate_batch(meas);
 
-    const sp::TransformMatrix T_rel =
-        integ.predict_relative_transform(imu::IMUBias{});
+    const sp::TransformMatrix T_rel = integ.predict_relative_transform(imu::IMUBias{});
 
     EXPECT_TRUE(T_rel.isApprox(sp::TransformMatrix::Identity(), kEps));
 }
@@ -231,31 +215,28 @@ TEST(IMUPreintegration, PredictRelativeTransformZeroMotion) {
 TEST(IMUPreintegration, PredictTransform_FreeFall) {
     // Sensor reports a = 0 (gravity is cancelled by free fall)
     // but the world-frame gravity still acts.
-    const double T      = 1.0;
-    const int n_steps   = 200;
+    const double T = 1.0;
+    const int n_steps = 200;
 
     imu::IMUPreintegrationParams params;
     params.gravity = Eigen::Vector3f(0.0f, 0.0f, -9.81f);
 
     imu::IMUPreintegration integ(params);
     // In free fall, the sensor measures ~0 acceleration.
-    auto meas = make_constant_imu(0.0, T, n_steps,
-                                  Eigen::Vector3f::Zero(),
-                                  Eigen::Vector3f::Zero());
+    auto meas = make_constant_imu(0.0, T, n_steps, Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero());
     integ.integrate_batch(meas);
 
     // Initial pose: identity (at origin, no rotation)
     sp::TransformMatrix T_i = sp::TransformMatrix::Identity();
-    Eigen::Vector3f v_i     = Eigen::Vector3f::Zero();
+    Eigen::Vector3f v_i = Eigen::Vector3f::Zero();
 
-    const sp::TransformMatrix T_j =
-        integ.predict_transform(T_i, v_i, imu::IMUBias{});
+    const sp::TransformMatrix T_j = integ.predict_transform(T_i, v_i, imu::IMUBias{});
 
     // Expected: p_j = 0 + 0 + 0.5 * (-9.81) * 1^2 along z
     const float expected_pz = 0.5f * (-9.81f) * static_cast<float>(T * T);
 
-    EXPECT_NEAR(T_j(0, 3), 0.0f,        kEps);
-    EXPECT_NEAR(T_j(1, 3), 0.0f,        kEps);
+    EXPECT_NEAR(T_j(0, 3), 0.0f, kEps);
+    EXPECT_NEAR(T_j(1, 3), 0.0f, kEps);
     EXPECT_NEAR(T_j(2, 3), expected_pz, kEps);
 
     // Rotation should be identity (no angular velocity)
@@ -272,23 +253,19 @@ TEST(IMUPreintegration, PredictTransform_InitialVelocity) {
     params.gravity = Eigen::Vector3f(0.0f, 0.0f, -9.81f);
 
     imu::IMUPreintegration integ(params);
-    auto meas = make_constant_imu(0.0, T, n_steps,
-                                  Eigen::Vector3f::Zero(),
-                                  Eigen::Vector3f::Zero());
+    auto meas = make_constant_imu(0.0, T, n_steps, Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero());
     integ.integrate_batch(meas);
 
     sp::TransformMatrix T_i = sp::TransformMatrix::Identity();
-    T_i(0, 3) = 1.0f; T_i(1, 3) = 2.0f; T_i(2, 3) = 3.0f;  // non-zero start position
+    T_i(0, 3) = 1.0f;
+    T_i(1, 3) = 2.0f;
+    T_i(2, 3) = 3.0f;  // non-zero start position
     const Eigen::Vector3f v_i(1.0f, -0.5f, 0.0f);
 
-    const sp::TransformMatrix T_j =
-        integ.predict_transform(T_i, v_i, imu::IMUBias{});
+    const sp::TransformMatrix T_j = integ.predict_transform(T_i, v_i, imu::IMUBias{});
 
     const float t = static_cast<float>(T);
-    const Eigen::Vector3f p_j_expected(
-        1.0f + 1.0f * t,
-        2.0f + (-0.5f) * t,
-        3.0f + 0.5f * (-9.81f) * t * t);
+    const Eigen::Vector3f p_j_expected(1.0f + 1.0f * t, 2.0f + (-0.5f) * t, 3.0f + 0.5f * (-9.81f) * t * t);
 
     EXPECT_NEAR(T_j(0, 3), p_j_expected.x(), kEps);
     EXPECT_NEAR(T_j(1, 3), p_j_expected.y(), kEps);
@@ -299,9 +276,8 @@ TEST(IMUPreintegration, PredictTransform_InitialVelocity) {
 TEST(IMUPreintegration, DeltaRRemainsValidRotation) {
     const int n_steps = 500;
     imu::IMUPreintegration integ;
-    auto meas = make_constant_imu(0.0, 5.0, n_steps,
-                                  Eigen::Vector3f(0.3f, -0.2f, 0.5f),
-                                  Eigen::Vector3f(0.1f, 0.2f, 9.5f));
+    auto meas =
+        make_constant_imu(0.0, 5.0, n_steps, Eigen::Vector3f(0.3f, -0.2f, 0.5f), Eigen::Vector3f(0.1f, 0.2f, 9.5f));
     integ.integrate_batch(meas);
 
     const Eigen::Matrix3f R = integ.get_raw().Delta_R;
@@ -314,16 +290,14 @@ TEST(IMUPreintegration, DeltaRRemainsValidRotation) {
 TEST(IMUPreintegration, MidpointBetterThanEulerForRotation) {
     // Analytical reference with many steps (ground truth)
     const float omega_z = 1.5f;  // rad/s
-    const double T      = 2.0;
+    const double T = 2.0;
     const Eigen::Matrix3f R_true = rot_z(omega_z * static_cast<float>(T));
 
     // Coarse integration (few steps) to amplify integration error
     const int n_coarse = 20;
 
     imu::IMUPreintegration integ;
-    auto meas = make_constant_imu(0.0, T, n_coarse,
-                                  Eigen::Vector3f(0.0f, 0.0f, omega_z),
-                                  Eigen::Vector3f::Zero());
+    auto meas = make_constant_imu(0.0, T, n_coarse, Eigen::Vector3f(0.0f, 0.0f, omega_z), Eigen::Vector3f::Zero());
     integ.integrate_batch(meas);
 
     const Eigen::Matrix3f R_midpoint = integ.get_raw().Delta_R;
@@ -340,9 +314,7 @@ TEST(IMUPreintegration, MidpointBetterThanEulerForRotation) {
 // 14. Covariance remains zero when all noise params are zero (default).
 TEST(IMUPreintegration, CovarianceZeroWithNoNoise) {
     imu::IMUPreintegration integ;  // default params: all noise = 0
-    auto meas = make_constant_imu(0.0, 1.0, 100,
-                                  Eigen::Vector3f(0.1f, 0.0f, 0.0f),
-                                  Eigen::Vector3f(0.0f, 0.0f, 9.81f));
+    auto meas = make_constant_imu(0.0, 1.0, 100, Eigen::Vector3f(0.1f, 0.0f, 0.0f), Eigen::Vector3f(0.0f, 0.0f, 9.81f));
     integ.integrate_batch(meas);
 
     EXPECT_TRUE(integ.get_raw().covariance.isZero(kEpsTight));
@@ -351,39 +323,36 @@ TEST(IMUPreintegration, CovarianceZeroWithNoNoise) {
 // 15. Covariance grows (is non-zero) after integration when noise params are set.
 TEST(IMUPreintegration, CovarianceGrowsWithNoise) {
     imu::IMUPreintegrationParams params;
-    params.gyro_noise_density    = 1e-3f;
-    params.accel_noise_density   = 1e-2f;
-    params.gyro_bias_rw_density  = 1e-5f;
+    params.gyro_noise_density = 1e-3f;
+    params.accel_noise_density = 1e-2f;
+    params.gyro_bias_rw_density = 1e-5f;
     params.accel_bias_rw_density = 1e-4f;
 
     imu::IMUPreintegration integ(params);
-    auto meas = make_constant_imu(0.0, 1.0, 100,
-                                  Eigen::Vector3f::Zero(),
-                                  Eigen::Vector3f::Zero());
+    auto meas = make_constant_imu(0.0, 1.0, 100, Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero());
     integ.integrate_batch(meas);
 
     const auto& cov = integ.get_raw().covariance;
 
     // Diagonal entries for rotation, velocity, and position must be positive.
-    EXPECT_GT(cov(3, 3), 0.0f);   // rotation
-    EXPECT_GT(cov(6, 6), 0.0f);   // velocity
-    EXPECT_GT(cov(0, 0), 0.0f);   // position (grows due to velocity uncertainty)
-    EXPECT_GT(cov(9, 9), 0.0f);   // accel bias RW
-    EXPECT_GT(cov(12, 12), 0.0f); // gyro bias RW
+    EXPECT_GT(cov(3, 3), 0.0f);    // rotation
+    EXPECT_GT(cov(6, 6), 0.0f);    // velocity
+    EXPECT_GT(cov(0, 0), 0.0f);    // position (grows due to velocity uncertainty)
+    EXPECT_GT(cov(9, 9), 0.0f);    // accel bias RW
+    EXPECT_GT(cov(12, 12), 0.0f);  // gyro bias RW
 }
 
 // 16. Covariance is symmetric after integration.
 TEST(IMUPreintegration, CovarianceIsSymmetric) {
     imu::IMUPreintegrationParams params;
-    params.gyro_noise_density    = 1e-3f;
-    params.accel_noise_density   = 1e-2f;
-    params.gyro_bias_rw_density  = 1e-5f;
+    params.gyro_noise_density = 1e-3f;
+    params.accel_noise_density = 1e-2f;
+    params.gyro_bias_rw_density = 1e-5f;
     params.accel_bias_rw_density = 1e-4f;
 
     imu::IMUPreintegration integ(params);
-    auto meas = make_constant_imu(0.0, 1.0, 100,
-                                  Eigen::Vector3f(0.1f, -0.05f, 0.08f),
-                                  Eigen::Vector3f(0.2f, 0.1f, 9.7f));
+    auto meas =
+        make_constant_imu(0.0, 1.0, 100, Eigen::Vector3f(0.1f, -0.05f, 0.08f), Eigen::Vector3f(0.2f, 0.1f, 9.7f));
     integ.integrate_batch(meas);
 
     const auto& cov = integ.get_raw().covariance;
@@ -393,15 +362,14 @@ TEST(IMUPreintegration, CovarianceIsSymmetric) {
 // 17. Covariance is positive semi-definite (all eigenvalues >= 0).
 TEST(IMUPreintegration, CovarianceIsPositiveSemiDefinite) {
     imu::IMUPreintegrationParams params;
-    params.gyro_noise_density    = 1e-3f;
-    params.accel_noise_density   = 1e-2f;
-    params.gyro_bias_rw_density  = 1e-5f;
+    params.gyro_noise_density = 1e-3f;
+    params.accel_noise_density = 1e-2f;
+    params.gyro_bias_rw_density = 1e-5f;
     params.accel_bias_rw_density = 1e-4f;
 
     imu::IMUPreintegration integ(params);
-    auto meas = make_constant_imu(0.0, 1.0, 100,
-                                  Eigen::Vector3f(0.1f, -0.05f, 0.08f),
-                                  Eigen::Vector3f(0.2f, 0.1f, 9.7f));
+    auto meas =
+        make_constant_imu(0.0, 1.0, 100, Eigen::Vector3f(0.1f, -0.05f, 0.08f), Eigen::Vector3f(0.2f, 0.1f, 9.7f));
     integ.integrate_batch(meas);
 
     const auto& cov = integ.get_raw().covariance;
@@ -414,24 +382,22 @@ TEST(IMUPreintegration, CovarianceIsPositiveSemiDefinite) {
 //     results in covariance >= initial_covariance (in the PSD sense).
 TEST(IMUPreintegration, InitialCovariancePropagatedForward) {
     imu::IMUPreintegrationParams params;
-    params.gyro_noise_density    = 1e-3f;
-    params.accel_noise_density   = 1e-2f;
-    params.gyro_bias_rw_density  = 1e-5f;
+    params.gyro_noise_density = 1e-3f;
+    params.accel_noise_density = 1e-2f;
+    params.gyro_bias_rw_density = 1e-5f;
     params.accel_bias_rw_density = 1e-4f;
 
     // Start with a diagonal initial covariance (1 cm² on position, etc.)
     Eigen::Matrix<float, 15, 15> P0 = Eigen::Matrix<float, 15, 15>::Zero();
-    P0.block<3, 3>(0, 0)   = 1e-4f * Eigen::Matrix3f::Identity();  // position
-    P0.block<3, 3>(3, 3)   = 1e-6f * Eigen::Matrix3f::Identity();  // rotation
-    P0.block<3, 3>(6, 6)   = 1e-4f * Eigen::Matrix3f::Identity();  // velocity
-    P0.block<3, 3>(9, 9)   = 1e-8f * Eigen::Matrix3f::Identity();  // acc bias
+    P0.block<3, 3>(0, 0) = 1e-4f * Eigen::Matrix3f::Identity();    // position
+    P0.block<3, 3>(3, 3) = 1e-6f * Eigen::Matrix3f::Identity();    // rotation
+    P0.block<3, 3>(6, 6) = 1e-4f * Eigen::Matrix3f::Identity();    // velocity
+    P0.block<3, 3>(9, 9) = 1e-8f * Eigen::Matrix3f::Identity();    // acc bias
     P0.block<3, 3>(12, 12) = 1e-8f * Eigen::Matrix3f::Identity();  // gyr bias
 
     imu::IMUPreintegration integ(params);
     integ.reset(imu::IMUBias{}, Eigen::Matrix3f::Identity(), P0);
-    auto meas = make_constant_imu(0.0, 1.0, 100,
-                                  Eigen::Vector3f::Zero(),
-                                  Eigen::Vector3f::Zero());
+    auto meas = make_constant_imu(0.0, 1.0, 100, Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero());
     integ.integrate_batch(meas);
 
     const auto& cov = integ.get_raw().covariance;
@@ -475,9 +441,7 @@ TEST(IMUPreintegration, ZeroNoisePropagatesInitialCovariance) {
     imu::IMUPreintegration integ(params);
     integ.reset(imu::IMUBias{}, Eigen::Matrix3f::Identity(), P0);
 
-    auto meas = make_constant_imu(0.0, 1.0, 100,
-                                  Eigen::Vector3f::Zero(),
-                                  Eigen::Vector3f::Zero());
+    auto meas = make_constant_imu(0.0, 1.0, 100, Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero());
     integ.integrate_batch(meas);
 
     const auto& cov = integ.get_raw().covariance;
@@ -495,17 +459,15 @@ TEST(IMUPreintegration, ZeroNoisePropagatesInitialCovariance) {
 // 21. get_corrected with identical bias returns the same result as get_raw.
 TEST(IMUPreintegration, GetCorrectedSameBiasEqualsRaw) {
     imu::IMUBias bias;
-    bias.gyro_bias  = Eigen::Vector3f(0.01f, -0.02f, 0.005f);
-    bias.accel_bias = Eigen::Vector3f(0.05f,  0.02f, -0.01f);
+    bias.gyro_bias = Eigen::Vector3f(0.01f, -0.02f, 0.005f);
+    bias.accel_bias = Eigen::Vector3f(0.05f, 0.02f, -0.01f);
 
     imu::IMUPreintegration integ;
     integ.reset(bias);
-    auto meas = make_constant_imu(0.0, 1.0, 100,
-                                  Eigen::Vector3f(0.1f, 0.0f, 0.0f),
-                                  Eigen::Vector3f(0.0f, 0.0f, 9.81f));
+    auto meas = make_constant_imu(0.0, 1.0, 100, Eigen::Vector3f(0.1f, 0.0f, 0.0f), Eigen::Vector3f(0.0f, 0.0f, 9.81f));
     integ.integrate_batch(meas);
 
-    const auto& raw     = integ.get_raw();
+    const auto& raw = integ.get_raw();
     const auto corrected = integ.get_corrected(bias);  // same bias
 
     EXPECT_TRUE(corrected.Delta_R.isApprox(raw.Delta_R, kEpsTight));

--- a/cpp/tests/test_imu_preintegration.cpp
+++ b/cpp/tests/test_imu_preintegration.cpp
@@ -445,23 +445,16 @@ TEST(IMUPreintegration, InitialCovariancePropagatedForward) {
     EXPECT_GT(cov(0, 0), P0(0, 0));
 }
 
-// 19. Covariance with zero noise but non-zero initial_covariance: after zero-motion
-//     integration the propagated covariance should only change due to F (no Q added).
-//     For pure zero motion (no rotation, no accel), F ≈ I + off-diagonal vel→pos term,
-//     so the rotation and bias blocks should be unchanged (= P0).
-TEST(IMUPreintegration, ZeroNoisePreservesInitialCovarianceBiasBlocks) {
-    // Zero noise params → no Q added during integration.
+// 19. Zero noise + no integration step: covariance unchanged (no step fires).
+TEST(IMUPreintegration, ZeroNoiseNoStepPreservesCovariance) {
     imu::IMUPreintegrationParams params;  // all noise densities = 0
 
     Eigen::Matrix<float, 15, 15> P0 = Eigen::Matrix<float, 15, 15>::Identity() * 1e-4f;
-    P0.block<3, 3>(9,  9 ) = 1e-6f * Eigen::Matrix3f::Identity();
-    P0.block<3, 3>(12, 12) = 1e-6f * Eigen::Matrix3f::Identity();
 
     imu::IMUPreintegration integ(params);
     integ.reset(imu::IMUBias{}, Eigen::Matrix3f::Identity(), P0);
 
-    // Zero motion: no integration steps fired (only one measurement fed → no step).
-    // Covariance must still equal P0 exactly.
+    // Only one measurement → no integrate_step called → covariance must equal P0.
     imu::IMUMeasurement m0;
     m0.timestamp = 0.0;
     integ.integrate(m0);
@@ -469,7 +462,37 @@ TEST(IMUPreintegration, ZeroNoisePreservesInitialCovarianceBiasBlocks) {
     EXPECT_TRUE(integ.get_raw().covariance.isApprox(P0, kEpsTight));
 }
 
-// 20. get_corrected with identical bias returns the same result as get_raw.
+// 20. Zero noise + non-zero initial_covariance: F still propagates existing uncertainty.
+//     Even when all noise densities are zero, an initial velocity error must
+//     grow into a position error over time (F[δp,δv] = I·dt coupling).
+TEST(IMUPreintegration, ZeroNoisePropagatesInitialCovariance) {
+    imu::IMUPreintegrationParams params;  // all noise densities = 0
+
+    // Initial covariance: only velocity uncertainty is non-zero.
+    Eigen::Matrix<float, 15, 15> P0 = Eigen::Matrix<float, 15, 15>::Zero();
+    P0.block<3, 3>(6, 6) = 1e-4f * Eigen::Matrix3f::Identity();  // velocity only
+
+    imu::IMUPreintegration integ(params);
+    integ.reset(imu::IMUBias{}, Eigen::Matrix3f::Identity(), P0);
+
+    auto meas = make_constant_imu(0.0, 1.0, 100,
+                                  Eigen::Vector3f::Zero(),
+                                  Eigen::Vector3f::Zero());
+    integ.integrate_batch(meas);
+
+    const auto& cov = integ.get_raw().covariance;
+
+    // Velocity uncertainty must remain (no damping).
+    EXPECT_NEAR(cov(6, 6), P0(6, 6), 1e-6f);
+
+    // Position uncertainty must have grown from the velocity→position coupling
+    // via F[δp,δv] = I·dt (even with zero noise Q).
+    EXPECT_GT(cov(0, 0), 0.0f);
+    EXPECT_GT(cov(1, 1), 0.0f);
+    EXPECT_GT(cov(2, 2), 0.0f);
+}
+
+// 21. get_corrected with identical bias returns the same result as get_raw.
 TEST(IMUPreintegration, GetCorrectedSameBiasEqualsRaw) {
     imu::IMUBias bias;
     bias.gyro_bias  = Eigen::Vector3f(0.01f, -0.02f, 0.005f);

--- a/cpp/tests/test_imu_preintegration.cpp
+++ b/cpp/tests/test_imu_preintegration.cpp
@@ -335,7 +335,141 @@ TEST(IMUPreintegration, MidpointBetterThanEulerForRotation) {
     EXPECT_LT(err_midpoint, 0.01f);
 }
 
-// 14. get_corrected with identical bias returns the same result as get_raw.
+// ─── covariance tests ─────────────────────────────────────────────────────────
+
+// 14. Covariance remains zero when all noise params are zero (default).
+TEST(IMUPreintegration, CovarianceZeroWithNoNoise) {
+    imu::IMUPreintegration integ;  // default params: all noise = 0
+    auto meas = make_constant_imu(0.0, 1.0, 100,
+                                  Eigen::Vector3f(0.1f, 0.0f, 0.0f),
+                                  Eigen::Vector3f(0.0f, 0.0f, 9.81f));
+    integ.integrate_batch(meas);
+
+    EXPECT_TRUE(integ.get_raw().covariance.isZero(kEpsTight));
+}
+
+// 15. Covariance grows (is non-zero) after integration when noise params are set.
+TEST(IMUPreintegration, CovarianceGrowsWithNoise) {
+    imu::IMUPreintegrationParams params;
+    params.gyro_noise_density    = 1e-3f;
+    params.accel_noise_density   = 1e-2f;
+    params.gyro_bias_rw_density  = 1e-5f;
+    params.accel_bias_rw_density = 1e-4f;
+
+    imu::IMUPreintegration integ(params);
+    auto meas = make_constant_imu(0.0, 1.0, 100,
+                                  Eigen::Vector3f::Zero(),
+                                  Eigen::Vector3f::Zero());
+    integ.integrate_batch(meas);
+
+    const auto& cov = integ.get_raw().covariance;
+
+    // Diagonal entries for rotation, velocity, and position must be positive.
+    EXPECT_GT(cov(3, 3), 0.0f);   // rotation
+    EXPECT_GT(cov(6, 6), 0.0f);   // velocity
+    EXPECT_GT(cov(0, 0), 0.0f);   // position (grows due to velocity uncertainty)
+    EXPECT_GT(cov(9, 9), 0.0f);   // accel bias RW
+    EXPECT_GT(cov(12, 12), 0.0f); // gyro bias RW
+}
+
+// 16. Covariance is symmetric after integration.
+TEST(IMUPreintegration, CovarianceIsSymmetric) {
+    imu::IMUPreintegrationParams params;
+    params.gyro_noise_density    = 1e-3f;
+    params.accel_noise_density   = 1e-2f;
+    params.gyro_bias_rw_density  = 1e-5f;
+    params.accel_bias_rw_density = 1e-4f;
+
+    imu::IMUPreintegration integ(params);
+    auto meas = make_constant_imu(0.0, 1.0, 100,
+                                  Eigen::Vector3f(0.1f, -0.05f, 0.08f),
+                                  Eigen::Vector3f(0.2f, 0.1f, 9.7f));
+    integ.integrate_batch(meas);
+
+    const auto& cov = integ.get_raw().covariance;
+    EXPECT_TRUE(cov.isApprox(cov.transpose(), 1e-5f));
+}
+
+// 17. Covariance is positive semi-definite (all eigenvalues >= 0).
+TEST(IMUPreintegration, CovarianceIsPositiveSemiDefinite) {
+    imu::IMUPreintegrationParams params;
+    params.gyro_noise_density    = 1e-3f;
+    params.accel_noise_density   = 1e-2f;
+    params.gyro_bias_rw_density  = 1e-5f;
+    params.accel_bias_rw_density = 1e-4f;
+
+    imu::IMUPreintegration integ(params);
+    auto meas = make_constant_imu(0.0, 1.0, 100,
+                                  Eigen::Vector3f(0.1f, -0.05f, 0.08f),
+                                  Eigen::Vector3f(0.2f, 0.1f, 9.7f));
+    integ.integrate_batch(meas);
+
+    const auto& cov = integ.get_raw().covariance;
+    const Eigen::SelfAdjointEigenSolver<Eigen::Matrix<float, 15, 15>> eig(cov);
+    EXPECT_EQ(eig.info(), Eigen::Success);
+    EXPECT_GE(eig.eigenvalues().minCoeff(), -1e-6f);  // non-negative up to float noise
+}
+
+// 18. Initial covariance is propagated: reset() with non-zero initial_covariance
+//     results in covariance >= initial_covariance (in the PSD sense).
+TEST(IMUPreintegration, InitialCovariancePropagatedForward) {
+    imu::IMUPreintegrationParams params;
+    params.gyro_noise_density    = 1e-3f;
+    params.accel_noise_density   = 1e-2f;
+    params.gyro_bias_rw_density  = 1e-5f;
+    params.accel_bias_rw_density = 1e-4f;
+
+    // Start with a diagonal initial covariance (1 cm² on position, etc.)
+    Eigen::Matrix<float, 15, 15> P0 = Eigen::Matrix<float, 15, 15>::Zero();
+    P0.block<3, 3>(0, 0)   = 1e-4f * Eigen::Matrix3f::Identity();  // position
+    P0.block<3, 3>(3, 3)   = 1e-6f * Eigen::Matrix3f::Identity();  // rotation
+    P0.block<3, 3>(6, 6)   = 1e-4f * Eigen::Matrix3f::Identity();  // velocity
+    P0.block<3, 3>(9, 9)   = 1e-8f * Eigen::Matrix3f::Identity();  // acc bias
+    P0.block<3, 3>(12, 12) = 1e-8f * Eigen::Matrix3f::Identity();  // gyr bias
+
+    imu::IMUPreintegration integ(params);
+    integ.reset(imu::IMUBias{}, Eigen::Matrix3f::Identity(), P0);
+    auto meas = make_constant_imu(0.0, 1.0, 100,
+                                  Eigen::Vector3f::Zero(),
+                                  Eigen::Vector3f::Zero());
+    integ.integrate_batch(meas);
+
+    const auto& cov = integ.get_raw().covariance;
+
+    // Rotation diagonal must be >= P0 rotation (process noise added it).
+    EXPECT_GE(cov(3, 3), P0(3, 3));
+    EXPECT_GE(cov(6, 6), P0(6, 6));
+
+    // With zero IMU signal and non-trivial initial velocity uncertainty,
+    // position uncertainty must exceed the initial position uncertainty.
+    EXPECT_GT(cov(0, 0), P0(0, 0));
+}
+
+// 19. Covariance with zero noise but non-zero initial_covariance: after zero-motion
+//     integration the propagated covariance should only change due to F (no Q added).
+//     For pure zero motion (no rotation, no accel), F ≈ I + off-diagonal vel→pos term,
+//     so the rotation and bias blocks should be unchanged (= P0).
+TEST(IMUPreintegration, ZeroNoisePreservesInitialCovarianceBiasBlocks) {
+    // Zero noise params → no Q added during integration.
+    imu::IMUPreintegrationParams params;  // all noise densities = 0
+
+    Eigen::Matrix<float, 15, 15> P0 = Eigen::Matrix<float, 15, 15>::Identity() * 1e-4f;
+    P0.block<3, 3>(9,  9 ) = 1e-6f * Eigen::Matrix3f::Identity();
+    P0.block<3, 3>(12, 12) = 1e-6f * Eigen::Matrix3f::Identity();
+
+    imu::IMUPreintegration integ(params);
+    integ.reset(imu::IMUBias{}, Eigen::Matrix3f::Identity(), P0);
+
+    // Zero motion: no integration steps fired (only one measurement fed → no step).
+    // Covariance must still equal P0 exactly.
+    imu::IMUMeasurement m0;
+    m0.timestamp = 0.0;
+    integ.integrate(m0);
+
+    EXPECT_TRUE(integ.get_raw().covariance.isApprox(P0, kEpsTight));
+}
+
+// 20. get_corrected with identical bias returns the same result as get_raw.
 TEST(IMUPreintegration, GetCorrectedSameBiasEqualsRaw) {
     imu::IMUBias bias;
     bias.gyro_bias  = Eigen::Vector3f(0.01f, -0.02f, 0.005f);


### PR DESCRIPTION
Implements discrete error-state covariance propagation following
Forster et al. (2017) for LIO integration:

  Σ_{k+1} = F_k · Σ_k · F_k^T  +  G_k · Q_d · G_k^T

Changes:
- IMUPreintegrationParams: add gyro/accel noise density and bias
  random-walk density parameters (default 0 = disabled)
- PreintegrationResult: add 15×15 covariance field matching
  the State ordering in imu_factor.hpp (pos/rot/vel/ba/bg)
- reset(): accept optional initial_covariance (e.g. posterior P
  from previous keyframe) to propagate full state uncertainty
- integrate_step(): propagate covariance using the midpoint-based
  discrete F matrix and closed-form G·Q_d·G^T process noise;
  propagation is skipped when all noise params are zero
- Tests: add 7 new test cases covering zero-noise behaviour,
  growth, symmetry, PSD property, and initial covariance propagation

https://claude.ai/code/session_019KVcbSEdAMLqd9QpcyCdDx