### PR TITLE
feat: Introduce base node and bag evaluation node

### DIFF
--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <deque>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -460,8 +461,8 @@ private:
         this->queue_ptr_ = std::make_shared<sycl_utils::DeviceQueue>(dev);
 
         // Point cloud buffers
-        this->preprocessed_pc_.reset(new PointCloudShared(*this->queue_ptr_));
-        this->registration_input_pc_.reset(new PointCloudShared(*this->queue_ptr_));
+        this->preprocessed_pc_ = std::make_shared<PointCloudShared>(*this->queue_ptr_);
+        this->registration_input_pc_ = std::make_shared<PointCloudShared>(*this->queue_ptr_);
 
         this->icp_weights_ = std::make_shared<shared_vector<float>>(*this->queue_ptr_->ptr);
 

--- a/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
@@ -342,7 +342,7 @@ private:
 
         // initialize buffer
         {
-            this->preprocessed_pc_.reset(new PointCloudShared(*this->queue_ptr_));
+            this->preprocessed_pc_ = std::make_shared<PointCloudShared>(*this->queue_ptr_);
         }
 
         // set Initial pose

--- a/cpp/include/sycl_points/pipeline/submapping.hpp
+++ b/cpp/include/sycl_points/pipeline/submapping.hpp
@@ -30,9 +30,9 @@ public:
     const PointCloudShared& get_keyframe_point_cloud() const { return *this->keyframe_pc_; }
 
     Submap(const sycl_utils::DeviceQueue& queue, const LidarOdometryParams& params) : queue_(queue) {
-        this->keyframe_pc_.reset(new PointCloudShared(this->queue_));
-        this->submap_pc_ptr_.reset(new PointCloudShared(this->queue_));
-        this->submap_pc_tmp_.reset(new PointCloudShared(this->queue_));
+        this->keyframe_pc_ = std::make_shared<PointCloudShared>(this->queue_);
+        this->submap_pc_ptr_ = std::make_shared<PointCloudShared>(this->queue_);
+        this->submap_pc_tmp_ = std::make_shared<PointCloudShared>(this->queue_);
 
         this->submap_params_ = params.submap;
         this->cov_params_ = params.covariance_estimation;

--- a/ros2/sycl_points_ros2/CMakeLists.txt
+++ b/ros2/sycl_points_ros2/CMakeLists.txt
@@ -31,6 +31,8 @@ ament_auto_add_library(lidar_odometry SHARED
   src/lidar_odometry_base_node.cpp
   src/lidar_odometry_bag_eval_node.cpp
   src/lidar_odometry_node.cpp
+  src/lidar_inertial_odometry_base_node.cpp
+  src/lidar_inertial_odometry_bag_eval_node.cpp
   src/lidar_inertial_odometry_node.cpp
 )
 
@@ -60,6 +62,12 @@ rclcpp_components_register_node(
   lidar_odometry
   PLUGIN "sycl_points::ros2::LidarInertialOdometryNode"
   EXECUTABLE lidar_inertial_odometry_node
+)
+
+rclcpp_components_register_node(
+  lidar_odometry
+  PLUGIN "sycl_points::ros2::LidarInertialOdometryBagEvalNode"
+  EXECUTABLE lidar_inertial_odometry_bag_eval_node
 )
 
 if(BUILD_TESTING)

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/lidar_inertial_odometry_bag_eval_node.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/lidar_inertial_odometry_bag_eval_node.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <fstream>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include "sycl_points_ros2/lidar_inertial_odometry_base_node.hpp"
+
+namespace sycl_points {
+namespace ros2 {
+
+class LidarInertialOdometryBagEvalNode : public LidarInertialOdometryBaseNode {
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    LidarInertialOdometryBagEvalNode(const rclcpp::NodeOptions& options);
+    ~LidarInertialOdometryBagEvalNode() override;
+
+private:
+    void run();
+    std::string detect_storage_id(const std::string& uri) const;
+    void write_tum_line(const geometry_msgs::msg::PoseStamped& pose_msg);
+
+    rclcpp::TimerBase::SharedPtr start_timer_ = nullptr;
+    std::ofstream tum_stream_;
+
+    std::string bag_uri_;
+    std::string output_tum_;
+    double start_offset_sec_ = 0.0;
+    bool write_first_frame_ = true;
+    bool exit_on_end_ = true;
+};
+
+}  // namespace ros2
+}  // namespace sycl_points

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/lidar_inertial_odometry_base_node.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/lidar_inertial_odometry_base_node.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <map>
+#include <memory>
+#include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <string>
+#include <sycl_points/pipeline/lidar_inertial_odometry.hpp>
+#include <sycl_points/pipeline/lidar_inertial_odometry_params.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
+#include <vector>
+
+#include "sycl_points_ros2/lidar_odometry_base_node.hpp"
+
+namespace sycl_points {
+namespace ros2 {
+
+class LidarInertialOdometryBaseNode : public rclcpp::Node {
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    struct PublishOptions {
+        bool publish_odom = true;
+        bool publish_tf = true;
+        bool publish_debug_clouds = true;
+    };
+
+    using ResultType = pipeline::lidar_inertial_odometry::LidarInertialOdometryPipeline::ResultType;
+
+    struct ProcessedFrame {
+        ResultType result = ResultType::error;
+        Eigen::Isometry3f odom = Eigen::Isometry3f::Identity();
+        Eigen::Isometry3f keyframe_pose = Eigen::Isometry3f::Identity();
+        double dt_from_ros2_msg = 0.0;
+        std::map<std::string, double> pipeline_processing_times;
+        double processing_subtotal = 0.0;
+        double publish_time = 0.0;
+    };
+
+    LidarInertialOdometryBaseNode(const std::string& node_name, const rclcpp::NodeOptions& options);
+    ~LidarInertialOdometryBaseNode() override;
+
+protected:
+    void initialize_processing();
+    void initialize_publishers(const PublishOptions& options);
+    ProcessedFrame process_point_cloud_message(const sensor_msgs::msg::PointCloud2& msg);
+    void publish_processed_frame(const std_msgs::msg::Header& header, ProcessedFrame& frame);
+    void record_processing_times(const ProcessedFrame& frame);
+
+    nav_msgs::msg::Odometry make_odom_message(const std_msgs::msg::Header& header, const Eigen::Isometry3f& odom) const;
+    geometry_msgs::msg::PoseStamped make_pose_message(const std_msgs::msg::Header& header,
+                                                      const Eigen::Isometry3f& odom) const;
+    nav_msgs::msg::Odometry make_keyframe_pose_message(const std_msgs::msg::Header& header,
+                                                       const Eigen::Isometry3f& odom) const;
+    geometry_msgs::msg::TransformStamped make_transform_message(const std_msgs::msg::Header& header,
+                                                                const Eigen::Isometry3f& odom) const;
+
+    bool publish_debug_clouds_enabled() const { return this->publish_options_.publish_debug_clouds; }
+    bool publish_odom_enabled() const { return this->publish_options_.publish_odom; }
+    bool publish_tf_enabled() const { return this->publish_options_.publish_tf; }
+
+    // -----------------------------------------------------------------------
+    // Publishers
+    // -----------------------------------------------------------------------
+    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_preprocessed_ = nullptr;
+    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_submap_ = nullptr;
+    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_pose_ = nullptr;
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_keyframe_pose_ = nullptr;
+    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odom_ = nullptr;
+    std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_ = nullptr;
+
+    // -----------------------------------------------------------------------
+    // Pipeline
+    // -----------------------------------------------------------------------
+    std::unique_ptr<pipeline::lidar_inertial_odometry::LidarInertialOdometryPipeline> pipeline_ = nullptr;
+    sycl_points::shared_vector_ptr<uint8_t> msg_data_buffer_ = nullptr;
+    PointCloudShared::Ptr scan_pc_ = nullptr;
+    pipeline::lidar_inertial_odometry::Parameters params_;
+
+    // -----------------------------------------------------------------------
+    // Node parameters (ROS2 / TF)
+    // -----------------------------------------------------------------------
+    std::string points_topic_ = "points";
+    std::string imu_topic_ = "imu/data";
+    bool input_convert_rgb_ = true;
+    bool input_convert_intensity_ = true;
+
+    std::string odom_frame_id_ = "odom";
+    std::string base_link_id_ = "base_link";
+    Eigen::Isometry3f T_base_link_to_lidar_ = Eigen::Isometry3f::Identity();
+    Eigen::Isometry3f T_lidar_to_base_link_ = Eigen::Isometry3f::Identity();
+
+    LiDAROdometryBaseNode::SubscriptionQoSParams points_qos_params_{"keep_last", 1, "best_effort"};
+    LiDAROdometryBaseNode::SubscriptionQoSParams imu_qos_params_{"keep_all", 100, "best_effort"};
+
+private:
+    void add_delta_time(const std::string& name, double dt);
+    void print_processing_times(const std::string& name, double dt);
+    void log_processing_times();
+
+    // -----------------------------------------------------------------------
+    // Processing-time bookkeeping
+    // -----------------------------------------------------------------------
+    PublishOptions publish_options_;
+    bool processing_initialized_ = false;
+    std::map<std::string, std::vector<double>> processing_times_;
+};
+
+}  // namespace ros2
+}  // namespace sycl_points

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/lidar_inertial_odometry_node.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/lidar_inertial_odometry_node.hpp
@@ -1,43 +1,21 @@
 #pragma once
 
-#include <geometry_msgs/msg/pose_stamped.hpp>
-#include <geometry_msgs/msg/transform_stamped.hpp>
-#include <map>
-#include <memory>
-#include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <string>
-#include <sycl_points/pipeline/lidar_inertial_odometry.hpp>
-#include <tf2_ros/transform_broadcaster.hpp>
-#include <vector>
 
-#include "sycl_points_ros2/lidar_odometry_base_node.hpp"
+#include "sycl_points_ros2/lidar_inertial_odometry_base_node.hpp"
 
 namespace sycl_points {
 namespace ros2 {
 
-/// @brief ROS 2 node for the LiDAR-Inertial Odometry pipeline.
-///
-/// IMU subscription is always enabled (LIO requires IMU).
-/// Publishes the same topics as LiDAROdometryNode (odom, pose, TF,
-/// preprocessed cloud, submap) so it can be used as a drop-in replacement.
-class LidarInertialOdometryNode : public rclcpp::Node {
+class LidarInertialOdometryNode : public LidarInertialOdometryBaseNode {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     explicit LidarInertialOdometryNode(const rclcpp::NodeOptions& options);
-    ~LidarInertialOdometryNode() override;
+    ~LidarInertialOdometryNode() override = default;
 
 private:
-    // -----------------------------------------------------------------------
-    // Pipeline
-    // -----------------------------------------------------------------------
-    std::unique_ptr<pipeline::lidar_inertial_odometry::LidarInertialOdometryPipeline> pipeline_;
-    pipeline::lidar_inertial_odometry::Parameters params_;
-    sycl_points::shared_vector_ptr<uint8_t> msg_data_buffer_;
-    PointCloudShared::Ptr scan_pc_;
-
     // -----------------------------------------------------------------------
     // Subscriptions (separate callback groups for concurrent IMU feed)
     // -----------------------------------------------------------------------
@@ -47,55 +25,10 @@ private:
     rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
 
     // -----------------------------------------------------------------------
-    // Publishers
-    // -----------------------------------------------------------------------
-    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_preprocessed_;
-    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_submap_;
-    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pub_pose_;
-    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odom_;
-    rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_keyframe_pose_;
-    std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
-
-    // -----------------------------------------------------------------------
-    // Node parameters (ROS2 / TF)
-    // -----------------------------------------------------------------------
-    std::string points_topic_ = "points";
-    std::string imu_topic_ = "imu/data";
-    std::string odom_frame_id_ = "odom";
-    std::string base_link_id_ = "base_link";
-    Eigen::Isometry3f T_base_link_to_lidar_ = Eigen::Isometry3f::Identity();
-    Eigen::Isometry3f T_lidar_to_base_link_ = Eigen::Isometry3f::Identity();
-    bool input_convert_rgb_ = true;
-    bool input_convert_intensity_ = true;
-
-    LiDAROdometryBaseNode::SubscriptionQoSParams points_qos_params_{"keep_last", 1, "best_effort"};
-    LiDAROdometryBaseNode::SubscriptionQoSParams imu_qos_params_{"keep_all", 100, "best_effort"};
-
-    // -----------------------------------------------------------------------
-    // Processing-time bookkeeping
-    // -----------------------------------------------------------------------
-    std::map<std::string, std::vector<double>> processing_times_;
-
-    // -----------------------------------------------------------------------
     // Callbacks
     // -----------------------------------------------------------------------
     void point_cloud_callback(const sensor_msgs::msg::PointCloud2::UniquePtr msg);
     void imu_callback(const sensor_msgs::msg::Imu::SharedPtr msg);
-
-    // -----------------------------------------------------------------------
-    // Helpers (same logic as LiDAROdometryBaseNode)
-    // -----------------------------------------------------------------------
-    nav_msgs::msg::Odometry make_odom_message(const std_msgs::msg::Header& header, const Eigen::Isometry3f& odom) const;
-    geometry_msgs::msg::PoseStamped make_pose_message(const std_msgs::msg::Header& header,
-                                                      const Eigen::Isometry3f& odom) const;
-    nav_msgs::msg::Odometry make_keyframe_pose_message(const std_msgs::msg::Header& header,
-                                                       const Eigen::Isometry3f& odom) const;
-    geometry_msgs::msg::TransformStamped make_transform_message(const std_msgs::msg::Header& header,
-                                                                const Eigen::Isometry3f& odom) const;
-    void record_processing_times(double dt_from_msg, double dt_publish);
-    void print_processing_times(const std::string& name, double dt);
-    void add_delta_time(const std::string& name, double dt);
-    void log_processing_times();
 };
 
 }  // namespace ros2

--- a/ros2/sycl_points_ros2/launch/lidar_inertial_odometry_bag_eval_launch.py
+++ b/ros2/sycl_points_ros2/launch/lidar_inertial_odometry_bag_eval_launch.py
@@ -1,0 +1,94 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+from ament_index_python.packages import get_package_share_directory
+import os
+import yaml
+
+
+def declare_params_from_yaml(yaml_path: str, target_node="lidar_inertial_odometry_node"):
+    launch_args = []
+    node_args = {}
+    with open(yaml_path, "r") as f:
+        all_params = yaml.safe_load(f)
+
+    for node_name in all_params.keys():
+        if node_name == target_node:
+            node_params: dict = all_params[node_name]["ros__parameters"]
+            for name, value in node_params.items():
+                if isinstance(value, float):
+                    value_str = format(value, "f")
+                else:
+                    value_str = str(value)
+                launch_args.append(
+                    DeclareLaunchArgument(name, default_value=value_str, description="")
+                )
+                node_args[name] = LaunchConfiguration(name)
+            break
+    return launch_args, node_args
+
+
+def generate_launch_description():
+    package_name = "sycl_points_ros2"
+    package_dir = get_package_share_directory(package_name)
+    param_yaml = os.path.join(package_dir, "config", "lidar_inertial_odometry.yaml")
+    launch_args, node_args = declare_params_from_yaml(param_yaml, "lidar_inertial_odometry_node")
+
+    launch_args.extend(
+        [
+            DeclareLaunchArgument(
+                "rosbag/uri", default_value="", description="input rosbag path"
+            ),
+            DeclareLaunchArgument(
+                "rosbag/start_offset/sec",
+                default_value="0.0",
+                description="bag start offset in seconds",
+            ),
+            DeclareLaunchArgument(
+                "eval/output_tum",
+                default_value="sycl_lio_odom.tum",
+                description="output tum filepath",
+            ),
+            DeclareLaunchArgument(
+                "eval/write_first_frame",
+                default_value="true",
+                choices=["true", "false"],
+                description="write first frame pose to tum",
+            ),
+            DeclareLaunchArgument(
+                "eval/exit_on_end",
+                default_value="true",
+                choices=["true", "false"],
+                description="shutdown node after evaluation",
+            ),
+        ]
+    )
+
+    nodes = [
+        Node(
+            package=package_name,
+            executable="lidar_inertial_odometry_bag_eval_node",
+            output="screen",
+            emulate_tty=True,
+            parameters=[
+                node_args,
+                {
+                    "rosbag/uri": LaunchConfiguration("rosbag/uri"),
+                    "rosbag/start_offset/sec": ParameterValue(
+                        LaunchConfiguration("rosbag/start_offset/sec"), value_type=float
+                    ),
+                    "eval/output_tum": LaunchConfiguration("eval/output_tum"),
+                    "eval/write_first_frame": ParameterValue(
+                        LaunchConfiguration("eval/write_first_frame"), value_type=bool
+                    ),
+                    "eval/exit_on_end": ParameterValue(
+                        LaunchConfiguration("eval/exit_on_end"), value_type=bool
+                    ),
+                },
+            ],
+        ),
+    ]
+
+    return LaunchDescription(launch_args + nodes)

--- a/ros2/sycl_points_ros2/src/lidar_inertial_odometry_bag_eval_node.cpp
+++ b/ros2/sycl_points_ros2/src/lidar_inertial_odometry_bag_eval_node.cpp
@@ -1,0 +1,204 @@
+#include "sycl_points_ros2/lidar_inertial_odometry_bag_eval_node.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <iomanip>
+#include <memory>
+#include <rclcpp/serialization.hpp>
+#include <rclcpp/serialized_message.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+#include <rosbag2_storage/storage_options.hpp>
+#include <rosbag2_transport/reader_writer_factory.hpp>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace sycl_points {
+namespace ros2 {
+
+LidarInertialOdometryBagEvalNode::LidarInertialOdometryBagEvalNode(const rclcpp::NodeOptions& options)
+    : LidarInertialOdometryBaseNode("lidar_inertial_odometry_bag_eval", options) {
+    this->bag_uri_ = this->declare_parameter<std::string>("rosbag/uri", "");
+    this->start_offset_sec_ = this->declare_parameter<double>("rosbag/start_offset/sec", 0.0);
+    this->output_tum_ = this->declare_parameter<std::string>("eval/output_tum", "sycl_lio_odom.tum");
+    this->write_first_frame_ = this->declare_parameter<bool>("eval/write_first_frame", true);
+    this->exit_on_end_ = this->declare_parameter<bool>("eval/exit_on_end", true);
+
+    this->initialize_processing();
+
+    this->start_timer_ = this->create_wall_timer(std::chrono::milliseconds(10), [this]() { this->run(); });
+}
+
+LidarInertialOdometryBagEvalNode::~LidarInertialOdometryBagEvalNode() {
+    if (this->tum_stream_.is_open()) {
+        this->tum_stream_.flush();
+        this->tum_stream_.close();
+    }
+}
+
+void LidarInertialOdometryBagEvalNode::run() {
+    if (this->start_timer_ != nullptr) {
+        this->start_timer_->cancel();
+    }
+
+    try {
+        if (this->points_topic_.empty()) {
+            throw std::runtime_error("`points_topic` must not be empty");
+        }
+        if (this->imu_topic_.empty()) {
+            throw std::runtime_error("`imu_topic` must not be empty");
+        }
+        if (this->bag_uri_.empty()) {
+            throw std::runtime_error("`rosbag/uri` must not be empty");
+        }
+        if (this->output_tum_.empty()) {
+            throw std::runtime_error("`eval/output_tum` must not be empty");
+        }
+
+        const std::filesystem::path output_path(this->output_tum_);
+        if (output_path.has_parent_path()) {
+            std::filesystem::create_directories(output_path.parent_path());
+        }
+
+        this->tum_stream_.open(output_path, std::ios::out | std::ios::trunc);
+        if (!this->tum_stream_.is_open()) {
+            throw std::runtime_error("failed to open output tum file: " + output_path.string());
+        }
+
+        rosbag2_storage::StorageOptions storage_options;
+        storage_options.uri = this->bag_uri_;
+        storage_options.storage_id = this->detect_storage_id(this->bag_uri_);
+
+        auto reader = rosbag2_transport::ReaderWriterFactory::make_reader(storage_options);
+        reader->open(storage_options);
+        rclcpp::Serialization<sensor_msgs::msg::PointCloud2> pc_serializer;
+        rclcpp::Serialization<sensor_msgs::msg::Imu> imu_serializer;
+
+        const auto& metadata = reader->get_metadata();
+        const auto bag_start_time_ns =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(metadata.starting_time.time_since_epoch()).count();
+        const auto start_time_ns = bag_start_time_ns + static_cast<int64_t>(this->start_offset_sec_ * 1.0e9);
+        if (start_time_ns > bag_start_time_ns) {
+            reader->seek(start_time_ns);
+        }
+
+        int64_t handled_frames = 0;
+        int64_t written_frames = 0;
+
+        while (rclcpp::ok() && reader->has_next()) {
+            auto bag_message = reader->read_next();
+            if (bag_message == nullptr) continue;
+
+            // IMU is always required for LIO — feed all IMU measurements to the pipeline
+            if (bag_message->topic_name == this->imu_topic_) {
+                sensor_msgs::msg::Imu imu_msg;
+                rclcpp::SerializedMessage serialized_imu(*bag_message->serialized_data);
+                imu_serializer.deserialize_message(&serialized_imu, &imu_msg);
+
+                imu::IMUMeasurement meas;
+                meas.timestamp = rclcpp::Time(imu_msg.header.stamp).seconds();
+                meas.gyro = Eigen::Vector3f(static_cast<float>(imu_msg.angular_velocity.x),
+                                            static_cast<float>(imu_msg.angular_velocity.y),
+                                            static_cast<float>(imu_msg.angular_velocity.z));
+                meas.accel = Eigen::Vector3f(static_cast<float>(imu_msg.linear_acceleration.x),
+                                             static_cast<float>(imu_msg.linear_acceleration.y),
+                                             static_cast<float>(imu_msg.linear_acceleration.z));
+                this->pipeline_->add_imu_measurement(meas);
+                continue;
+            }
+
+            if (bag_message->topic_name != this->points_topic_) continue;
+
+            sensor_msgs::msg::PointCloud2 msg;
+            rclcpp::SerializedMessage serialized_msg(*bag_message->serialized_data);
+            pc_serializer.deserialize_message(&serialized_msg, &msg);
+
+            ++handled_frames;
+            const auto frame = this->process_point_cloud_message(msg);
+            this->record_processing_times(frame);
+
+            const bool should_write_tum = frame.result == ResultType::success ||
+                                          (frame.result == ResultType::first_frame && this->write_first_frame_);
+            if (should_write_tum) {
+                const auto pose_msg = this->make_pose_message(msg.header, frame.odom);
+                this->write_tum_line(pose_msg);
+                ++written_frames;
+            }
+        }
+
+        this->tum_stream_.flush();
+        this->tum_stream_.close();
+
+        RCLCPP_INFO(this->get_logger(),
+                    "Bag evaluation finished. topic=%s handled_frames=%ld written_frames=%ld tum=%s",
+                    this->points_topic_.c_str(), handled_frames, written_frames, this->output_tum_.c_str());
+    } catch (const std::exception& e) {
+        RCLCPP_ERROR(this->get_logger(), "bag evaluation failed: %s", e.what());
+    }
+
+    if (this->exit_on_end_) {
+        rclcpp::shutdown();
+    }
+}
+
+std::string LidarInertialOdometryBagEvalNode::detect_storage_id(const std::string& uri) const {
+    namespace fs = std::filesystem;
+
+    const fs::path path(uri);
+    if (path.extension() == ".mcap") {
+        return "mcap";
+    }
+    if (path.extension() == ".db3") {
+        return "sqlite3";
+    }
+
+    const fs::path metadata_path = path / "metadata.yaml";
+    if (!fs::exists(metadata_path)) {
+        throw std::runtime_error("failed to detect storage id: metadata.yaml not found at " + metadata_path.string());
+    }
+
+    std::ifstream metadata_stream(metadata_path);
+    if (!metadata_stream.is_open()) {
+        throw std::runtime_error("failed to open metadata.yaml: " + metadata_path.string());
+    }
+
+    std::string line;
+    while (std::getline(metadata_stream, line)) {
+        constexpr std::string_view key = "  storage_identifier:";
+        const auto pos = line.find(key);
+        if (pos == std::string::npos) {
+            continue;
+        }
+
+        std::string value = line.substr(pos + key.size());
+        const auto first = value.find_first_not_of(" \t");
+        if (first == std::string::npos) {
+            break;
+        }
+        value = value.substr(first);
+        const auto last = value.find_last_not_of(" \t\r\n");
+        if (last != std::string::npos) {
+            value = value.substr(0, last + 1);
+        }
+        if (!value.empty()) {
+            return value;
+        }
+    }
+
+    throw std::runtime_error("failed to detect storage identifier from metadata: " + metadata_path.string());
+}
+
+void LidarInertialOdometryBagEvalNode::write_tum_line(const geometry_msgs::msg::PoseStamped& pose_msg) {
+    const double timestamp =
+        static_cast<double>(pose_msg.header.stamp.sec) + static_cast<double>(pose_msg.header.stamp.nanosec) * 1.0e-9;
+
+    this->tum_stream_ << std::fixed << std::setprecision(9) << timestamp << " " << pose_msg.pose.position.x << " "
+                      << pose_msg.pose.position.y << " " << pose_msg.pose.position.z << " "
+                      << pose_msg.pose.orientation.x << " " << pose_msg.pose.orientation.y << " "
+                      << pose_msg.pose.orientation.z << " " << pose_msg.pose.orientation.w << "\n";
+}
+
+}  // namespace ros2
+}  // namespace sycl_points
+
+RCLCPP_COMPONENTS_REGISTER_NODE(sycl_points::ros2::LidarInertialOdometryBagEvalNode)

--- a/ros2/sycl_points_ros2/src/lidar_inertial_odometry_bag_eval_node.cpp
+++ b/ros2/sycl_points_ros2/src/lidar_inertial_odometry_bag_eval_node.cpp
@@ -142,50 +142,13 @@ void LidarInertialOdometryBagEvalNode::run() {
 }
 
 std::string LidarInertialOdometryBagEvalNode::detect_storage_id(const std::string& uri) const {
-    namespace fs = std::filesystem;
-
-    const fs::path path(uri);
-    if (path.extension() == ".mcap") {
-        return "mcap";
+    rosbag2_storage::MetadataIo io;
+    try {
+        const auto metadata = io.read_metadata(uri);
+        return metadata.storage_identifier;
+    } catch (const std::exception& e) {
+        throw std::runtime_error("Failed to detect storage id from metadata: " + std::string(e.what()));
     }
-    if (path.extension() == ".db3") {
-        return "sqlite3";
-    }
-
-    const fs::path metadata_path = path / "metadata.yaml";
-    if (!fs::exists(metadata_path)) {
-        throw std::runtime_error("failed to detect storage id: metadata.yaml not found at " + metadata_path.string());
-    }
-
-    std::ifstream metadata_stream(metadata_path);
-    if (!metadata_stream.is_open()) {
-        throw std::runtime_error("failed to open metadata.yaml: " + metadata_path.string());
-    }
-
-    std::string line;
-    while (std::getline(metadata_stream, line)) {
-        constexpr std::string_view key = "  storage_identifier:";
-        const auto pos = line.find(key);
-        if (pos == std::string::npos) {
-            continue;
-        }
-
-        std::string value = line.substr(pos + key.size());
-        const auto first = value.find_first_not_of(" \t");
-        if (first == std::string::npos) {
-            break;
-        }
-        value = value.substr(first);
-        const auto last = value.find_last_not_of(" \t\r\n");
-        if (last != std::string::npos) {
-            value = value.substr(0, last + 1);
-        }
-        if (!value.empty()) {
-            return value;
-        }
-    }
-
-    throw std::runtime_error("failed to detect storage identifier from metadata: " + metadata_path.string());
 }
 
 void LidarInertialOdometryBagEvalNode::write_tum_line(const geometry_msgs::msg::PoseStamped& pose_msg) {

--- a/ros2/sycl_points_ros2/src/lidar_inertial_odometry_base_node.cpp
+++ b/ros2/sycl_points_ros2/src/lidar_inertial_odometry_base_node.cpp
@@ -1,5 +1,6 @@
 #include "sycl_points_ros2/lidar_inertial_odometry_base_node.hpp"
 
+#include <memory>
 #include <sycl_points/ros2/convert.hpp>
 #include <sycl_points/utils/time_utils.hpp>
 
@@ -77,8 +78,8 @@ void LidarInertialOdometryBaseNode::initialize_processing() {
     this->pipeline_ = std::make_unique<pipeline::lidar_inertial_odometry::LidarInertialOdometryPipeline>(this->params_);
     this->pipeline_->get_device_queue()->print_device_info();
 
-    this->msg_data_buffer_.reset(new shared_vector<uint8_t>(*this->pipeline_->get_device_queue()->ptr));
-    this->scan_pc_.reset(new PointCloudShared(*this->pipeline_->get_device_queue()));
+    this->msg_data_buffer_ = std::make_shared<shared_vector<uint8_t>>(*this->pipeline_->get_device_queue()->ptr);
+    this->scan_pc_ = std::make_shared<PointCloudShared>(*this->pipeline_->get_device_queue());
     this->processing_initialized_ = true;
 
     RCLCPP_INFO(this->get_logger(), "Input conversion - RGB: %s, intensity: %s",

--- a/ros2/sycl_points_ros2/src/lidar_inertial_odometry_base_node.cpp
+++ b/ros2/sycl_points_ros2/src/lidar_inertial_odometry_base_node.cpp
@@ -1,0 +1,343 @@
+#include "sycl_points_ros2/lidar_inertial_odometry_base_node.hpp"
+
+#include <sycl_points/ros2/convert.hpp>
+#include <sycl_points/utils/time_utils.hpp>
+
+#include "sycl_points_ros2/declare_lidar_inertial_odometry_params.hpp"
+
+namespace sycl_points {
+namespace ros2 {
+
+LidarInertialOdometryBaseNode::LidarInertialOdometryBaseNode(const std::string& node_name,
+                                                             const rclcpp::NodeOptions& options)
+    : rclcpp::Node(node_name, options) {}
+
+LidarInertialOdometryBaseNode::~LidarInertialOdometryBaseNode() {
+    if (!this->processing_initialized_) {
+        return;
+    }
+    this->log_processing_times();
+}
+
+void LidarInertialOdometryBaseNode::initialize_processing() {
+    this->params_ = ros2::declare_lidar_inertial_odometry_parameters(this);
+
+    this->points_topic_ = this->declare_parameter<std::string>("points_topic", this->points_topic_);
+    this->imu_topic_ = this->declare_parameter<std::string>("imu_topic", this->imu_topic_);
+    this->input_convert_rgb_ = this->declare_parameter<bool>("input/convert_rgb", true);
+    this->input_convert_intensity_ = this->declare_parameter<bool>("input/convert_intensity", true);
+
+    // QoS settings
+    this->points_qos_params_.history =
+        this->declare_parameter<std::string>("points_qos/history", this->points_qos_params_.history);
+    this->points_qos_params_.depth =
+        this->declare_parameter<int64_t>("points_qos/depth", this->points_qos_params_.depth);
+    this->points_qos_params_.reliability =
+        this->declare_parameter<std::string>("points_qos/reliability", this->points_qos_params_.reliability);
+    this->imu_qos_params_.history =
+        this->declare_parameter<std::string>("imu_qos/history", this->imu_qos_params_.history);
+    this->imu_qos_params_.depth = this->declare_parameter<int64_t>("imu_qos/depth", this->imu_qos_params_.depth);
+    this->imu_qos_params_.reliability =
+        this->declare_parameter<std::string>("imu_qos/reliability", this->imu_qos_params_.reliability);
+
+    this->odom_frame_id_ = this->declare_parameter<std::string>("odom_frame_id", this->odom_frame_id_);
+    this->base_link_id_ = this->declare_parameter<std::string>("base_link_id", this->base_link_id_);
+    {
+        const auto x = this->declare_parameter<double>("T_base_link_to_lidar/x", 0.0);
+        const auto y = this->declare_parameter<double>("T_base_link_to_lidar/y", 0.0);
+        const auto z = this->declare_parameter<double>("T_base_link_to_lidar/z", 0.0);
+        const auto qx = this->declare_parameter<double>("T_base_link_to_lidar/qx", 0.0);
+        const auto qy = this->declare_parameter<double>("T_base_link_to_lidar/qy", 0.0);
+        const auto qz = this->declare_parameter<double>("T_base_link_to_lidar/qz", 0.0);
+        const auto qw = this->declare_parameter<double>("T_base_link_to_lidar/qw", 1.0);
+        this->T_base_link_to_lidar_.setIdentity();
+        this->T_base_link_to_lidar_.translation() << static_cast<float>(x), static_cast<float>(y),
+            static_cast<float>(z);
+        const Eigen::Quaternionf q(static_cast<float>(qw), static_cast<float>(qx), static_cast<float>(qy),
+                                   static_cast<float>(qz));
+        this->T_base_link_to_lidar_.matrix().block<3, 3>(0, 0) = q.normalized().matrix();
+        this->T_lidar_to_base_link_ = this->T_base_link_to_lidar_.inverse();
+    }
+    {
+        const auto x = this->declare_parameter<double>("initial_base_link_pose/x", 0.0);
+        const auto y = this->declare_parameter<double>("initial_base_link_pose/y", 0.0);
+        const auto z = this->declare_parameter<double>("initial_base_link_pose/z", 0.0);
+        const auto qx = this->declare_parameter<double>("initial_base_link_pose/qx", 0.0);
+        const auto qy = this->declare_parameter<double>("initial_base_link_pose/qy", 0.0);
+        const auto qz = this->declare_parameter<double>("initial_base_link_pose/qz", 0.0);
+        const auto qw = this->declare_parameter<double>("initial_base_link_pose/qw", 1.0);
+        Eigen::Isometry3f init = Eigen::Isometry3f::Identity();
+        init.translation() << static_cast<float>(x), static_cast<float>(y), static_cast<float>(z);
+        const Eigen::Quaternionf q(static_cast<float>(qw), static_cast<float>(qx), static_cast<float>(qy),
+                                   static_cast<float>(qz));
+        init.matrix().block<3, 3>(0, 0) = q.normalized().matrix();
+        this->params_.pose.initial = init * this->T_base_link_to_lidar_;
+    }
+
+    this->pipeline_ = std::make_unique<pipeline::lidar_inertial_odometry::LidarInertialOdometryPipeline>(this->params_);
+    this->pipeline_->get_device_queue()->print_device_info();
+
+    this->msg_data_buffer_.reset(new shared_vector<uint8_t>(*this->pipeline_->get_device_queue()->ptr));
+    this->scan_pc_.reset(new PointCloudShared(*this->pipeline_->get_device_queue()));
+    this->processing_initialized_ = true;
+
+    RCLCPP_INFO(this->get_logger(), "Input conversion - RGB: %s, intensity: %s",
+                this->input_convert_rgb_ ? "enabled" : "disabled",
+                this->input_convert_intensity_ ? "enabled" : "disabled");
+}
+
+void LidarInertialOdometryBaseNode::initialize_publishers(const PublishOptions& options) {
+    this->publish_options_ = options;
+
+    if (options.publish_debug_clouds) {
+        this->pub_preprocessed_ =
+            this->create_publisher<sensor_msgs::msg::PointCloud2>("sycl_lo/preprocessed", rclcpp::QoS(5));
+        this->pub_submap_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("sycl_lo/submap", rclcpp::QoS(5));
+    }
+
+    if (options.publish_odom) {
+        this->pub_odom_ = this->create_publisher<nav_msgs::msg::Odometry>("sycl_lo/odom", rclcpp::QoS(5));
+        this->pub_pose_ = this->create_publisher<geometry_msgs::msg::PoseStamped>("sycl_lo/pose", rclcpp::QoS(5));
+        this->pub_keyframe_pose_ =
+            this->create_publisher<nav_msgs::msg::Odometry>("sycl_lo/keyframe/pose", rclcpp::QoS(5));
+    }
+
+    if (options.publish_tf) {
+        this->tf_broadcaster_ =
+            std::make_unique<tf2_ros::TransformBroadcaster>(*this, tf2_ros::DynamicBroadcasterQoS(1000));
+    }
+
+    if (this->pub_preprocessed_ != nullptr) {
+        RCLCPP_INFO(this->get_logger(), "Publish Preprocessed PointCloud: %s",
+                    this->pub_preprocessed_->get_topic_name());
+    }
+    if (this->pub_submap_ != nullptr) {
+        RCLCPP_INFO(this->get_logger(), "Publish Submap PointCloud: %s", this->pub_submap_->get_topic_name());
+    }
+    if (this->pub_odom_ != nullptr) {
+        RCLCPP_INFO(this->get_logger(), "Publish Odometry: %s", this->pub_odom_->get_topic_name());
+    }
+    if (this->pub_pose_ != nullptr) {
+        RCLCPP_INFO(this->get_logger(), "Publish Pose: %s", this->pub_pose_->get_topic_name());
+    }
+    if (this->pub_keyframe_pose_ != nullptr) {
+        RCLCPP_INFO(this->get_logger(), "Publish Keyframe Pose: %s", this->pub_keyframe_pose_->get_topic_name());
+    }
+}
+
+LidarInertialOdometryBaseNode::ProcessedFrame LidarInertialOdometryBaseNode::process_point_cloud_message(
+    const sensor_msgs::msg::PointCloud2& msg) {
+    ProcessedFrame frame;
+    const double timestamp = rclcpp::Time(msg.header.stamp).seconds();
+    bool converted = false;
+
+    double dt_from_ros2_msg = 0.0;
+    time_utils::measure_execution(
+        [&]() {
+            converted = fromROS2msg(*this->pipeline_->get_device_queue(), msg, this->scan_pc_, this->msg_data_buffer_,
+                                    this->input_convert_rgb_, this->input_convert_intensity_);
+        },
+        dt_from_ros2_msg);
+
+    if (!converted || this->scan_pc_ == nullptr) {
+        RCLCPP_WARN(this->get_logger(), "failed to convert input point cloud");
+        frame.result = ResultType::error;
+        return frame;
+    }
+
+    if (this->scan_pc_->size() == 0) {
+        RCLCPP_WARN(this->get_logger(), "input point cloud is empty");
+        frame.result = ResultType::error;
+        return frame;
+    }
+
+    frame.result = this->pipeline_->process(this->scan_pc_, timestamp);
+    if (frame.result >= ResultType::error) {
+        RCLCPP_WARN(this->get_logger(), "LIO failed: %s", this->pipeline_->get_error_message().c_str());
+        return frame;
+    }
+
+    frame.odom = this->pipeline_->get_odom();
+    frame.keyframe_pose = this->pipeline_->get_last_keyframe_pose();
+
+    frame.dt_from_ros2_msg = dt_from_ros2_msg;
+    frame.pipeline_processing_times = this->pipeline_->get_current_processing_time();
+    frame.processing_subtotal = dt_from_ros2_msg;
+    for (const auto& item : frame.pipeline_processing_times) {
+        frame.processing_subtotal += item.second;
+    }
+
+    return frame;
+}
+
+void LidarInertialOdometryBaseNode::publish_processed_frame(const std_msgs::msg::Header& header,
+                                                            ProcessedFrame& frame) {
+    frame.publish_time = 0.0;
+    time_utils::measure_execution(
+        [&]() {
+            if (this->publish_tf_enabled() && this->tf_broadcaster_ != nullptr) {
+                this->tf_broadcaster_->sendTransform(this->make_transform_message(header, frame.odom));
+            }
+
+            if (this->publish_odom_enabled()) {
+                if (this->pub_odom_ != nullptr) {
+                    this->pub_odom_->publish(this->make_odom_message(header, frame.odom));
+                }
+                if (this->pub_pose_ != nullptr) {
+                    this->pub_pose_->publish(this->make_pose_message(header, frame.odom));
+                }
+                if (this->pub_keyframe_pose_ != nullptr) {
+                    this->pub_keyframe_pose_->publish(this->make_keyframe_pose_message(header, frame.keyframe_pose));
+                }
+            }
+
+            if (!this->publish_debug_clouds_enabled()) {
+                return;
+            }
+
+            if (this->pub_preprocessed_ != nullptr && this->pub_preprocessed_->get_subscription_count() > 0) {
+                const auto pc_msg = toROS2msg(this->pipeline_->get_preprocessed_point_cloud(), header);
+                if (pc_msg != nullptr) {
+                    this->pub_preprocessed_->publish(*pc_msg);
+                }
+            }
+
+            if (this->pub_submap_ != nullptr && this->pub_submap_->get_subscription_count() > 0) {
+                auto submap_msg = toROS2msg(this->pipeline_->get_submap_point_cloud(), header);
+                if (submap_msg != nullptr) {
+                    submap_msg->header.frame_id = this->odom_frame_id_;
+                    this->pub_submap_->publish(*submap_msg);
+                }
+            }
+        },
+        frame.publish_time);
+}
+
+// ---------------------------------------------------------------------------
+// Message helpers (same logic as LidarInertialOdometryNode)
+// ---------------------------------------------------------------------------
+
+nav_msgs::msg::Odometry LidarInertialOdometryBaseNode::make_odom_message(const std_msgs::msg::Header& header,
+                                                                         const Eigen::Isometry3f& odom) const {
+    const Eigen::Isometry3f T = odom * this->T_lidar_to_base_link_;
+    const Eigen::Quaternionf q(T.rotation());
+
+    nav_msgs::msg::Odometry msg;
+    msg.header.stamp = header.stamp;
+    msg.header.frame_id = this->odom_frame_id_;
+    msg.child_frame_id = this->base_link_id_;
+    msg.pose.pose.position.x = T.translation().x();
+    msg.pose.pose.position.y = T.translation().y();
+    msg.pose.pose.position.z = T.translation().z();
+    msg.pose.pose.orientation.x = q.x();
+    msg.pose.pose.orientation.y = q.y();
+    msg.pose.pose.orientation.z = q.z();
+    msg.pose.pose.orientation.w = q.w();
+    return msg;
+}
+
+geometry_msgs::msg::PoseStamped LidarInertialOdometryBaseNode::make_pose_message(const std_msgs::msg::Header& header,
+                                                                                 const Eigen::Isometry3f& odom) const {
+    const auto odom_msg = this->make_odom_message(header, odom);
+    geometry_msgs::msg::PoseStamped pose;
+    pose.header = odom_msg.header;
+    pose.pose = odom_msg.pose.pose;
+    return pose;
+}
+
+nav_msgs::msg::Odometry LidarInertialOdometryBaseNode::make_keyframe_pose_message(const std_msgs::msg::Header& header,
+                                                                                  const Eigen::Isometry3f& odom) const {
+    return this->make_odom_message(header, odom);
+}
+
+geometry_msgs::msg::TransformStamped LidarInertialOdometryBaseNode::make_transform_message(
+    const std_msgs::msg::Header& header, const Eigen::Isometry3f& odom) const {
+    const Eigen::Isometry3f T = odom * this->T_lidar_to_base_link_;
+    const Eigen::Quaternionf q(T.rotation());
+
+    geometry_msgs::msg::TransformStamped tf;
+    tf.header.stamp = header.stamp;
+    tf.header.frame_id = this->odom_frame_id_;
+    tf.child_frame_id = this->base_link_id_;
+    tf.transform.translation.x = T.translation().x();
+    tf.transform.translation.y = T.translation().y();
+    tf.transform.translation.z = T.translation().z();
+    tf.transform.rotation.x = q.x();
+    tf.transform.rotation.y = q.y();
+    tf.transform.rotation.z = q.z();
+    tf.transform.rotation.w = q.w();
+    return tf;
+}
+
+void LidarInertialOdometryBaseNode::record_processing_times(const ProcessedFrame& frame) {
+    const double total_time = frame.processing_subtotal + frame.publish_time;
+
+    this->add_delta_time("0. from ROS 2 msg", frame.dt_from_ros2_msg);
+    for (const auto& [process_name, time] : frame.pipeline_processing_times) {
+        this->add_delta_time(process_name, time);
+    }
+    this->add_delta_time("5. publish ROS 2 msg", frame.publish_time);
+    this->add_delta_time("6. total", total_time);
+
+    this->print_processing_times("0. from ROS 2 msg", frame.dt_from_ros2_msg);
+    for (const auto& [process_name, time] : frame.pipeline_processing_times) {
+        this->print_processing_times(process_name, time);
+    }
+    this->print_processing_times("5. publish ROS 2 msg", frame.publish_time);
+    this->print_processing_times("6. total", total_time);
+    RCLCPP_INFO(this->get_logger(), "");
+}
+
+void LidarInertialOdometryBaseNode::add_delta_time(const std::string& name, double dt) {
+    if (this->processing_times_.count(name) > 0) {
+        this->processing_times_[name].push_back(dt);
+    } else {
+        this->processing_times_[name] = {dt};
+    }
+}
+
+void LidarInertialOdometryBaseNode::print_processing_times(const std::string& name, double dt) {
+    constexpr size_t LENGTH = 24;
+    std::string log = name + ": ";
+    if (name.length() < LENGTH) {
+        log += std::string(LENGTH - name.length(), ' ');
+    }
+    log += "%9.2f us";
+    RCLCPP_INFO(this->get_logger(), log.c_str(), dt);
+}
+
+void LidarInertialOdometryBaseNode::log_processing_times() {
+    RCLCPP_INFO(this->get_logger(), "");
+    RCLCPP_INFO(this->get_logger(), "MAX processing time");
+
+    this->processing_times_.insert(this->pipeline_->get_total_processing_times().begin(),
+                                   this->pipeline_->get_total_processing_times().end());
+
+    for (auto& item : this->processing_times_) {
+        if (item.second.empty()) continue;
+        const double max = *std::max_element(item.second.begin(), item.second.end());
+        this->print_processing_times(item.first, max);
+    }
+
+    RCLCPP_INFO(this->get_logger(), "");
+    RCLCPP_INFO(this->get_logger(), "MEAN processing time");
+    for (auto& item : this->processing_times_) {
+        if (item.second.empty()) continue;
+        const double avg =
+            std::accumulate(item.second.begin(), item.second.end(), 0.0) / static_cast<double>(item.second.size());
+        this->print_processing_times(item.first, avg);
+    }
+
+    RCLCPP_INFO(this->get_logger(), "");
+    RCLCPP_INFO(this->get_logger(), "MEDIAN processing time");
+    for (auto& item : this->processing_times_) {
+        if (item.second.empty()) continue;
+        std::sort(item.second.begin(), item.second.end());
+        const double median = item.second[item.second.size() / 2];
+        this->print_processing_times(item.first, median);
+    }
+    RCLCPP_INFO(this->get_logger(), "");
+}
+
+}  // namespace ros2
+}  // namespace sycl_points

--- a/ros2/sycl_points_ros2/src/lidar_inertial_odometry_node.cpp
+++ b/ros2/sycl_points_ros2/src/lidar_inertial_odometry_node.cpp
@@ -1,93 +1,21 @@
 #include "sycl_points_ros2/lidar_inertial_odometry_node.hpp"
 
-#include <algorithm>
-#include <numeric>
 #include <rclcpp_components/register_node_macro.hpp>
-#include <sycl_points/ros2/convert.hpp>
-#include <sycl_points/utils/time_utils.hpp>
-
-#include "sycl_points_ros2/declare_lidar_inertial_odometry_params.hpp"
 
 namespace sycl_points {
 namespace ros2 {
 
 LidarInertialOdometryNode::LidarInertialOdometryNode(const rclcpp::NodeOptions& options)
-    : rclcpp::Node("lidar_inertial_odometry", options) {
-    // -----------------------------------------------------------------------
-    // Parameters
-    // -----------------------------------------------------------------------
-    params_ = declare_lidar_inertial_odometry_parameters(this);
-
-    points_topic_ = this->declare_parameter<std::string>("points_topic", points_topic_);
-    imu_topic_ = this->declare_parameter<std::string>("imu_topic", imu_topic_);
-    input_convert_rgb_ = this->declare_parameter<bool>("input/convert_rgb", true);
-    input_convert_intensity_ = this->declare_parameter<bool>("input/convert_intensity", true);
-
-    points_qos_params_.history = this->declare_parameter<std::string>("points_qos/history", points_qos_params_.history);
-    points_qos_params_.depth = this->declare_parameter<int64_t>("points_qos/depth", points_qos_params_.depth);
-    points_qos_params_.reliability =
-        this->declare_parameter<std::string>("points_qos/reliability", points_qos_params_.reliability);
-    imu_qos_params_.history = this->declare_parameter<std::string>("imu_qos/history", imu_qos_params_.history);
-    imu_qos_params_.depth = this->declare_parameter<int64_t>("imu_qos/depth", imu_qos_params_.depth);
-    imu_qos_params_.reliability =
-        this->declare_parameter<std::string>("imu_qos/reliability", imu_qos_params_.reliability);
-
-    odom_frame_id_ = this->declare_parameter<std::string>("odom_frame_id", odom_frame_id_);
-    base_link_id_ = this->declare_parameter<std::string>("base_link_id", base_link_id_);
-
-    {
-        const auto x = this->declare_parameter<double>("T_base_link_to_lidar/x", 0.0);
-        const auto y = this->declare_parameter<double>("T_base_link_to_lidar/y", 0.0);
-        const auto z = this->declare_parameter<double>("T_base_link_to_lidar/z", 0.0);
-        const auto qx = this->declare_parameter<double>("T_base_link_to_lidar/qx", 0.0);
-        const auto qy = this->declare_parameter<double>("T_base_link_to_lidar/qy", 0.0);
-        const auto qz = this->declare_parameter<double>("T_base_link_to_lidar/qz", 0.0);
-        const auto qw = this->declare_parameter<double>("T_base_link_to_lidar/qw", 1.0);
-        T_base_link_to_lidar_.setIdentity();
-        T_base_link_to_lidar_.translation() << static_cast<float>(x), static_cast<float>(y), static_cast<float>(z);
-        const Eigen::Quaternionf q(static_cast<float>(qw), static_cast<float>(qx), static_cast<float>(qy),
-                                   static_cast<float>(qz));
-        T_base_link_to_lidar_.matrix().block<3, 3>(0, 0) = q.normalized().matrix();
-        T_lidar_to_base_link_ = T_base_link_to_lidar_.inverse();
-    }
-    {
-        const auto x = this->declare_parameter<double>("initial_base_link_pose/x", 0.0);
-        const auto y = this->declare_parameter<double>("initial_base_link_pose/y", 0.0);
-        const auto z = this->declare_parameter<double>("initial_base_link_pose/z", 0.0);
-        const auto qx = this->declare_parameter<double>("initial_base_link_pose/qx", 0.0);
-        const auto qy = this->declare_parameter<double>("initial_base_link_pose/qy", 0.0);
-        const auto qz = this->declare_parameter<double>("initial_base_link_pose/qz", 0.0);
-        const auto qw = this->declare_parameter<double>("initial_base_link_pose/qw", 1.0);
-        Eigen::Isometry3f init = Eigen::Isometry3f::Identity();
-        init.translation() << static_cast<float>(x), static_cast<float>(y), static_cast<float>(z);
-        const Eigen::Quaternionf q(static_cast<float>(qw), static_cast<float>(qx), static_cast<float>(qy),
-                                   static_cast<float>(qz));
-        init.matrix().block<3, 3>(0, 0) = q.normalized().matrix();
-        params_.pose.initial = init * T_base_link_to_lidar_;
-    }
-
-    // -----------------------------------------------------------------------
-    // Pipeline
-    // -----------------------------------------------------------------------
-    pipeline_ = std::make_unique<pipeline::lidar_inertial_odometry::LidarInertialOdometryPipeline>(params_);
-    pipeline_->get_device_queue()->print_device_info();
-
-    msg_data_buffer_.reset(new shared_vector<uint8_t>(*pipeline_->get_device_queue()->ptr));
-    scan_pc_.reset(new PointCloudShared(*pipeline_->get_device_queue()));
-
-    // -----------------------------------------------------------------------
-    // Publishers
-    // -----------------------------------------------------------------------
-    pub_preprocessed_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("sycl_lo/preprocessed", rclcpp::QoS(5));
-    pub_submap_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("sycl_lo/submap", rclcpp::QoS(5));
-    pub_pose_ = this->create_publisher<geometry_msgs::msg::PoseStamped>("sycl_lo/pose", rclcpp::QoS(5));
-    pub_odom_ = this->create_publisher<nav_msgs::msg::Odometry>("sycl_lo/odom", rclcpp::QoS(5));
-    pub_keyframe_pose_ = this->create_publisher<nav_msgs::msg::Odometry>("sycl_lo/keyframe/pose", rclcpp::QoS(5));
-    tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(*this, tf2_ros::DynamicBroadcasterQoS(1000));
+    : LidarInertialOdometryBaseNode("lidar_inertial_odometry", options) {
+    this->initialize_processing();
+    this->initialize_publishers({});
 
     // -----------------------------------------------------------------------
     // Subscriptions
     // -----------------------------------------------------------------------
+    // Create separate MutuallyExclusive callback groups for LiDAR and IMU so that
+    // IMU callbacks can run concurrently with point cloud processing when using
+    // a MultiThreadedExecutor
     cb_group_lidar_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
     cb_group_imu_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
@@ -96,77 +24,30 @@ LidarInertialOdometryNode::LidarInertialOdometryNode(const rclcpp::NodeOptions& 
     sub_pc_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
         points_topic_, points_qos_params_.to_qos(),
         std::bind(&LidarInertialOdometryNode::point_cloud_callback, this, std::placeholders::_1), lidar_opts);
-    RCLCPP_INFO(this->get_logger(), "Subscribe PointCloud: %s", sub_pc_->get_topic_name());
+    RCLCPP_INFO(this->get_logger(), "Subscribe PointCloud: %s (history=%s, depth=%ld, reliability=%s)",
+                sub_pc_->get_topic_name(), points_qos_params_.history.c_str(), points_qos_params_.depth,
+                points_qos_params_.reliability.c_str());
 
     rclcpp::SubscriptionOptions imu_opts;
     imu_opts.callback_group = cb_group_imu_;
     sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
         imu_topic_, imu_qos_params_.to_qos(),
         std::bind(&LidarInertialOdometryNode::imu_callback, this, std::placeholders::_1), imu_opts);
-    RCLCPP_INFO(this->get_logger(), "Subscribe IMU: %s", sub_imu_->get_topic_name());
+    RCLCPP_INFO(this->get_logger(), "Subscribe IMU: %s (history=%s, depth=%ld, reliability=%s)",
+                sub_imu_->get_topic_name(), imu_qos_params_.history.c_str(), imu_qos_params_.depth,
+                imu_qos_params_.reliability.c_str());
 }
-
-LidarInertialOdometryNode::~LidarInertialOdometryNode() { log_processing_times(); }
 
 // ---------------------------------------------------------------------------
 // Callbacks
 // ---------------------------------------------------------------------------
 
 void LidarInertialOdometryNode::point_cloud_callback(const sensor_msgs::msg::PointCloud2::UniquePtr msg) {
-    const double timestamp = rclcpp::Time(msg->header.stamp).seconds();
-
-    double dt_convert = 0.0;
-    bool converted = false;
-    time_utils::measure_execution(
-        [&]() {
-            converted = fromROS2msg(*pipeline_->get_device_queue(), *msg, scan_pc_, msg_data_buffer_,
-                                    input_convert_rgb_, input_convert_intensity_);
-        },
-        dt_convert);
-
-    if (!converted || scan_pc_ == nullptr || scan_pc_->size() == 0) {
-        RCLCPP_WARN(this->get_logger(), "failed to convert input point cloud");
-        return;
+    auto frame = this->process_point_cloud_message(*msg);
+    if (frame.result == ResultType::success || frame.result == ResultType::first_frame) {
+        this->publish_processed_frame(msg->header, frame);
     }
-
-    {
-        using ResultType = pipeline::lidar_inertial_odometry::LidarInertialOdometryPipeline::ResultType;
-        const auto result = pipeline_->process(scan_pc_, timestamp);
-        if (result >= ResultType::error) {
-            RCLCPP_WARN(this->get_logger(), "LIO failed: %s", pipeline_->get_error_message().c_str());
-            return;
-        }
-        if (result != ResultType::success && result != ResultType::first_frame) return;
-    }
-
-    const auto& header = msg->header;
-    const auto& odom = pipeline_->get_odom();
-    const auto& kf_pose = pipeline_->get_last_keyframe_pose();
-
-    // Publish (timed, matching "5. publish ROS 2 msg" in the base node)
-    double dt_publish = 0.0;
-    time_utils::measure_execution(
-        [&]() {
-            tf_broadcaster_->sendTransform(make_transform_message(header, odom));
-            pub_odom_->publish(make_odom_message(header, odom));
-            pub_pose_->publish(make_pose_message(header, odom));
-            pub_keyframe_pose_->publish(make_keyframe_pose_message(header, kf_pose));
-
-            if (pub_preprocessed_->get_subscription_count() > 0) {
-                const auto pc_msg = toROS2msg(pipeline_->get_preprocessed_point_cloud(), header);
-                if (pc_msg) pub_preprocessed_->publish(*pc_msg);
-            }
-            if (pub_submap_->get_subscription_count() > 0) {
-                auto submap_msg = toROS2msg(pipeline_->get_submap_point_cloud(), header);
-                if (submap_msg) {
-                    submap_msg->header.frame_id = odom_frame_id_;
-                    pub_submap_->publish(*submap_msg);
-                }
-            }
-        },
-        dt_publish);
-
-    record_processing_times(dt_convert, dt_publish);
+    this->record_processing_times(frame);
 }
 
 void LidarInertialOdometryNode::imu_callback(const sensor_msgs::msg::Imu::SharedPtr msg) {
@@ -179,126 +60,6 @@ void LidarInertialOdometryNode::imu_callback(const sensor_msgs::msg::Imu::Shared
         Eigen::Vector3f(static_cast<float>(msg->linear_acceleration.x), static_cast<float>(msg->linear_acceleration.y),
                         static_cast<float>(msg->linear_acceleration.z));
     pipeline_->add_imu_measurement(meas);
-}
-
-// ---------------------------------------------------------------------------
-// Message helpers (same logic as LiDAROdometryBaseNode)
-// ---------------------------------------------------------------------------
-
-nav_msgs::msg::Odometry LidarInertialOdometryNode::make_odom_message(const std_msgs::msg::Header& header,
-                                                                     const Eigen::Isometry3f& odom) const {
-    const Eigen::Isometry3f T = odom * T_lidar_to_base_link_;
-    const Eigen::Quaternionf q(T.rotation());
-
-    nav_msgs::msg::Odometry msg;
-    msg.header.stamp = header.stamp;
-    msg.header.frame_id = odom_frame_id_;
-    msg.child_frame_id = base_link_id_;
-    msg.pose.pose.position.x = T.translation().x();
-    msg.pose.pose.position.y = T.translation().y();
-    msg.pose.pose.position.z = T.translation().z();
-    msg.pose.pose.orientation.x = q.x();
-    msg.pose.pose.orientation.y = q.y();
-    msg.pose.pose.orientation.z = q.z();
-    msg.pose.pose.orientation.w = q.w();
-    return msg;
-}
-
-geometry_msgs::msg::PoseStamped LidarInertialOdometryNode::make_pose_message(const std_msgs::msg::Header& header,
-                                                                             const Eigen::Isometry3f& odom) const {
-    const auto odom_msg = make_odom_message(header, odom);
-    geometry_msgs::msg::PoseStamped pose;
-    pose.header = odom_msg.header;
-    pose.pose = odom_msg.pose.pose;
-    return pose;
-}
-
-nav_msgs::msg::Odometry LidarInertialOdometryNode::make_keyframe_pose_message(const std_msgs::msg::Header& header,
-                                                                              const Eigen::Isometry3f& odom) const {
-    return make_odom_message(header, odom);
-}
-
-geometry_msgs::msg::TransformStamped LidarInertialOdometryNode::make_transform_message(
-    const std_msgs::msg::Header& header, const Eigen::Isometry3f& odom) const {
-    const Eigen::Isometry3f T = odom * T_lidar_to_base_link_;
-    const Eigen::Quaternionf q(T.rotation());
-
-    geometry_msgs::msg::TransformStamped tf;
-    tf.header.stamp = header.stamp;
-    tf.header.frame_id = odom_frame_id_;
-    tf.child_frame_id = base_link_id_;
-    tf.transform.translation.x = T.translation().x();
-    tf.transform.translation.y = T.translation().y();
-    tf.transform.translation.z = T.translation().z();
-    tf.transform.rotation.x = q.x();
-    tf.transform.rotation.y = q.y();
-    tf.transform.rotation.z = q.z();
-    tf.transform.rotation.w = q.w();
-    return tf;
-}
-
-void LidarInertialOdometryNode::record_processing_times(double dt_from_msg, double dt_publish) {
-    double total = dt_from_msg + dt_publish;
-
-    add_delta_time("0. from ROS 2 msg", dt_from_msg);
-    print_processing_times("0. from ROS 2 msg", dt_from_msg);
-
-    for (const auto& [name, dt] : pipeline_->get_current_processing_time()) {
-        add_delta_time(name, dt);
-        print_processing_times(name, dt);
-        total += dt;
-    }
-
-    add_delta_time("5. publish ROS 2 msg", dt_publish);
-    print_processing_times("5. publish ROS 2 msg", dt_publish);
-
-    add_delta_time("6. total", total);
-    print_processing_times("6. total", total);
-
-    RCLCPP_INFO(this->get_logger(), "");
-}
-
-void LidarInertialOdometryNode::print_processing_times(const std::string& name, double dt) {
-    constexpr size_t LENGTH = 24;
-    std::string log = name + ": ";
-    if (name.length() < LENGTH) {
-        log += std::string(LENGTH - name.length(), ' ');
-    }
-    log += "%9.2f us";
-    RCLCPP_INFO(this->get_logger(), log.c_str(), dt);
-}
-
-void LidarInertialOdometryNode::add_delta_time(const std::string& name, double dt) {
-    processing_times_[name].push_back(dt);
-}
-
-void LidarInertialOdometryNode::log_processing_times() {
-    RCLCPP_INFO(this->get_logger(), "");
-    processing_times_.insert(pipeline_->get_total_processing_times().begin(),
-                             pipeline_->get_total_processing_times().end());
-
-    RCLCPP_INFO(this->get_logger(), "MAX processing time");
-    for (auto& [name, times] : processing_times_) {
-        if (times.empty()) continue;
-        print_processing_times(name, *std::max_element(times.begin(), times.end()));
-    }
-
-    RCLCPP_INFO(this->get_logger(), "");
-    RCLCPP_INFO(this->get_logger(), "MEAN processing time");
-    for (auto& [name, times] : processing_times_) {
-        if (times.empty()) continue;
-        print_processing_times(name,
-                               std::accumulate(times.begin(), times.end(), 0.0) / static_cast<double>(times.size()));
-    }
-
-    RCLCPP_INFO(this->get_logger(), "");
-    RCLCPP_INFO(this->get_logger(), "MEDIAN processing time");
-    for (auto& [name, times] : processing_times_) {
-        if (times.empty()) continue;
-        std::sort(times.begin(), times.end());
-        print_processing_times(name, times[times.size() / 2]);
-    }
-    RCLCPP_INFO(this->get_logger(), "");
 }
 
 }  // namespace ros2

--- a/ros2/sycl_points_ros2/src/lidar_odometry_bag_eval_node.cpp
+++ b/ros2/sycl_points_ros2/src/lidar_odometry_bag_eval_node.cpp
@@ -139,50 +139,13 @@ void LiDAROdometryBagEvalNode::run() {
 }
 
 std::string LiDAROdometryBagEvalNode::detect_storage_id(const std::string& uri) const {
-    namespace fs = std::filesystem;
-
-    const fs::path path(uri);
-    if (path.extension() == ".mcap") {
-        return "mcap";
+    rosbag2_storage::MetadataIo io;
+    try {
+        const auto metadata = io.read_metadata(uri);
+        return metadata.storage_identifier;
+    } catch (const std::exception& e) {
+        throw std::runtime_error("Failed to detect storage id from metadata: " + std::string(e.what()));
     }
-    if (path.extension() == ".db3") {
-        return "sqlite3";
-    }
-
-    const fs::path metadata_path = path / "metadata.yaml";
-    if (!fs::exists(metadata_path)) {
-        throw std::runtime_error("failed to detect storage id: metadata.yaml not found at " + metadata_path.string());
-    }
-
-    std::ifstream metadata_stream(metadata_path);
-    if (!metadata_stream.is_open()) {
-        throw std::runtime_error("failed to open metadata.yaml: " + metadata_path.string());
-    }
-
-    std::string line;
-    while (std::getline(metadata_stream, line)) {
-        constexpr std::string_view key = "  storage_identifier:";
-        const auto pos = line.find(key);
-        if (pos == std::string::npos) {
-            continue;
-        }
-
-        std::string value = line.substr(pos + key.size());
-        const auto first = value.find_first_not_of(" \t");
-        if (first == std::string::npos) {
-            break;
-        }
-        value = value.substr(first);
-        const auto last = value.find_last_not_of(" \t\r\n");
-        if (last != std::string::npos) {
-            value = value.substr(0, last + 1);
-        }
-        if (!value.empty()) {
-            return value;
-        }
-    }
-
-    throw std::runtime_error("failed to detect storage identifier from metadata: " + metadata_path.string());
 }
 
 void LiDAROdometryBagEvalNode::write_tum_line(const geometry_msgs::msg::PoseStamped& pose_msg) {

--- a/ros2/sycl_points_ros2/src/lidar_odometry_base_node.cpp
+++ b/ros2/sycl_points_ros2/src/lidar_odometry_base_node.cpp
@@ -96,8 +96,8 @@ void LiDAROdometryBaseNode::initialize_processing() {
     this->pipeline_ = std::make_unique<pipeline::lidar_odometry::LiDAROdometryPipeline>(this->params_);
     this->pipeline_->get_device_queue()->print_device_info();
 
-    this->msg_data_buffer_.reset(new shared_vector<uint8_t>(*this->pipeline_->get_device_queue()->ptr));
-    this->scan_pc_.reset(new PointCloudShared(*this->pipeline_->get_device_queue()));
+    this->msg_data_buffer_ = std::make_shared<shared_vector<uint8_t>>(*this->pipeline_->get_device_queue()->ptr);
+    this->scan_pc_ = std::make_shared<PointCloudShared>(*this->pipeline_->get_device_queue());
     this->processing_initialized_ = true;
 
     RCLCPP_INFO(this->get_logger(), "Input conversion - RGB: %s, intensity: %s",


### PR DESCRIPTION
This commit refactors the LiDAR-Inertial Odometry (LIO) ROS 2 nodes by extracting common logic into a new `LidarInertialOdometryBaseNode`. The existing `LidarInertialOdometryNode` now inherits from this base class, simplifying its implementation. A new `LidarInertialOdometryBagEvalNode` is added to enable LIO pipeline evaluation from ROS 2 bags, providing output in TUM format. This evaluation node also extends the new base class. Accompanying changes include updated CMakeLists.txt for new source files and ROS 2 component registration, as well as a new launch file for the bag evaluation node.