### PR TITLE
Add MAP estimation prior using previous-frame Hessian

### DIFF
--- a/cpp/include/sycl_points/algorithms/registration/map_prior.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/map_prior.hpp
@@ -11,10 +11,10 @@ namespace registration {
 
 struct MapPriorParams {
     bool enabled = false;
-    /// @brief Process noise added to each rotation diagonal of H_raw^{-1} before inverting.
+    /// @brief Process noise for each rotation axis (diagonal of Q).
     ///        Larger value = weaker (more permissive) prior on rotation.
     float rot_process_noise = 0.01f;
-    /// @brief Process noise added to each translation diagonal of H_raw^{-1} before inverting.
+    /// @brief Process noise for each translation axis (diagonal of Q).
     ///        Larger value = weaker (more permissive) prior on translation.
     float trans_process_noise = 0.01f;
 };
@@ -22,12 +22,14 @@ struct MapPriorParams {
 /// @brief MAP estimation prior using the previous frame's Hessian as the information matrix.
 ///
 /// Adds a Gaussian prior N(T_pred, Omega_prior^{-1}) to the GICP normal equations each
-/// iteration.  The information matrix is computed once per frame as:
+/// iteration.  The information matrix is computed once per frame via the Matrix Inversion
+/// Lemma to avoid directly inverting H_raw_prev (which may be singular in degenerate cases):
 ///
-///   Omega_prior = (H_raw_prev^{-1} + Q)^{-1}
+///   R = Q^{-1}  (trivial: diagonal)
+///   Omega_prior = (H^{-1} + Q)^{-1} = R - R(H + R)^{-1}R
 ///
-/// where Q is a diagonal process-noise matrix that prevents the prior from being too
-/// tight in directions that were well-constrained in the previous frame.
+/// Since R is positive-definite, (H + R) is always invertible even when H is singular,
+/// making this formulation robust to degenerate environments.
 ///
 /// The resulting updates to the normal equations (H * delta = -b, solve(-b) convention):
 ///
@@ -43,7 +45,7 @@ class MapPrior {
 public:
     void set_params(const MapPriorParams& params) { params_ = params; }
 
-    /// @brief Precompute Omega_prior for the upcoming align() call.
+    /// @brief Precompute Omega_prior and T_pred_inv for the upcoming align() call.
     ///        Call this once per frame, after motion prediction and before align().
     /// @param H_raw_prev  Unregularized Hessian (RegistrationResult::H_raw) from the previous frame.
     /// @param T_pred      Predicted pose used as the initial guess for the current frame.
@@ -51,23 +53,20 @@ public:
         has_prior_ = false;
         if (!params_.enabled) return;
 
-        // Q = diag(rot_noise * I_3, trans_noise * I_3)
-        Eigen::Matrix<float, 6, 6> Q = Eigen::Matrix<float, 6, 6>::Zero();
-        Q.block<3, 3>(0, 0) = Eigen::Matrix3f::Identity() * params_.rot_process_noise;
-        Q.block<3, 3>(3, 3) = Eigen::Matrix3f::Identity() * params_.trans_process_noise;
+        // R = Q^{-1}: diagonal, trivially computed from process-noise parameters
+        const float inv_rot = 1.0f / std::max(params_.rot_process_noise, 1e-6f);
+        const float inv_trans = 1.0f / std::max(params_.trans_process_noise, 1e-6f);
+        Eigen::Matrix<float, 6, 6> R = Eigen::Matrix<float, 6, 6>::Zero();
+        R.diagonal() << inv_rot, inv_rot, inv_rot, inv_trans, inv_trans, inv_trans;
 
-        // Sigma_prior = H_raw_prev^{-1} + Q
-        Eigen::LDLT<Eigen::Matrix<float, 6, 6>> ldlt_h(H_raw_prev);
-        if (ldlt_h.info() != Eigen::Success || ldlt_h.vectorD().minCoeff() <= 0.0f) return;
-        const Eigen::Matrix<float, 6, 6> Sigma_prior =
-            ldlt_h.solve(Eigen::Matrix<float, 6, 6>::Identity()) + Q;
+        // Omega_prior = (H^{-1} + Q)^{-1} = R - R(H + R)^{-1}R
+        // (H + R) is always PD since R is PD, so this is robust to singular H.
+        Eigen::LDLT<Eigen::Matrix<float, 6, 6>> ldlt(H_raw_prev + R);
+        if (ldlt.info() != Eigen::Success) return;
+        Omega_prior_ = R - R * ldlt.solve(R);
 
-        // Omega_prior = Sigma_prior^{-1}
-        Eigen::LDLT<Eigen::Matrix<float, 6, 6>> ldlt_s(Sigma_prior);
-        if (ldlt_s.info() != Eigen::Success || ldlt_s.vectorD().minCoeff() <= 0.0f) return;
-        Omega_prior_ = ldlt_s.solve(Eigen::Matrix<float, 6, 6>::Identity());
-
-        T_pred_ = T_pred;
+        // Precompute inverse once; reused every iteration inside apply()
+        T_pred_inv_ = T_pred.inverse();
         has_prior_ = true;
     }
 
@@ -79,7 +78,7 @@ public:
         if (!is_active()) return in;
 
         // e_prior = Log(T_pred^{-1} * T_est): deviation of the current estimate from the prediction
-        const Eigen::Vector<float, 6> e_prior = eigen_utils::lie::se3_log(T_pred_.inverse() * T_est);
+        const Eigen::Vector<float, 6> e_prior = eigen_utils::lie::se3_log(T_pred_inv_ * T_est);
 
         LinearizedResult ret = in;
         ret.H += Omega_prior_;
@@ -93,7 +92,7 @@ private:
     MapPriorParams params_;
     bool has_prior_ = false;
     Eigen::Matrix<float, 6, 6> Omega_prior_ = Eigen::Matrix<float, 6, 6>::Zero();
-    Eigen::Isometry3f T_pred_ = Eigen::Isometry3f::Identity();
+    Eigen::Isometry3f T_pred_inv_ = Eigen::Isometry3f::Identity();
 };
 
 }  // namespace registration

--- a/cpp/include/sycl_points/algorithms/registration/map_prior.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/map_prior.hpp
@@ -66,46 +66,40 @@ public:
     void set_params(const MapPriorParams& params) {
         params_ = params;
         has_prior_ = false;
-        has_prev_pose_ = false;
     }
 
     /// @brief Precompute Omega_prior and T_pred_inv for the upcoming align() call.
     ///        Call this once per frame, after motion prediction and before align().
-    ///        The previous pose is maintained internally: no external delta computation needed.
-    /// @param H_raw_prev  Unregularized Hessian (RegistrationResult::H_raw) from the previous frame.
-    /// @param T_pred      Predicted pose used as the initial guess for the current frame.
-    void update(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_pred) {
+    /// @param H_raw_prev   Unregularized Hessian (RegistrationResult::H_raw) from the previous frame.
+    ///                     This was computed at T_opt_prev, so the Adjoint must use T_opt_prev.
+    /// @param T_opt_prev   Optimized pose of the previous frame (= odom_ in LiDAROdometryPipeline).
+    /// @param T_pred       Predicted pose used as the initial guess for the current frame.
+    void update(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_opt_prev,
+                const Eigen::Isometry3f& T_pred) {
         has_prior_ = false;
         if (!params_.enabled) return;
 
-        // Relative rotation from the stored previous pose to T_pred (for Adjoint and delta_rot).
-        // On the first call has_prev_pose_ is false, so we use Identity (no rotation change).
-        Eigen::Matrix3f R_rel = Eigen::Matrix3f::Identity();
-        if (has_prev_pose_) {
-            R_rel = T_prev_.rotation().transpose() * T_pred.rotation();
-        }
+        // R_rel = R_opt_prev^T * R_pred: relative rotation from the optimized previous frame
+        // to the predicted current frame.  H_raw_prev was built at T_opt_prev, so this is
+        // the correct rotation for the Adjoint transformation and for the per-axis delta.
+        const Eigen::Matrix3f R_rel = T_opt_prev.rotation().transpose() * T_pred.rotation();
 
-        // Per-axis inter-frame delta in T_pred body frame.
-        // Zero on first call; floor noise takes effect instead of velocity scaling.
-        Eigen::Vector3f delta_rot_body   = Eigen::Vector3f::Zero();
-        Eigen::Vector3f delta_trans_body = Eigen::Vector3f::Zero();
-        if (has_prev_pose_) {
-            delta_rot_body   = Eigen::AngleAxisf(R_rel).axis() * Eigen::AngleAxisf(R_rel).angle();
-            delta_trans_body = T_pred.rotation().transpose() * (T_pred.translation() - T_prev_.translation());
-        }
+        // Per-axis inter-frame delta expressed in T_pred body frame.
+        const Eigen::AngleAxisf aa(R_rel);
+        const Eigen::Vector3f delta_rot_body = aa.axis() * aa.angle();
+        const Eigen::Vector3f delta_trans_body =
+            T_pred.rotation().transpose() * (T_pred.translation() - T_opt_prev.translation());
 
         // Per-axis process noise Q: velocity-proportional with a floor for sudden acceleration.
         //   Q_rot[i]   = max(rot_min_noise,   rot_vel_scale   * delta_rot_body[i]^2)
         //   Q_trans[i] = max(trans_min_noise, trans_vel_scale * delta_trans_body[i]^2)
         const Eigen::Vector3f q_rot =
-            (delta_rot_body.cwiseProduct(delta_rot_body) * params_.rot_vel_scale)
-                .cwiseMax(params_.rot_min_noise);
-        const Eigen::Vector3f q_trans =
-            (delta_trans_body.cwiseProduct(delta_trans_body) * params_.trans_vel_scale)
-                .cwiseMax(params_.trans_min_noise);
+            (delta_rot_body.cwiseProduct(delta_rot_body) * params_.rot_vel_scale).cwiseMax(params_.rot_min_noise);
+        const Eigen::Vector3f q_trans = (delta_trans_body.cwiseProduct(delta_trans_body) * params_.trans_vel_scale)
+                                            .cwiseMax(params_.trans_min_noise);
 
-        // Rotate H_raw_prev into the T_pred body frame using the rotation-only Adjoint.
-        // Ad = block_diag(R_rel, R_rel)
+        // Rotate H_raw_prev from T_opt_prev body frame into T_pred body frame via rotation-only
+        // Adjoint: Ad = block_diag(R_rel, R_rel), H_curr = Ad^T * H_raw_prev * Ad
         Eigen::Matrix<float, 6, 6> Ad = Eigen::Matrix<float, 6, 6>::Zero();
         Ad.block<3, 3>(0, 0) = R_rel;
         Ad.block<3, 3>(3, 3) = R_rel;
@@ -120,14 +114,12 @@ public:
         // Omega_prior = (H^{-1} + Q)^{-1} = R - R(H + R)^{-1}R
         // (H + R) is always PD since R is PD, so this is robust to singular H.
         Eigen::LDLT<Eigen::Matrix<float, 6, 6>> ldlt(H_curr + R);
-        T_prev_      = T_pred;
-        has_prev_pose_ = true;
         if (ldlt.info() != Eigen::Success) return;
         Omega_prior_ = R - R * ldlt.solve(R);
 
         // Precompute inverse once; reused every iteration inside apply() and prior_error()
         T_pred_inv_ = T_pred.inverse();
-        has_prior_  = true;
+        has_prior_ = true;
     }
 
     /// @brief Apply the MAP prior to the normal equations for one optimizer iteration.
@@ -161,11 +153,9 @@ public:
 
 private:
     MapPriorParams params_;
-    bool has_prior_     = false;
-    bool has_prev_pose_ = false;
+    bool has_prior_ = false;
     Eigen::Matrix<float, 6, 6> Omega_prior_ = Eigen::Matrix<float, 6, 6>::Zero();
     Eigen::Isometry3f T_pred_inv_ = Eigen::Isometry3f::Identity();
-    Eigen::Isometry3f T_prev_     = Eigen::Isometry3f::Identity();
 };
 
 }  // namespace registration

--- a/cpp/include/sycl_points/algorithms/registration/map_prior.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/map_prior.hpp
@@ -31,10 +31,17 @@ struct MapPriorParams {
 /// Since R is positive-definite, (H + R) is always invertible even when H is singular,
 /// making this formulation robust to degenerate environments.
 ///
+/// H_raw_prev is expressed in the previous sensor frame.  Before computing Omega_prior,
+/// it is rotated into the current sensor frame using the rotation-only Adjoint:
+///
+///   Ad = block_diag(R_rel, R_rel),  R_rel = R_prev^T * R_pred
+///   H_curr = Ad^T * H_raw_prev * Ad
+///
 /// The resulting updates to the normal equations (H * delta = -b, solve(-b) convention):
 ///
 ///   H_total = H_gicp + Omega_prior
 ///   b_total = b_gicp + Omega_prior * e_prior
+///   error_total = error_gicp + 0.5 * e_prior^T * Omega_prior * e_prior
 ///
 /// where e_prior = Log(T_pred^{-1} * T_est) is the deviation of the current estimate
 /// from the predicted pose on the SE(3) manifold.
@@ -49,9 +56,19 @@ public:
     ///        Call this once per frame, after motion prediction and before align().
     /// @param H_raw_prev  Unregularized Hessian (RegistrationResult::H_raw) from the previous frame.
     /// @param T_pred      Predicted pose used as the initial guess for the current frame.
-    void update(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_pred) {
+    /// @param T_prev      Previous odometry pose (used to compute relative rotation for Adjoint).
+    void update(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_pred,
+                const Eigen::Isometry3f& T_prev) {
         has_prior_ = false;
         if (!params_.enabled) return;
+
+        // Rotate H_raw_prev into the current sensor frame using the rotation-only Adjoint.
+        // Ad = block_diag(R_rel, R_rel), R_rel = R_prev^T * R_pred
+        const Eigen::Matrix3f R_rel = T_prev.rotation().transpose() * T_pred.rotation();
+        Eigen::Matrix<float, 6, 6> Ad = Eigen::Matrix<float, 6, 6>::Zero();
+        Ad.block<3, 3>(0, 0) = R_rel;
+        Ad.block<3, 3>(3, 3) = R_rel;
+        const Eigen::Matrix<float, 6, 6> H_curr = Ad.transpose() * H_raw_prev * Ad;
 
         // R = Q^{-1}: diagonal, trivially computed from process-noise parameters
         const float inv_rot = 1.0f / std::max(params_.rot_process_noise, 1e-6f);
@@ -61,16 +78,17 @@ public:
 
         // Omega_prior = (H^{-1} + Q)^{-1} = R - R(H + R)^{-1}R
         // (H + R) is always PD since R is PD, so this is robust to singular H.
-        Eigen::LDLT<Eigen::Matrix<float, 6, 6>> ldlt(H_raw_prev + R);
+        Eigen::LDLT<Eigen::Matrix<float, 6, 6>> ldlt(H_curr + R);
         if (ldlt.info() != Eigen::Success) return;
         Omega_prior_ = R - R * ldlt.solve(R);
 
-        // Precompute inverse once; reused every iteration inside apply()
+        // Precompute inverse once; reused every iteration inside apply() and prior_error()
         T_pred_inv_ = T_pred.inverse();
         has_prior_ = true;
     }
 
     /// @brief Apply the MAP prior to the normal equations for one optimizer iteration.
+    ///        Adds Omega_prior to H and b, and adds the prior's scalar cost to error.
     /// @param in    Linearized result after GICP (and optional degenerate regularization).
     /// @param T_est Current pose estimate at this iteration.
     /// @return Modified LinearizedResult with prior terms added.
@@ -79,11 +97,21 @@ public:
 
         // e_prior = Log(T_pred^{-1} * T_est): deviation of the current estimate from the prediction
         const Eigen::Vector<float, 6> e_prior = eigen_utils::lie::se3_log(T_pred_inv_ * T_est);
+        const Eigen::Vector<float, 6> Omega_e = Omega_prior_ * e_prior;
 
         LinearizedResult ret = in;
         ret.H += Omega_prior_;
-        ret.b += Omega_prior_ * e_prior;
+        ret.b += Omega_e;
+        ret.error += 0.5f * e_prior.dot(Omega_e);
         return ret;
+    }
+
+    /// @brief Compute the scalar prior cost at a given pose.
+    ///        Used to augment compute_error() results for LM/Dogleg step acceptance.
+    float prior_error(const Eigen::Isometry3f& T_est) const {
+        if (!is_active()) return 0.0f;
+        const Eigen::Vector<float, 6> e = eigen_utils::lie::se3_log(T_pred_inv_ * T_est);
+        return 0.5f * e.dot(Omega_prior_ * e);
     }
 
     bool is_active() const { return params_.enabled && has_prior_; }

--- a/cpp/include/sycl_points/algorithms/registration/map_prior.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/map_prior.hpp
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+#include "sycl_points/algorithms/registration/linearized_result.hpp"
+#include "sycl_points/utils/eigen_utils.hpp"
+
+namespace sycl_points {
+namespace algorithms {
+namespace registration {
+
+struct MapPriorParams {
+    bool enabled = false;
+    /// @brief Process noise added to each rotation diagonal of H_raw^{-1} before inverting.
+    ///        Larger value = weaker (more permissive) prior on rotation.
+    float rot_process_noise = 0.01f;
+    /// @brief Process noise added to each translation diagonal of H_raw^{-1} before inverting.
+    ///        Larger value = weaker (more permissive) prior on translation.
+    float trans_process_noise = 0.01f;
+};
+
+/// @brief MAP estimation prior using the previous frame's Hessian as the information matrix.
+///
+/// Adds a Gaussian prior N(T_pred, Omega_prior^{-1}) to the GICP normal equations each
+/// iteration.  The information matrix is computed once per frame as:
+///
+///   Omega_prior = (H_raw_prev^{-1} + Q)^{-1}
+///
+/// where Q is a diagonal process-noise matrix that prevents the prior from being too
+/// tight in directions that were well-constrained in the previous frame.
+///
+/// The resulting updates to the normal equations (H * delta = -b, solve(-b) convention):
+///
+///   H_total = H_gicp + Omega_prior
+///   b_total = b_gicp + Omega_prior * e_prior
+///
+/// where e_prior = Log(T_pred^{-1} * T_est) is the deviation of the current estimate
+/// from the predicted pose on the SE(3) manifold.
+///
+/// In degenerate directions H_raw_prev is small, so Omega_prior is also small and
+/// nl_reg's Tikhonov penalty dominates — the two mechanisms are complementary.
+class MapPrior {
+public:
+    void set_params(const MapPriorParams& params) { params_ = params; }
+
+    /// @brief Precompute Omega_prior for the upcoming align() call.
+    ///        Call this once per frame, after motion prediction and before align().
+    /// @param H_raw_prev  Unregularized Hessian (RegistrationResult::H_raw) from the previous frame.
+    /// @param T_pred      Predicted pose used as the initial guess for the current frame.
+    void update(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_pred) {
+        has_prior_ = false;
+        if (!params_.enabled) return;
+
+        // Q = diag(rot_noise * I_3, trans_noise * I_3)
+        Eigen::Matrix<float, 6, 6> Q = Eigen::Matrix<float, 6, 6>::Zero();
+        Q.block<3, 3>(0, 0) = Eigen::Matrix3f::Identity() * params_.rot_process_noise;
+        Q.block<3, 3>(3, 3) = Eigen::Matrix3f::Identity() * params_.trans_process_noise;
+
+        // Sigma_prior = H_raw_prev^{-1} + Q
+        Eigen::LDLT<Eigen::Matrix<float, 6, 6>> ldlt_h(H_raw_prev);
+        if (ldlt_h.info() != Eigen::Success || ldlt_h.vectorD().minCoeff() <= 0.0f) return;
+        const Eigen::Matrix<float, 6, 6> Sigma_prior =
+            ldlt_h.solve(Eigen::Matrix<float, 6, 6>::Identity()) + Q;
+
+        // Omega_prior = Sigma_prior^{-1}
+        Eigen::LDLT<Eigen::Matrix<float, 6, 6>> ldlt_s(Sigma_prior);
+        if (ldlt_s.info() != Eigen::Success || ldlt_s.vectorD().minCoeff() <= 0.0f) return;
+        Omega_prior_ = ldlt_s.solve(Eigen::Matrix<float, 6, 6>::Identity());
+
+        T_pred_ = T_pred;
+        has_prior_ = true;
+    }
+
+    /// @brief Apply the MAP prior to the normal equations for one optimizer iteration.
+    /// @param in    Linearized result after GICP (and optional degenerate regularization).
+    /// @param T_est Current pose estimate at this iteration.
+    /// @return Modified LinearizedResult with prior terms added.
+    LinearizedResult apply(const LinearizedResult& in, const Eigen::Isometry3f& T_est) const {
+        if (!is_active()) return in;
+
+        // e_prior = Log(T_pred^{-1} * T_est): deviation of the current estimate from the prediction
+        const Eigen::Vector<float, 6> e_prior = eigen_utils::lie::se3_log(T_pred_.inverse() * T_est);
+
+        LinearizedResult ret = in;
+        ret.H += Omega_prior_;
+        ret.b += Omega_prior_ * e_prior;
+        return ret;
+    }
+
+    bool is_active() const { return params_.enabled && has_prior_; }
+
+private:
+    MapPriorParams params_;
+    bool has_prior_ = false;
+    Eigen::Matrix<float, 6, 6> Omega_prior_ = Eigen::Matrix<float, 6, 6>::Zero();
+    Eigen::Isometry3f T_pred_ = Eigen::Isometry3f::Identity();
+};
+
+}  // namespace registration
+}  // namespace algorithms
+}  // namespace sycl_points

--- a/cpp/include/sycl_points/algorithms/registration/map_prior.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/map_prior.hpp
@@ -11,12 +11,18 @@ namespace registration {
 
 struct MapPriorParams {
     bool enabled = false;
-    /// @brief Process noise for each rotation axis (diagonal of Q).
-    ///        Larger value = weaker (more permissive) prior on rotation.
-    float rot_process_noise = 0.01f;
-    /// @brief Process noise for each translation axis (diagonal of Q).
-    ///        Larger value = weaker (more permissive) prior on translation.
-    float trans_process_noise = 0.01f;
+    /// @brief Velocity-proportional scale for rotation noise.
+    ///        Q_rot = max(rot_min_noise, rot_vel_scale * delta_rot^2)   [rad^2 / rad^2]
+    float rot_vel_scale = 1.0f;
+    /// @brief Velocity-proportional scale for translation noise.
+    ///        Q_trans = max(trans_min_noise, trans_vel_scale * delta_trans^2)   [m^2 / m^2]
+    float trans_vel_scale = 1.0f;
+    /// @brief Floor for rotation process noise [rad^2].
+    ///        Prevents over-constraining during sudden acceleration.
+    float rot_min_noise = 1e-3f;
+    /// @brief Floor for translation process noise [m^2].
+    ///        Prevents over-constraining during sudden acceleration.
+    float trans_min_noise = 1e-4f;
 };
 
 /// @brief MAP estimation prior using the previous frame's Hessian as the information matrix.
@@ -46,45 +52,82 @@ struct MapPriorParams {
 /// where e_prior = Log(T_pred^{-1} * T_est) is the deviation of the current estimate
 /// from the predicted pose on the SE(3) manifold.
 ///
+/// The process noise Q is computed adaptively from the predicted inter-frame motion:
+///
+///   Q_rot   = max(rot_min_noise,   rot_vel_scale   * delta_rot^2)
+///   Q_trans = max(trans_min_noise, trans_vel_scale * delta_trans^2)
+///
+/// This tightens the prior during slow/smooth motion and loosens it during fast motion,
+/// while the floor (min_noise) prevents over-constraining during sudden acceleration.
 /// In degenerate directions H_raw_prev is small, so Omega_prior is also small and
 /// nl_reg's Tikhonov penalty dominates — the two mechanisms are complementary.
 class MapPrior {
 public:
-    void set_params(const MapPriorParams& params) { params_ = params; }
+    void set_params(const MapPriorParams& params) {
+        params_ = params;
+        has_prior_ = false;
+        has_prev_pose_ = false;
+    }
 
     /// @brief Precompute Omega_prior and T_pred_inv for the upcoming align() call.
     ///        Call this once per frame, after motion prediction and before align().
+    ///        The previous pose is maintained internally: no external delta computation needed.
     /// @param H_raw_prev  Unregularized Hessian (RegistrationResult::H_raw) from the previous frame.
     /// @param T_pred      Predicted pose used as the initial guess for the current frame.
-    /// @param T_prev      Previous odometry pose (used to compute relative rotation for Adjoint).
-    void update(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_pred,
-                const Eigen::Isometry3f& T_prev) {
+    void update(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_pred) {
         has_prior_ = false;
         if (!params_.enabled) return;
 
-        // Rotate H_raw_prev into the current sensor frame using the rotation-only Adjoint.
-        // Ad = block_diag(R_rel, R_rel), R_rel = R_prev^T * R_pred
-        const Eigen::Matrix3f R_rel = T_prev.rotation().transpose() * T_pred.rotation();
+        // Relative rotation from the stored previous pose to T_pred (for Adjoint and delta_rot).
+        // On the first call has_prev_pose_ is false, so we use Identity (no rotation change).
+        Eigen::Matrix3f R_rel = Eigen::Matrix3f::Identity();
+        if (has_prev_pose_) {
+            R_rel = T_prev_.rotation().transpose() * T_pred.rotation();
+        }
+
+        // Per-axis inter-frame delta in T_pred body frame.
+        // Zero on first call; floor noise takes effect instead of velocity scaling.
+        Eigen::Vector3f delta_rot_body   = Eigen::Vector3f::Zero();
+        Eigen::Vector3f delta_trans_body = Eigen::Vector3f::Zero();
+        if (has_prev_pose_) {
+            delta_rot_body   = Eigen::AngleAxisf(R_rel).axis() * Eigen::AngleAxisf(R_rel).angle();
+            delta_trans_body = T_pred.rotation().transpose() * (T_pred.translation() - T_prev_.translation());
+        }
+
+        // Per-axis process noise Q: velocity-proportional with a floor for sudden acceleration.
+        //   Q_rot[i]   = max(rot_min_noise,   rot_vel_scale   * delta_rot_body[i]^2)
+        //   Q_trans[i] = max(trans_min_noise, trans_vel_scale * delta_trans_body[i]^2)
+        const Eigen::Vector3f q_rot =
+            (delta_rot_body.cwiseProduct(delta_rot_body) * params_.rot_vel_scale)
+                .cwiseMax(params_.rot_min_noise);
+        const Eigen::Vector3f q_trans =
+            (delta_trans_body.cwiseProduct(delta_trans_body) * params_.trans_vel_scale)
+                .cwiseMax(params_.trans_min_noise);
+
+        // Rotate H_raw_prev into the T_pred body frame using the rotation-only Adjoint.
+        // Ad = block_diag(R_rel, R_rel)
         Eigen::Matrix<float, 6, 6> Ad = Eigen::Matrix<float, 6, 6>::Zero();
         Ad.block<3, 3>(0, 0) = R_rel;
         Ad.block<3, 3>(3, 3) = R_rel;
         const Eigen::Matrix<float, 6, 6> H_curr = Ad.transpose() * H_raw_prev * Ad;
 
-        // R = Q^{-1}: diagonal, trivially computed from process-noise parameters
-        const float inv_rot = 1.0f / std::max(params_.rot_process_noise, 1e-6f);
-        const float inv_trans = 1.0f / std::max(params_.trans_process_noise, 1e-6f);
-        Eigen::Matrix<float, 6, 6> R = Eigen::Matrix<float, 6, 6>::Zero();
-        R.diagonal() << inv_rot, inv_rot, inv_rot, inv_trans, inv_trans, inv_trans;
+        // R = Q^{-1}: per-axis diagonal (safe because q >= min_noise > 0)
+        Eigen::Vector<float, 6> R_diag;
+        R_diag.head<3>() = q_rot.cwiseInverse();
+        R_diag.tail<3>() = q_trans.cwiseInverse();
+        const Eigen::Matrix<float, 6, 6> R = R_diag.asDiagonal();
 
         // Omega_prior = (H^{-1} + Q)^{-1} = R - R(H + R)^{-1}R
         // (H + R) is always PD since R is PD, so this is robust to singular H.
         Eigen::LDLT<Eigen::Matrix<float, 6, 6>> ldlt(H_curr + R);
+        T_prev_      = T_pred;
+        has_prev_pose_ = true;
         if (ldlt.info() != Eigen::Success) return;
         Omega_prior_ = R - R * ldlt.solve(R);
 
         // Precompute inverse once; reused every iteration inside apply() and prior_error()
         T_pred_inv_ = T_pred.inverse();
-        has_prior_ = true;
+        has_prior_  = true;
     }
 
     /// @brief Apply the MAP prior to the normal equations for one optimizer iteration.
@@ -118,9 +161,11 @@ public:
 
 private:
     MapPriorParams params_;
-    bool has_prior_ = false;
+    bool has_prior_     = false;
+    bool has_prev_pose_ = false;
     Eigen::Matrix<float, 6, 6> Omega_prior_ = Eigen::Matrix<float, 6, 6>::Zero();
     Eigen::Isometry3f T_pred_inv_ = Eigen::Isometry3f::Identity();
+    Eigen::Isometry3f T_prev_     = Eigen::Isometry3f::Identity();
 };
 
 }  // namespace registration

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -116,12 +116,11 @@ public:
 
     /// @brief Set the MAP prior state for the upcoming align() call.
     ///        Must be called once per frame, after motion prediction and before align().
+    ///        The previous pose and inter-frame delta are maintained internally by MapPrior.
     /// @param H_raw_prev  Unregularized Hessian (RegistrationResult::H_raw) from the previous frame.
     /// @param T_pred      Predicted pose used as the initial guess for the current frame.
-    /// @param T_prev      Previous odometry pose (used to compute relative rotation for Adjoint).
-    void set_map_prior_state(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_pred,
-                             const Eigen::Isometry3f& T_prev) {
-        this->map_prior_.update(H_raw_prev, T_pred, T_prev);
+    void set_map_prior_state(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_pred) {
+        this->map_prior_.update(H_raw_prev, T_pred);
     }
 
     /// @brief validate parameters

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -978,8 +978,8 @@ private:
             }
             const Eigen::Isometry3f new_T = result.T * Eigen::Isometry3f(eigen_utils::lie::se3_exp(delta));
 
-            const auto [new_gicp_error, inlier] = compute_error(source, target, this->neighbors_->at(0),
-                                                                 new_T.matrix(), robust_scale, rotation_robust_scale);
+            const auto [new_gicp_error, inlier] = compute_error(source, target, this->neighbors_->at(0), new_T.matrix(),
+                                                                robust_scale, rotation_robust_scale);
             const float new_error = new_gicp_error + this->map_prior_.prior_error(new_T);
 
             if (this->params_.verbose) {

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -111,6 +111,15 @@ public:
         this->linearized_on_device_ = std::make_shared<LinearizedDevice>(this->queue_);
 
         this->degenerate_reg_.set_params(this->params_.degenerate_reg);
+        this->map_prior_.set_params(this->params_.map_prior);
+    }
+
+    /// @brief Set the MAP prior state for the upcoming align() call.
+    ///        Must be called once per frame, after motion prediction and before align().
+    /// @param H_raw_prev  Unregularized Hessian (RegistrationResult::H_raw) from the previous frame.
+    /// @param T_pred      Predicted pose used as the initial guess for the current frame.
+    void set_map_prior_state(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_pred) {
+        this->map_prior_.update(H_raw_prev, T_pred);
     }
 
     /// @brief validate parameters
@@ -245,22 +254,25 @@ public:
                 result.H_raw = linearized_result.H;
                 result.b_raw = linearized_result.b;
 
-                // Regularization
+                // Regularization: nl_reg (Tikhonov penalty for degenerate directions)
                 const LinearizedResult regularized_result =
                     this->degenerate_reg_.regularize(linearized_result, result.T, T_initial);
+
+                // MAP prior: adds Omega_prior to H and b to anchor the solution near T_pred
+                const LinearizedResult prior_result = this->map_prior_.apply(regularized_result, result.T);
 
                 // Optimize on Host
                 switch (this->params_.optimization_method) {
                     case OptimizationMethod::LEVENBERG_MARQUARDT:
-                        this->optimize_levenberg_marquardt(source, target, result, regularized_result, lm_lambda, iter,
+                        this->optimize_levenberg_marquardt(source, target, result, prior_result, lm_lambda, iter,
                                                            robust_scale, rotation_robust_scale);
                         break;
                     case OptimizationMethod::POWELL_DOGLEG:
-                        this->optimize_powell_dogleg(source, target, result, regularized_result, trust_region_radius,
-                                                     iter, robust_scale, rotation_robust_scale);
+                        this->optimize_powell_dogleg(source, target, result, prior_result, trust_region_radius, iter,
+                                                     robust_scale, rotation_robust_scale);
                         break;
                     case OptimizationMethod::GAUSS_NEWTON:
-                        this->optimize_gauss_newton(result, regularized_result, iter);
+                        this->optimize_gauss_newton(result, prior_result, iter);
                         break;
                 }
                 if (result.converged) {
@@ -339,6 +351,7 @@ private:
     std::shared_ptr<LinearizedDevice> linearized_on_device_ = nullptr;
 
     DegenerateRegularization degenerate_reg_;
+    MapPrior map_prior_;
     float genz_alpha_ = 1.0f;
     AndersonAcceleration anderson_acc_;
 

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -118,8 +118,10 @@ public:
     ///        Must be called once per frame, after motion prediction and before align().
     /// @param H_raw_prev  Unregularized Hessian (RegistrationResult::H_raw) from the previous frame.
     /// @param T_pred      Predicted pose used as the initial guess for the current frame.
-    void set_map_prior_state(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_pred) {
-        this->map_prior_.update(H_raw_prev, T_pred);
+    /// @param T_prev      Previous odometry pose (used to compute relative rotation for Adjoint).
+    void set_map_prior_state(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_pred,
+                             const Eigen::Isometry3f& T_prev) {
+        this->map_prior_.update(H_raw_prev, T_pred, T_prev);
     }
 
     /// @brief validate parameters
@@ -904,11 +906,13 @@ private:
         if (this->params_.optimization_method == OptimizationMethod::GAUSS_NEWTON) {
             std::tie(baseline_error, baseline_inlier) = compute_error(
                 source, target, this->neighbors_->at(0), result.T.matrix(), robust_scale, rotation_robust_scale);
+            baseline_error += this->map_prior_.prior_error(result.T);
         }
 
         const Eigen::Isometry3f T_anderson = this->anderson_acc_.apply(result.T, T_initial);
-        const auto [anderson_error, anderson_inlier] = compute_error(
+        const auto [anderson_gicp_error, anderson_inlier] = compute_error(
             source, target, this->neighbors_->at(0), T_anderson.matrix(), robust_scale, rotation_robust_scale);
+        const float anderson_error = anderson_gicp_error + this->map_prior_.prior_error(T_anderson);
 
         const bool accepted = anderson_error <= baseline_error;
         if (this->params_.verbose) {
@@ -974,8 +978,9 @@ private:
             }
             const Eigen::Isometry3f new_T = result.T * Eigen::Isometry3f(eigen_utils::lie::se3_exp(delta));
 
-            const auto [new_error, inlier] = compute_error(source, target, this->neighbors_->at(0), new_T.matrix(),
-                                                           robust_scale, rotation_robust_scale);
+            const auto [new_gicp_error, inlier] = compute_error(source, target, this->neighbors_->at(0),
+                                                                 new_T.matrix(), robust_scale, rotation_robust_scale);
+            const float new_error = new_gicp_error + this->map_prior_.prior_error(new_T);
 
             if (this->params_.verbose) {
                 std::cout << "iter [" << iter << "] ";
@@ -1104,8 +1109,9 @@ private:
         }
 
         const Eigen::Isometry3f new_T = result.T * Eigen::Isometry3f(eigen_utils::lie::se3_exp(p_dl));
-        const auto [new_error, inlier] =
+        const auto [new_gicp_error, inlier] =
             compute_error(source, target, this->neighbors_->at(0), new_T.matrix(), robust_scale, rotation_robust_scale);
+        const float new_error = new_gicp_error + this->map_prior_.prior_error(new_T);
 
         const float actual_reduction = current_error - new_error;
         const float rho = actual_reduction / predicted_reduction;

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -116,11 +116,12 @@ public:
 
     /// @brief Set the MAP prior state for the upcoming align() call.
     ///        Must be called once per frame, after motion prediction and before align().
-    ///        The previous pose and inter-frame delta are maintained internally by MapPrior.
-    /// @param H_raw_prev  Unregularized Hessian (RegistrationResult::H_raw) from the previous frame.
-    /// @param T_pred      Predicted pose used as the initial guess for the current frame.
-    void set_map_prior_state(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_pred) {
-        this->map_prior_.update(H_raw_prev, T_pred);
+    /// @param H_raw_prev   Unregularized Hessian (RegistrationResult::H_raw) from the previous frame.
+    /// @param T_opt_prev   Optimized pose of the previous frame (the frame at which H_raw_prev was built).
+    /// @param T_pred       Predicted pose used as the initial guess for the current frame.
+    void set_map_prior_state(const Eigen::Matrix<float, 6, 6>& H_raw_prev, const Eigen::Isometry3f& T_opt_prev,
+                             const Eigen::Isometry3f& T_pred) {
+        this->map_prior_.update(H_raw_prev, T_opt_prev, T_pred);
     }
 
     /// @brief validate parameters

--- a/cpp/include/sycl_points/algorithms/registration/registration_params.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration_params.hpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "sycl_points/algorithms/registration/degenerate_regularization.hpp"
+#include "sycl_points/algorithms/registration/map_prior.hpp"
 #include "sycl_points/algorithms/registration/factor.hpp"
 #include "sycl_points/algorithms/robust/robust.hpp"
 
@@ -104,6 +105,7 @@ struct RegistrationParams {
     OptimizationMethod optimization_method = OptimizationMethod::GAUSS_NEWTON;  // Optimization method selector
 
     DegenerateRegularizationParams degenerate_reg;  // Degenerate Regularization
+    MapPriorParams map_prior;                        // MAP estimation prior using previous-frame Hessian
 
     bool verbose = false;  // If true, print debug messages
 };

--- a/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
@@ -451,6 +451,12 @@ private:
                                                       this->dt_, this->reg_result_, this->registrated_);
         }
 
+        // Provide the previous frame's unregularized Hessian as a MAP prior so the optimizer
+        // stays anchored to init_T in directions with weak geometric constraints.
+        if (this->registrated_) {
+            this->registration_pipeline_->registration()->set_map_prior_state(this->reg_result_->H_raw, init_T);
+        }
+
         algorithms::registration::Registration::ExecutionOptions options;
         options.dt = this->dt_;
         options.prev_pose = this->odom_.matrix();

--- a/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
@@ -454,8 +454,7 @@ private:
         // Provide the previous frame's unregularized Hessian as a MAP prior so the optimizer
         // stays anchored to init_T in directions with weak geometric constraints.
         if (this->registrated_) {
-            this->registration_pipeline_->registration()->set_map_prior_state(this->reg_result_->H_raw, init_T,
-                                                                              this->odom_);
+            this->registration_pipeline_->registration()->set_map_prior_state(this->reg_result_->H_raw, init_T);
         }
 
         algorithms::registration::Registration::ExecutionOptions options;

--- a/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
@@ -454,8 +454,8 @@ private:
         // Provide the previous frame's unregularized Hessian as a MAP prior so the optimizer
         // stays anchored to init_T in directions with weak geometric constraints.
         if (this->registrated_) {
-            this->registration_pipeline_->registration()->set_map_prior_state(
-                this->reg_result_->H_raw, init_T, this->odom_);
+            this->registration_pipeline_->registration()->set_map_prior_state(this->reg_result_->H_raw, init_T,
+                                                                              this->odom_);
         }
 
         algorithms::registration::Registration::ExecutionOptions options;

--- a/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
@@ -454,7 +454,10 @@ private:
         // Provide the previous frame's unregularized Hessian as a MAP prior so the optimizer
         // stays anchored to init_T in directions with weak geometric constraints.
         if (this->registrated_) {
-            this->registration_pipeline_->registration()->set_map_prior_state(this->reg_result_->H_raw, init_T);
+            // odom_ is the optimized pose of the previous frame, which is the frame at which
+            // H_raw was built. Passing it explicitly ensures the Adjoint rotation is correct.
+            this->registration_pipeline_->registration()->set_map_prior_state(this->reg_result_->H_raw, this->odom_,
+                                                                              init_T);
         }
 
         algorithms::registration::Registration::ExecutionOptions options;

--- a/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
@@ -454,7 +454,8 @@ private:
         // Provide the previous frame's unregularized Hessian as a MAP prior so the optimizer
         // stays anchored to init_T in directions with weak geometric constraints.
         if (this->registrated_) {
-            this->registration_pipeline_->registration()->set_map_prior_state(this->reg_result_->H_raw, init_T);
+            this->registration_pipeline_->registration()->set_map_prior_state(
+                this->reg_result_->H_raw, init_T, this->odom_);
         }
 
         algorithms::registration::Registration::ExecutionOptions options;

--- a/ros2/sycl_points_ros2/config/lidar_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_odometry.yaml
@@ -148,6 +148,10 @@ lidar_odometry_node:
     registration/criteria/translation: 1.0e-3  # [m]
     registration/criteria/rotation: 1.0e-6     # [rad]
 
+    registration/map_prior/enabled: true
+    registration/map_prior/rot_process_noise: 0.01
+    registration/map_prior/trans_process_noise: 0.01
+
     # Deskew pointcloud without IMU.
     # Automatically disabled when imu/deskew/enable is true.
     registration/velocity_update/enable: true

--- a/ros2/sycl_points_ros2/config/lidar_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_odometry.yaml
@@ -149,8 +149,10 @@ lidar_odometry_node:
     registration/criteria/rotation: 1.0e-6     # [rad]
 
     registration/map_prior/enabled: true
-    registration/map_prior/rot_process_noise: 1.0e-2    # [rad^2]
-    registration/map_prior/trans_process_noise: 1.0e-2  # [m^2]
+    registration/map_prior/rot_vel_scale: 1.0        # Q_rot   = max(rot_min_noise,   rot_vel_scale   * delta_rot^2)
+    registration/map_prior/trans_vel_scale: 1.0      # Q_trans = max(trans_min_noise, trans_vel_scale * delta_trans^2)
+    registration/map_prior/rot_min_noise: 1.0e-3     # floor [rad^2]: prevents over-constraining on sudden acceleration
+    registration/map_prior/trans_min_noise: 1.0e-4   # floor [m^2]:   prevents over-constraining on sudden acceleration
 
     # Deskew pointcloud without IMU.
     # Automatically disabled when imu/deskew/enable is true.

--- a/ros2/sycl_points_ros2/config/lidar_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_odometry.yaml
@@ -148,7 +148,7 @@ lidar_odometry_node:
     registration/criteria/translation: 1.0e-3  # [m]
     registration/criteria/rotation: 1.0e-6     # [rad]
 
-    registration/map_prior/enabled: true
+    registration/map_prior/enabled: false            # EXPERIMENTAL
     registration/map_prior/rot_vel_scale: 1.0        # Q_rot   = max(rot_min_noise,   rot_vel_scale   * delta_rot^2)
     registration/map_prior/trans_vel_scale: 1.0      # Q_trans = max(trans_min_noise, trans_vel_scale * delta_trans^2)
     registration/map_prior/rot_min_noise: 1.0e-3     # floor [rad^2]: prevents over-constraining on sudden acceleration

--- a/ros2/sycl_points_ros2/config/lidar_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_odometry.yaml
@@ -149,8 +149,8 @@ lidar_odometry_node:
     registration/criteria/rotation: 1.0e-6     # [rad]
 
     registration/map_prior/enabled: true
-    registration/map_prior/rot_process_noise: 0.01
-    registration/map_prior/trans_process_noise: 0.01
+    registration/map_prior/rot_process_noise: 1.0e-2    # [rad^2]
+    registration/map_prior/trans_process_noise: 1.0e-2  # [m^2]
 
     # Deskew pointcloud without IMU.
     # Automatically disabled when imu/deskew/enable is true.

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
@@ -333,8 +333,8 @@ inline pipeline::lidar_odometry::Parameters declare_lidar_odometry_parameters(rc
         {
             auto& map_prior = solver.map_prior;
             map_prior.enabled = node->declare_parameter<bool>("registration/map_prior/enabled", map_prior.enabled);
-            map_prior.rot_process_noise = node->declare_parameter<double>(
-                "registration/map_prior/rot_process_noise", map_prior.rot_process_noise);
+            map_prior.rot_process_noise = node->declare_parameter<double>("registration/map_prior/rot_process_noise",
+                                                                          map_prior.rot_process_noise);
             map_prior.trans_process_noise = node->declare_parameter<double>(
                 "registration/map_prior/trans_process_noise", map_prior.trans_process_noise);
         }

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
@@ -329,6 +329,15 @@ inline pipeline::lidar_odometry::Parameters declare_lidar_odometry_parameters(rc
                 "registration/degenerate_regularization/nl_reg/rot_eigenvalue_threshold",
                 degenerate_reg.rot_eigenvalue_threshold);
         }
+        // MAP Prior
+        {
+            auto& map_prior = solver.map_prior;
+            map_prior.enabled = node->declare_parameter<bool>("registration/map_prior/enabled", map_prior.enabled);
+            map_prior.rot_process_noise = node->declare_parameter<double>(
+                "registration/map_prior/rot_process_noise", map_prior.rot_process_noise);
+            map_prior.trans_process_noise = node->declare_parameter<double>(
+                "registration/map_prior/trans_process_noise", map_prior.trans_process_noise);
+        }
     }
 
     // IMU

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
@@ -333,10 +333,14 @@ inline pipeline::lidar_odometry::Parameters declare_lidar_odometry_parameters(rc
         {
             auto& map_prior = solver.map_prior;
             map_prior.enabled = node->declare_parameter<bool>("registration/map_prior/enabled", map_prior.enabled);
-            map_prior.rot_process_noise = node->declare_parameter<double>("registration/map_prior/rot_process_noise",
-                                                                          map_prior.rot_process_noise);
-            map_prior.trans_process_noise = node->declare_parameter<double>(
-                "registration/map_prior/trans_process_noise", map_prior.trans_process_noise);
+            map_prior.rot_vel_scale = node->declare_parameter<double>("registration/map_prior/rot_vel_scale",
+                                                                      map_prior.rot_vel_scale);
+            map_prior.trans_vel_scale = node->declare_parameter<double>("registration/map_prior/trans_vel_scale",
+                                                                        map_prior.trans_vel_scale);
+            map_prior.rot_min_noise = node->declare_parameter<double>("registration/map_prior/rot_min_noise",
+                                                                      map_prior.rot_min_noise);
+            map_prior.trans_min_noise = node->declare_parameter<double>("registration/map_prior/trans_min_noise",
+                                                                        map_prior.trans_min_noise);
         }
     }
 


### PR DESCRIPTION
Introduces MapPrior, which anchors the GICP optimizer to the motion-
predicted pose by adding a Gaussian prior N(T_pred, Omega_prior^{-1})
to the normal equations each iteration:

  H_total = H_gicp + Omega_prior
  b_total = b_gicp + Omega_prior * e_prior

where Omega_prior = (H_raw_prev^{-1} + Q)^{-1} and
e_prior = Log(T_pred^{-1} * T_est).

The process-noise matrix Q prevents the prior from over-constraining
well-observed directions.  In degenerate directions H_raw_prev is small
so Omega_prior is also small and the existing nl_reg Tikhonov penalty
remains dominant — the two mechanisms are complementary.

New file: registration/map_prior.hpp (MapPrior + MapPriorParams)
Changed:  registration_params.hpp — MapPriorParams member added
Changed:  registration.hpp — map_prior_ member, set_map_prior_state(),
          and prior_result applied in the optimization loop
Changed:  lidar_odometry.hpp — set_map_prior_state() called before
          each align() with the previous frame's H_raw and init_T

https://claude.ai/code/session_012WYNaN1eEtk1nymhNrLanF