### PR TITLE
refactor(lio): remove estimate_extrinsic and shrink IEKF state to 15-DOF (#168)

### DIFF
--- a/cpp/include/sycl_points/algorithms/imu/imu_factor.hpp
+++ b/cpp/include/sycl_points/algorithms/imu/imu_factor.hpp
@@ -8,29 +8,28 @@
 // IMU factor for tightly-coupled LiDAR-IMU Odometry (LIO)
 //
 // This header provides:
-//   - State        : 21-DOF navigation state (position, SO(3) rotation,
-//                    velocity, accelerometer bias, gyroscope bias,
-//                    extrinsic rotation offset_R_L_I, extrinsic translation
-//                    offset_T_L_I)
+//   - State        : 15-DOF navigation state (position, SO(3) rotation,
+//                    velocity, accelerometer bias, gyroscope bias)
 //   - compute_imu_hessian_gradient()
 //                  : Linearises the IMU prior cost around a given operating
 //                    point for use in the LIO Gauss-Newton optimisation loop.
 //
-// State-vector ordering (21-D error-state / tangent-space):
+// State-vector ordering (15-D error-state / tangent-space):
 //   indices  0– 2  position           (3-D, world frame)
 //   indices  3– 5  rotation           (3-D, so(3) tangent, right-perturbation)
 //   indices  6– 8  velocity           (3-D, world frame)
 //   indices  9–11  accelerometer bias (3-D, body frame)
 //   indices 12–14  gyroscope bias     (3-D, body frame)
-//   indices 15–17  extrinsic rotation (3-D, so(3) tangent, right-perturbation)
-//   indices 18–20  extrinsic translation (3-D)
+//
+// The LiDAR-IMU extrinsic is no longer part of the optimised state.  It is
+// held as a static calibration value at the pipeline level (params_.imu.T_imu_to_lidar).
 // ---------------------------------------------------------------------------
 
 namespace sycl_points {
 namespace imu {
 
 // ---------------------------------------------------------------------------
-// State  – full 21-DOF navigation state
+// State  – full 15-DOF navigation state
 // ---------------------------------------------------------------------------
 
 /// @brief Full navigation state used by the LIO optimisation back-end.
@@ -39,35 +38,23 @@ namespace imu {
 /// all perturbations are expressed in the 3-D tangent space (Lie algebra so(3))
 /// using a right-perturbation convention.
 ///
-/// offset_R_L_I and offset_T_L_I store the LiDAR-IMU extrinsic calibration:
-///   p_lidar = offset_R_L_I * p_imu + offset_T_L_I
-///
-/// When estimate_extrinsic = false these fields are copied from the fixed
-/// params but never updated (the corresponding P_post blocks are pinned to
-/// a large value so the optimiser effectively treats them as constant).
-///
 /// The named index constants (kIdx*) identify the start of each 3-D block
-/// in the 21-D error-state vector and should be used instead of magic numbers.
+/// in the 15-D error-state vector and should be used instead of magic numbers.
 struct State {
-    /// Start indices of each 3-D block in the 21-D error-state / tangent vector.
+    /// Start indices of each 3-D block in the 15-D error-state / tangent vector.
     static constexpr int kIdxPos = 0;       ///< position           (indices  0– 2)
     static constexpr int kIdxRot = 3;       ///< rotation           (indices  3– 5)
     static constexpr int kIdxVel = 6;       ///< velocity           (indices  6– 8)
     static constexpr int kIdxAccBias = 9;   ///< accel bias         (indices  9–11)
     static constexpr int kIdxGyrBias = 12;  ///< gyro bias          (indices 12–14)
-    static constexpr int kIdxExRot = 15;    ///< extrinsic rotation (indices 15–17)
-    static constexpr int kIdxExTrans = 18;  ///< extrinsic transl.  (indices 18–20)
 
-    static constexpr int kDOF = 21;
+    static constexpr int kDOF = 15;
 
     Eigen::Vector3f position = Eigen::Vector3f::Zero();      ///< World-frame position [m]
     Eigen::Matrix3f rotation = Eigen::Matrix3f::Identity();  ///< Body-to-world rotation R ∈ SO(3)
     Eigen::Vector3f velocity = Eigen::Vector3f::Zero();      ///< World-frame velocity [m/s]
     Eigen::Vector3f accel_bias = Eigen::Vector3f::Zero();    ///< Accelerometer bias [m/s²]
     Eigen::Vector3f gyro_bias = Eigen::Vector3f::Zero();     ///< Gyroscope bias [rad/s]
-
-    Eigen::Matrix3f offset_R_L_I = Eigen::Matrix3f::Identity();  ///< Extrinsic rotation (IMU→LiDAR) ∈ SO(3)
-    Eigen::Vector3f offset_T_L_I = Eigen::Vector3f::Zero();      ///< Extrinsic translation (IMU→LiDAR) [m]
 
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
@@ -76,13 +63,13 @@ struct State {
 // compute_manifold_residual
 // ---------------------------------------------------------------------------
 
-/// @brief Compute the 21-D manifold residual r = x_op ⊖ x_pred.
+/// @brief Compute the 15-D manifold residual r = x_op ⊖ x_pred.
 ///
 /// Vector quantities use plain subtraction; SO(3) quantities use the group
 /// logarithm (right-perturbation convention).  Shared by both
 /// compute_imu_hessian_gradient() and compute_imu_gradient().
-inline Eigen::Matrix<float, 21, 1> compute_manifold_residual(const State& x_pred, const State& x_op) {
-    Eigen::Matrix<float, 21, 1> r;
+inline Eigen::Matrix<float, 15, 1> compute_manifold_residual(const State& x_pred, const State& x_op) {
+    Eigen::Matrix<float, 15, 1> r;
 
     r.segment<3>(State::kIdxPos) = x_op.position - x_pred.position;
 
@@ -93,12 +80,6 @@ inline Eigen::Matrix<float, 21, 1> compute_manifold_residual(const State& x_pred
     r.segment<3>(State::kIdxVel) = x_op.velocity - x_pred.velocity;
     r.segment<3>(State::kIdxAccBias) = x_op.accel_bias - x_pred.accel_bias;
     r.segment<3>(State::kIdxGyrBias) = x_op.gyro_bias - x_pred.gyro_bias;
-
-    const Eigen::Matrix3f R_ex_rel = x_pred.offset_R_L_I.transpose() * x_op.offset_R_L_I;
-    const Eigen::Vector4f q_ex_rel = eigen_utils::geometry::rotation_matrix_to_quaternion(R_ex_rel);
-    r.segment<3>(State::kIdxExRot) = eigen_utils::lie::so3_log(q_ex_rel);
-
-    r.segment<3>(State::kIdxExTrans) = x_op.offset_T_L_I - x_pred.offset_T_L_I;
 
     return r;
 }
@@ -117,11 +98,6 @@ inline Eigen::Matrix<float, 21, 1> compute_manifold_residual(const State& x_pred
 /// where  r = x_op ⊖ x_pred  is computed on the state manifold (SO(3)
 /// part uses the group logarithm; all other parts use plain subtraction).
 ///
-/// The 21-D P_pred has:
-///   - Upper-left 15×15 block: IMU preintegration covariance (propagated).
-///   - Lower-right 6×6 block:  extrinsic prior from the previous frame's
-///     posterior (passed by the caller from P_post).
-///
 /// Linearising around x_op gives the Gauss-Newton normal equations
 ///
 ///   H_imu · δx = −b_imu
@@ -132,18 +108,18 @@ inline Eigen::Matrix<float, 21, 1> compute_manifold_residual(const State& x_pred
 ///
 /// @param x_pred   IMU-preintegration prediction (prior mean).
 /// @param x_op     Current Gauss-Newton operating point (linearisation point).
-/// @param P_pred   21×21 prior covariance.  Must be symmetric positive-definite.
-/// @param[out] H_imu  21×21 information matrix  (= P_pred⁻¹).
-/// @param[out] b_imu  21×1  gradient vector     (= H_imu · r).
+/// @param P_pred   15×15 prior covariance.  Must be symmetric positive-definite.
+/// @param[out] H_imu  15×15 information matrix  (= P_pred⁻¹).
+/// @param[out] b_imu  15×1  gradient vector     (= H_imu · r).
 /// @return true on success; false if P_pred is ill-conditioned (H_imu and
 ///         b_imu are set to zero in that case).
 inline bool compute_imu_hessian_gradient(const State& x_pred, const State& x_op,
-                                         const Eigen::Matrix<float, 21, 21>& P_pred,
-                                         Eigen::Matrix<float, 21, 21>& H_imu, Eigen::Matrix<float, 21, 1>& b_imu) {
+                                         const Eigen::Matrix<float, 15, 15>& P_pred,
+                                         Eigen::Matrix<float, 15, 15>& H_imu, Eigen::Matrix<float, 15, 1>& b_imu) {
     // ------------------------------------------------------------------
     // 1. Information matrix  H_imu = P_pred⁻¹
     // ------------------------------------------------------------------
-    Eigen::LDLT<Eigen::Matrix<float, 21, 21>> ldlt(P_pred);
+    Eigen::LDLT<Eigen::Matrix<float, 15, 15>> ldlt(P_pred);
     if (ldlt.info() != Eigen::Success || ldlt.vectorD().minCoeff() <= 0.0f) {
         H_imu.setZero();
         b_imu.setZero();
@@ -153,9 +129,9 @@ inline bool compute_imu_hessian_gradient(const State& x_pred, const State& x_op,
     ldlt.solveInPlace(H_imu);
 
     // ------------------------------------------------------------------
-    // 2. Manifold residual  r = x_op ⊖ x_pred  (21×1)
+    // 2. Manifold residual  r = x_op ⊖ x_pred  (15×1)
     // ------------------------------------------------------------------
-    const Eigen::Matrix<float, 21, 1> r = compute_manifold_residual(x_pred, x_op);
+    const Eigen::Matrix<float, 15, 1> r = compute_manifold_residual(x_pred, x_op);
 
     // ------------------------------------------------------------------
     // 3. Gradient  b_imu = P_pred⁻¹ · r  (via LDLT for numerical stability)
@@ -169,14 +145,14 @@ inline bool compute_imu_hessian_gradient(const State& x_pred, const State& x_op,
 /// Inner-loop companion to compute_imu_hessian_gradient().  P_pred is constant
 /// within a single Gauss-Newton frame, so H_imu = P_pred⁻¹ need only be
 /// computed once.  Subsequent iterations reuse H_imu and only update b_imu as
-/// x_op changes — this avoids repeated LDLT factorisation of the 21×21 matrix.
+/// x_op changes — this avoids repeated LDLT factorisation of the 15×15 matrix.
 ///
 /// @param x_pred  IMU-preintegration prediction (prior mean, fixed for the frame).
 /// @param x_op    Current Gauss-Newton operating point (linearisation point).
-/// @param H_imu   21×21 information matrix from compute_imu_hessian_gradient().
-/// @param[out] b_imu  21×1 updated gradient vector (= H_imu · r).
-inline void compute_imu_gradient(const State& x_pred, const State& x_op, const Eigen::Matrix<float, 21, 21>& H_imu,
-                                 Eigen::Matrix<float, 21, 1>& b_imu) {
+/// @param H_imu   15×15 information matrix from compute_imu_hessian_gradient().
+/// @param[out] b_imu  15×1 updated gradient vector (= H_imu · r).
+inline void compute_imu_gradient(const State& x_pred, const State& x_op, const Eigen::Matrix<float, 15, 15>& H_imu,
+                                 Eigen::Matrix<float, 15, 1>& b_imu) {
     b_imu = H_imu * compute_manifold_residual(x_pred, x_op);
 }
 

--- a/cpp/include/sycl_points/algorithms/lio/lio_registration.hpp
+++ b/cpp/include/sycl_points/algorithms/lio/lio_registration.hpp
@@ -11,27 +11,25 @@
 //
 // Provides the building blocks for the LIO Gauss-Newton optimisation loop:
 //
-//   1. add_icp_factor()   — embed the 6×6 ICP linearization into the 21-DOF
+//   1. add_icp_factor()   — embed the 6×6 ICP linearization into the 15-DOF
 //                           normal equation, handling the perturbation-convention
 //                           mismatch between ICP (body-frame δt) and LIO
 //                           (world-frame δp).
-//   2. add_imu_factor()   — add the 21×21 IMU prior Hessian/gradient.
+//   2. add_imu_factor()   — add the 15×15 IMU prior Hessian/gradient.
 //   3. solve_ldlt()       — solve H·δx = −b and optionally compute P_post = H⁻¹.
-//   4. retract()          — apply a 21-D tangent-space update to a State,
-//                           respecting SO(3) for the two rotation components.
+//   4. retract()          — apply a 15-D tangent-space update to a State,
+//                           respecting SO(3) for the rotation component.
 //   5. imu_to_lidar_jacobian() / transform_covariance_*()
 //                         — convert the 15-D IMU-frame preintegration covariance
 //                           to the 15-D LiDAR-frame used by the optimiser, and
 //                           back again for the next IMU reset window.
 //
-// State-vector ordering (21-D, same as imu_factor.hpp):
+// State-vector ordering (15-D, same as imu_factor.hpp):
 //   indices  0– 2  position           δp   (world frame)
 //   indices  3– 5  rotation           δφ   (so(3) tangent, right-perturbation)
 //   indices  6– 8  velocity           δv   (world frame)
 //   indices  9–11  accelerometer bias δb_a (body frame)
 //   indices 12–14  gyroscope bias     δb_g (body frame)
-//   indices 15–17  extrinsic rotation δφ_ex (so(3) tangent, right-perturbation)
-//   indices 18–20  extrinsic transl.  δt_ex
 //
 // ICP 6-DOF delta ordering (registration.hpp convention):
 //   indices  0– 2  rotation    δω  (body frame)
@@ -52,7 +50,7 @@ namespace lio {
 
 /// @brief Accumulated Gauss-Newton normal equation for one LIO iteration.
 ///
-/// Holds the combined 21×21 Hessian H and 21×1 gradient b that result from
+/// Holds the combined 15×15 Hessian H and 15×1 gradient b that result from
 /// accumulating one or more factors (ICP geometry, IMU prior).  After all
 /// factors have been added, pass H and b to solve_ldlt() to obtain the state
 /// update δx and the posterior covariance P_post = H⁻¹.
@@ -67,8 +65,8 @@ namespace lio {
 ///
 /// Diagnostic fields (error_icp, error_imu, inlier) are for logging only.
 struct LIOLinearizedResult {
-    Eigen::Matrix<float, 21, 21> H = Eigen::Matrix<float, 21, 21>::Zero();  ///< Combined Hessian
-    Eigen::Matrix<float, 21, 1> b = Eigen::Matrix<float, 21, 1>::Zero();    ///< Combined gradient
+    Eigen::Matrix<float, 15, 15> H = Eigen::Matrix<float, 15, 15>::Zero();  ///< Combined Hessian
+    Eigen::Matrix<float, 15, 1> b = Eigen::Matrix<float, 15, 1>::Zero();    ///< Combined gradient
     float error_icp = 0.0f;                                                 ///< Accumulated ICP cost (for diagnostics)
     float error_imu = 0.0f;                                                 ///< IMU prior cost (for diagnostics)
     uint32_t inlier = 0;                                                    ///< Number of valid ICP correspondences
@@ -80,7 +78,7 @@ struct LIOLinearizedResult {
 // add_icp_factor
 // ---------------------------------------------------------------------------
 
-/// @brief Embed an ICP 6×6 Hessian/gradient into the LIO 21×21 normal equation.
+/// @brief Embed an ICP 6×6 Hessian/gradient into the LIO 15×15 normal equation.
 ///
 /// ## Perturbation-convention mismatch and how it is resolved
 ///
@@ -92,7 +90,7 @@ struct LIOLinearizedResult {
 ///   - δω : rotation increment (body frame)
 ///   - δt : translation increment (body frame) → p_new = p + R · δt
 ///
-/// The LIO 21-D error-state uses:
+/// The LIO 15-D error-state uses:
 ///   - δφ : rotation increment (body frame)  — same as ICP δω ✓
 ///   - δp : position increment (world frame) — p_new = p + δp ✗
 ///
@@ -108,9 +106,6 @@ struct LIOLinearizedResult {
 ///   H_lio[p,p]   = R · H_icp[t,t] · Rᵀ
 ///   H_lio[p,φ]   = R · H_icp[t,ω]         (φ stays in body frame)
 ///   H_lio[φ,p]   = H_icp[ω,t] · Rᵀ
-///
-/// The extrinsic blocks (rows/columns 15–20) of H and b are unaffected because
-/// the ICP measurement depends only on the LiDAR-frame pose, not the extrinsic.
 ///
 /// @param result        LIO normal equation to accumulate into.
 /// @param icp           ICP linearization from registration::Registration.
@@ -138,20 +133,18 @@ inline void add_icp_factor(LIOLinearizedResult& result, const registration::Line
 // add_imu_factor
 // ---------------------------------------------------------------------------
 
-/// @brief Add the IMU prior 21×21 Hessian/gradient into the LIO normal equation.
+/// @brief Add the IMU prior 15×15 Hessian/gradient into the LIO normal equation.
 ///
-/// The IMU factor is already expressed in the LIO 21-D state ordering
+/// The IMU factor is already expressed in the LIO 15-D state ordering
 /// (computed by compute_imu_hessian_gradient()), so no index permutation is
-/// needed.  When extrinsic estimation is enabled the caller is responsible for
-/// adding the cross-terms between the navigation state and the extrinsic blocks
-/// before calling this function.
+/// needed.
 ///
 /// @param result  LIO normal equation to accumulate into.
-/// @param H_imu   21×21 IMU information matrix from compute_imu_hessian_gradient().
-/// @param b_imu   21×1  IMU gradient vector   from compute_imu_hessian_gradient().
+/// @param H_imu   15×15 IMU information matrix from compute_imu_hessian_gradient().
+/// @param b_imu   15×1  IMU gradient vector   from compute_imu_hessian_gradient().
 /// @param error   Optional scalar IMU prior cost for logging (default 0).
-inline void add_imu_factor(LIOLinearizedResult& result, const Eigen::Matrix<float, 21, 21>& H_imu,
-                           const Eigen::Matrix<float, 21, 1>& b_imu, float error = 0.0f) {
+inline void add_imu_factor(LIOLinearizedResult& result, const Eigen::Matrix<float, 15, 15>& H_imu,
+                           const Eigen::Matrix<float, 15, 1>& b_imu, float error = 0.0f) {
     result.H += H_imu;
     result.b += b_imu;
     result.error_imu = error;
@@ -171,15 +164,15 @@ inline void add_imu_factor(LIOLinearizedResult& result, const Eigen::Matrix<floa
 /// preintegration window (passed to IMUPreintegration::reset() after
 /// converting back to IMU frame via transform_covariance_lidar_to_imu()).
 ///
-/// @param[in]  H      Combined LIO Hessian (21×21), may include a Levenberg–
+/// @param[in]  H      Combined LIO Hessian (15×15), may include a Levenberg–
 ///                    Marquardt damping term λI added by the caller.
-/// @param[in]  b      Combined LIO gradient (21×1).
-/// @param[out] delta  21-D state update δx on success; zero on failure.
+/// @param[in]  b      Combined LIO gradient (15×1).
+/// @param[out] delta  15-D state update δx on success; zero on failure.
 /// @param[out] P_post Posterior covariance H⁻¹ (optional, pass nullptr to skip).
 /// @return true on success; false if H is numerically ill-conditioned.
-inline bool solve_ldlt(const Eigen::Matrix<float, 21, 21>& H, const Eigen::Matrix<float, 21, 1>& b,
-                       Eigen::Matrix<float, 21, 1>& delta, Eigen::Matrix<float, 21, 21>* P_post = nullptr) {
-    Eigen::LDLT<Eigen::Matrix<float, 21, 21>> ldlt(H);
+inline bool solve_ldlt(const Eigen::Matrix<float, 15, 15>& H, const Eigen::Matrix<float, 15, 1>& b,
+                       Eigen::Matrix<float, 15, 1>& delta, Eigen::Matrix<float, 15, 15>* P_post = nullptr) {
+    Eigen::LDLT<Eigen::Matrix<float, 15, 15>> ldlt(H);
     if (ldlt.info() != Eigen::Success || ldlt.vectorD().minCoeff() <= 0.0f) {
         delta.setZero();
         if (P_post) P_post->setZero();
@@ -197,7 +190,7 @@ inline bool solve_ldlt(const Eigen::Matrix<float, 21, 21>& H, const Eigen::Matri
 // retract
 // ---------------------------------------------------------------------------
 
-/// @brief Apply a 21-D tangent-space update δx to a navigation state.
+/// @brief Apply a 15-D tangent-space update δx to a navigation state.
 ///
 /// Implements the manifold retraction  x_new = x ⊕ δx:
 ///
@@ -206,16 +199,14 @@ inline bool solve_ldlt(const Eigen::Matrix<float, 21, 21>& H, const Eigen::Matri
 ///   velocity     : v_new = v + δv                         (additive)
 ///   accel_bias   : b_a_new = b_a + δb_a                  (additive)
 ///   gyro_bias    : b_g_new = b_g + δb_g                  (additive)
-///   offset_R_L_I : R_ex_new = R_ex · Exp(δφ_ex)          (SO(3) right-perturbation)
-///   offset_T_L_I : t_ex_new = t_ex + δt_ex               (additive)
 ///
 /// The right-perturbation convention is consistent throughout: the same
 /// convention is used by add_icp_factor() and compute_imu_hessian_gradient().
 ///
 /// @param state  Current navigation state (linearisation point x_op).
-/// @param delta  21-D tangent-space update δx from solve_ldlt().
+/// @param delta  15-D tangent-space update δx from solve_ldlt().
 /// @return Updated navigation state x_op ⊕ δx.
-inline imu::State retract(const imu::State& state, const Eigen::Matrix<float, 21, 1>& delta) {
+inline imu::State retract(const imu::State& state, const Eigen::Matrix<float, 15, 1>& delta) {
     imu::State updated = state;
 
     updated.position += delta.segment<3>(imu::State::kIdxPos);
@@ -226,12 +217,6 @@ inline imu::State retract(const imu::State& state, const Eigen::Matrix<float, 21
     updated.velocity += delta.segment<3>(imu::State::kIdxVel);
     updated.accel_bias += delta.segment<3>(imu::State::kIdxAccBias);
     updated.gyro_bias += delta.segment<3>(imu::State::kIdxGyrBias);
-
-    // Extrinsic rotation: right-perturbation on SO(3)
-    const Eigen::Vector4f dq_ex = eigen_utils::lie::so3_exp(delta.segment<3>(imu::State::kIdxExRot));
-    updated.offset_R_L_I = state.offset_R_L_I * eigen_utils::geometry::quaternion_to_rotation_matrix(dq_ex);
-
-    updated.offset_T_L_I += delta.segment<3>(imu::State::kIdxExTrans);
 
     return updated;
 }
@@ -246,10 +231,6 @@ inline imu::State retract(const imu::State& state, const Eigen::Matrix<float, 21
 // When T_imu_to_lidar ≠ Identity the two frames differ, and the covariance
 // must be transformed before it can be used as the IMU prior.  These functions
 // implement that transformation via a first-order Jacobian J.
-//
-// The extrinsic blocks (indices 15–20) are not part of IMU preintegration and
-// are therefore handled separately (see lio_registration() in
-// lidar_inertial_odometry.hpp).
 // ---------------------------------------------------------------------------
 
 /// @brief Jacobian that maps the 15-D IMU error-state to the 15-D LiDAR error-state.

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -45,11 +45,12 @@
 //
 //   Composed world pose:  T_world_lidar = T_world_init_ * R_init_imu_att_ * x_
 //
-// NOTE: The ICP Hessian is embedded into the 15-DOF LiDAR-frame error-state.
-//       When T_imu_to_lidar ≠ Identity the preintegration covariance P_pred is
-//       expressed in the IMU error-state, which introduces a small mismatch.
-//       A full adjoint correction (P_lidar = Ad * P_imu * Ad^T) is left for a
-//       future update.
+// The ICP Hessian is embedded into the 15-DOF LiDAR-frame error-state.  The
+// IMU preintegration covariance lives in the IMU error-state and is rotated
+// into the LiDAR error-state via transform_covariance_imu_to_lidar() before
+// being passed to compute_imu_hessian_gradient(); the inverse Jacobian is
+// applied in reset_imu_preintegration() when handing P_post back to the
+// preintegrator.
 // ---------------------------------------------------------------------------
 
 namespace sycl_points {

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -35,7 +35,7 @@
 //                           for future online gravity correction (Phase 3).
 //                           imu_attitude is therefore gravity-aligned in Phase 1
 //                           (= init_pose), so gravity stays (0,0,-g) canonical.
-//   TF3 = x_              : 21-DOF LIO state (the time-varying pose tracked by
+//   TF3 = x_              : 15-DOF LIO state (the time-varying pose tracked by
 //                           the IEKF, expressed in the imu_attitude frame).
 //
 //   x_.position  = imu_attitude-frame position of the LiDAR origin [m]
@@ -249,7 +249,7 @@ public:
             this->x_.position = this->odom_.translation();
             this->x_.rotation = this->odom_.rotation();
             this->x_.velocity = Eigen::Vector3f::Zero();
-            // x_.accel_bias / gyro_bias / offset_R_L_I / offset_T_L_I already set in initialize();
+            // x_.accel_bias / gyro_bias already set in initialize();
             // x_.gyro_bias may also have been updated by apply_initial_alignment().
 
             this->reset_imu_preintegration();
@@ -331,10 +331,10 @@ private:
 
     Parameters params_;
 
-    // LIO state (LiDAR frame convention, 21-DOF including extrinsic)
+    // LIO state (LiDAR frame convention, 15-DOF: position, rotation, velocity, accel_bias, gyro_bias)
     imu::State x_;
-    // Posterior covariance passed as initial covariance to the next IMU reset window. (LiDAR frame, 21×21)
-    Eigen::Matrix<float, 21, 21> P_post_ = Eigen::Matrix<float, 21, 21>::Zero();
+    // Posterior covariance passed as initial covariance to the next IMU reset window. (LiDAR frame, 15×15)
+    Eigen::Matrix<float, 15, 15> P_post_ = Eigen::Matrix<float, 15, 15>::Zero();
 
     imu::IMUPreintegration::Ptr imu_preintegration_ = nullptr;
     /// Window-start IMU orientation/velocity snapshotted at the latest preintegration
@@ -377,35 +377,16 @@ private:
         return this->T_world_init_ * T_init_imu_att * pose_imu_att;
     }
 
-    /// @brief Return the effective LiDAR-IMU extrinsic to use for prediction/reset.
-    /// When estimate_extrinsic is enabled, uses the current state x_; otherwise uses the fixed param.
-    Eigen::Isometry3f effective_extrinsic() const { return this->effective_extrinsic_from(this->x_); }
-
-    /// @brief Return effective extrinsic from an operating-point state (used inside IEKF loop).
-    Eigen::Isometry3f effective_extrinsic_from(const imu::State& x_op) const {
-        if (this->params_.lio.estimate_extrinsic) {
-            Eigen::Isometry3f T;
-            T.setIdentity();
-            T.linear() = x_op.offset_R_L_I;
-            T.translation() = x_op.offset_T_L_I;
-            return T;
-        }
-        return this->params_.imu.T_imu_to_lidar;
-    }
-
-    bool is_lio_converged(const Eigen::Matrix<float, 21, 1>& delta) const {
+    bool is_lio_converged(const Eigen::Matrix<float, 15, 1>& delta) const {
         return delta.segment<3>(imu::State::kIdxRot).norm() < params_.lio.criteria.rotation &&
                delta.segment<3>(imu::State::kIdxPos).norm() < params_.lio.criteria.translation;
     }
 
     void reset_imu_preintegration() {
-        // Use current state extrinsic when online calibration is enabled
-        const Eigen::Isometry3f T_i2l_eff = effective_extrinsic();
-        const Eigen::Matrix3f R_world_imu = x_.rotation * T_i2l_eff.rotation();
+        const Eigen::Isometry3f& T_i2l = this->params_.imu.T_imu_to_lidar;
+        const Eigen::Matrix3f R_world_imu = x_.rotation * T_i2l.rotation();
 
-        // Extract the 15×15 navigation-state covariance block from P_post_ (21×21).
-        // The extrinsic block is not passed to IMU preintegration (it doesn't model extrinsic).
-        Eigen::Matrix<float, 15, 15> P_initial = this->P_post_.block<15, 15>(0, 0);
+        Eigen::Matrix<float, 15, 15> P_initial = this->P_post_;
 
         // Add fixed-sigma floors to P_initial before resetting the integrator.
         // Velocity floor: ensures P_pred[p,p] ≳ (fd_velocity_sigma × dt)², keeping
@@ -420,16 +401,16 @@ private:
         // Convert before passing so that get_raw().covariance → transform_covariance_imu_to_lidar
         // yields the correct P_pred_lidar without double-transformation.
         const Eigen::Matrix<float, 15, 15> P_initial_imu =
-            algorithms::lio::transform_covariance_lidar_to_imu(P_initial, T_i2l_eff, this->x_.rotation);
+            algorithms::lio::transform_covariance_lidar_to_imu(P_initial, T_i2l, this->x_.rotation);
 
         this->imu_preintegration_->reset({this->x_.gyro_bias, this->x_.accel_bias}, P_initial_imu);
         this->imu_R_world_at_reset_ = R_world_imu;
         this->imu_v_world_at_reset_ = this->x_.velocity;
     }
 
-    /// @brief Predict the full 21-DOF state from IMU preintegration using the given extrinsic.
-    /// @param T_i2l  Extrinsic to use for the prediction (may be from x_ or x_op).
-    imu::State predict_state_with(const Eigen::Isometry3f& T_i2l) const {
+    /// @brief Predict the 15-DOF state from IMU preintegration.
+    imu::State predict_state() const {
+        const Eigen::Isometry3f& T_i2l = this->params_.imu.T_imu_to_lidar;
         const imu::IMUBias current_bias{this->x_.gyro_bias, this->x_.accel_bias};
 
         // Relative pose prediction (gravity + initial velocity already compensated)
@@ -454,67 +435,7 @@ private:
         pred.velocity = this->x_.velocity + this->params_.imu.preintegration.gravity * dt_f + R_world_imu * c.Delta_v;
         pred.accel_bias = this->x_.accel_bias;
         pred.gyro_bias = this->x_.gyro_bias;
-        pred.offset_R_L_I = T_i2l.rotation();
-        pred.offset_T_L_I = T_i2l.translation();
         return pred;
-    }
-
-    /// @brief Predict from the current state extrinsic (convenience wrapper).
-    imu::State predict_state() const { return predict_state_with(effective_extrinsic()); }
-
-    /// @brief Compute the 15×6 Jacobian of the IMU prediction residual w.r.t. the extrinsic [δφ_ex | δt_ex].
-    ///
-    /// The navigation prediction (position, rotation, velocity) depends on the LiDAR-IMU extrinsic
-    /// T_i2l = [R_li | t_li].  This Jacobian captures that coupling so the IEKF cross-terms are correct.
-    ///
-    /// Rows 0–2  (position):   -x_.rotation * ∂t_pred_rel/∂δex
-    /// Rows 3–5  (rotation):    R_li * (I − R_imu_rel^T)   (columns 0–2 only; cols 3–5 = 0)
-    /// Rows 6–8  (velocity):    x_.rotation * R_li * [Delta_v]×   (columns 0–2 only)
-    /// Rows 9–14 (biases):      0
-    Eigen::Matrix<float, 15, 6> compute_extrinsic_jacobian(const imu::State& x_op) const {
-        Eigen::Matrix<float, 15, 6> J = Eigen::Matrix<float, 15, 6>::Zero();
-
-        const Eigen::Isometry3f T_i2l = effective_extrinsic_from(x_op);
-        const Eigen::Matrix3f R_li = T_i2l.rotation();
-        const Eigen::Vector3f t_li = T_i2l.translation();
-
-        const imu::IMUBias current_bias{x_op.gyro_bias, x_op.accel_bias};
-        const TransformMatrix T_imu_rel_mat = this->imu_preintegration_->predict_relative_transform(
-            this->imu_R_world_at_reset_, this->imu_v_world_at_reset_, current_bias);
-        const Eigen::Matrix3f R_imu_rel = T_imu_rel_mat.block<3, 3>(0, 0);
-        const Eigen::Vector3f t_imu_rel = T_imu_rel_mat.block<3, 1>(0, 3);
-        const Eigen::Matrix3f R_pred_rel = R_li * R_imu_rel * R_li.transpose();
-
-        // a = R_li^T * t_li  (lever-arm in IMU frame)
-        const Eigen::Vector3f a = R_li.transpose() * t_li;
-
-        // ∂t_pred_rel / ∂δφ_ex:
-        //   t_pred_rel = (I − R_pred_rel) * t_li + R_li * t_imu_rel
-        //   δt_pred_rel|_δφ = R_li * ([R_imu_rel*a]× − R_imu_rel*[a]× − [t_imu_rel]×) * δφ
-        const Eigen::Matrix3f dpos_dphi = this->x_.rotation * R_li *
-                                          (eigen_utils::lie::skew(Eigen::Vector3f(R_imu_rel * a)) -
-                                           R_imu_rel * eigen_utils::lie::skew(Eigen::Vector3f(a)) -
-                                           eigen_utils::lie::skew(Eigen::Vector3f(t_imu_rel)));
-
-        // ∂t_pred_rel / ∂δt_ex:
-        //   = I − R_pred_rel
-        const Eigen::Matrix3f dpos_dt = this->x_.rotation * (Eigen::Matrix3f::Identity() - R_pred_rel);
-
-        J.block<3, 3>(imu::State::kIdxPos, 0) = -dpos_dphi;
-        J.block<3, 3>(imu::State::kIdxPos, 3) = -dpos_dt;
-
-        // ∂r_rot / ∂δφ_ex = R_li * (I − R_imu_rel^T)   (δt_ex has no effect)
-        J.block<3, 3>(imu::State::kIdxRot, 0) = R_li * (Eigen::Matrix3f::Identity() - R_imu_rel.transpose());
-
-        // ∂r_vel / ∂δφ_ex: velocity prediction uses R_world_imu = x_.rotation * R_li
-        //   ∂(R_world_imu * Delta_v) / ∂δφ_ex = x_.rotation * R_li * [Delta_v]×  (negate for residual)
-        // Wait: r_vel = x_op.vel − x_pred.vel, and x_pred.vel depends on extrinsic via R_world_imu.
-        //   ∂r_vel / ∂δφ_ex = −∂x_pred.vel / ∂δφ_ex = x_.rotation * R_li * [Delta_v]×
-        // (sign: ∂(R_li*Exp(δφ)*Delta_v)/∂δφ = −R_li*[Delta_v]× → world: x_.rot*R_li*[Δv]×, negated gives +)
-        const auto c = this->imu_preintegration_->get_corrected(current_bias);
-        J.block<3, 3>(imu::State::kIdxVel, 0) = this->x_.rotation * R_li * eigen_utils::lie::skew(c.Delta_v);
-
-        return J;
     }
 
     /// @brief Combined LIO Gauss-Newton optimization for one LiDAR frame.
@@ -522,29 +443,13 @@ private:
         // ---- Build prior from IMU preintegration ----
         imu::State x_pred = predict_state();
 
-        // Build 21×21 P_pred:
-        //   - Upper-left 15×15: IMU preintegration covariance transformed to LiDAR frame.
-        //   - Lower-right 6×6:  Extrinsic prior from the previous frame's posterior.
-        const Eigen::Isometry3f T_i2l_init = effective_extrinsic();
-        const Eigen::Matrix<float, 15, 15> P_nav_lidar = algorithms::lio::transform_covariance_imu_to_lidar(
-            this->imu_preintegration_->get_raw().covariance, T_i2l_init, x_pred.rotation);
+        // Transform IMU-frame preintegration covariance into the LiDAR error-state frame.
+        const Eigen::Matrix<float, 15, 15> P_pred = algorithms::lio::transform_covariance_imu_to_lidar(
+            this->imu_preintegration_->get_raw().covariance, this->params_.imu.T_imu_to_lidar, x_pred.rotation);
 
-        Eigen::Matrix<float, 21, 21> P_pred_21 = Eigen::Matrix<float, 21, 21>::Zero();
-        P_pred_21.block<15, 15>(0, 0) = P_nav_lidar;
-        P_pred_21.block<6, 6>(imu::State::kIdxExRot, imu::State::kIdxExRot) =
-            this->P_post_.block<6, 6>(imu::State::kIdxExRot, imu::State::kIdxExRot);
-
-        // When extrinsic estimation is disabled, pin the extrinsic with a large stiffness
-        // so the 21×21 system behaves identically to the original 15-DOF system.
-        if (!this->params_.lio.estimate_extrinsic) {
-            constexpr float kPin = 1e6f;
-            P_pred_21.block<6, 6>(imu::State::kIdxExRot, imu::State::kIdxExRot) =
-                (1.0f / kPin) * Eigen::Matrix<float, 6, 6>::Identity();
-        }
-
-        Eigen::Matrix<float, 21, 21> H_imu = Eigen::Matrix<float, 21, 21>::Zero();
-        Eigen::Matrix<float, 21, 1> b_imu = Eigen::Matrix<float, 21, 1>::Zero();
-        bool imu_valid = imu::compute_imu_hessian_gradient(x_pred, x_pred, P_pred_21, H_imu, b_imu);
+        Eigen::Matrix<float, 15, 15> H_imu = Eigen::Matrix<float, 15, 15>::Zero();
+        Eigen::Matrix<float, 15, 1> b_imu = Eigen::Matrix<float, 15, 1>::Zero();
+        const bool imu_valid = imu::compute_imu_hessian_gradient(x_pred, x_pred, P_pred, H_imu, b_imu);
 
         // ---- Prepare ICP source (random sampling) ----
         const auto& rs = this->params_.registration.pipeline.random_sampling;
@@ -582,44 +487,17 @@ private:
                                                                       this->submap_->get_submap_kdtree(), T_op,
                                                                       T_initial, options);
 
-            // Update gradient b_imu at the current operating point.
-            // H_imu = P_pred_21^{-1} is constant for this frame, so we only recompute
+            // H_imu = P_pred^{-1} is constant for this frame, so we only recompute
             // the residual r and b_imu = H_imu · r (no LDLT inversion needed).
-            // When extrinsic estimation is enabled, also re-linearise the navigation
-            // prediction using the current x_op extrinsic — but keep x_pred's extrinsic
-            // fixed to the prior mean so that the extrinsic prior term is correctly enforced.
             if (iter > 0 && imu_valid) {
-                if (this->params_.lio.estimate_extrinsic) {
-                    const imu::State x_nav_pred = predict_state_with(effective_extrinsic_from(x_op));
-                    x_pred.position = x_nav_pred.position;
-                    x_pred.rotation = x_nav_pred.rotation;
-                    x_pred.velocity = x_nav_pred.velocity;
-                    // x_pred.offset_R_L_I / offset_T_L_I stay as the prior mean
-                }
                 imu::compute_imu_gradient(x_pred, x_op, H_imu, b_imu);
             }
 
-            // Combine ICP + IMU into 21×21 normal equations.
-            // When extrinsic estimation is enabled, add cross-terms that make the
-            // extrinsic observable through the navigation-state residual. The copies
-            // are only made in that case to avoid the 21×21 allocation on the common path.
+            // Combine ICP + IMU into 15×15 normal equations.
             algorithms::lio::LIOLinearizedResult lio;
             algorithms::lio::add_icp_factor(lio, last_icp, x_op.rotation);
             if (imu_valid) {
-                if (this->params_.lio.estimate_extrinsic) {
-                    Eigen::Matrix<float, 21, 21> H_cross = H_imu;
-                    Eigen::Matrix<float, 21, 1> b_cross = b_imu;
-                    const Eigen::Matrix<float, 15, 6> J_nav_ex = compute_extrinsic_jacobian(x_op);
-                    const Eigen::Matrix<float, 15, 15> Omega_nav = H_imu.block<15, 15>(0, 0);
-                    const Eigen::Matrix<float, 15, 6> OJ = Omega_nav * J_nav_ex;
-                    H_cross.block<15, 6>(0, imu::State::kIdxExRot) += OJ;
-                    H_cross.block<6, 15>(imu::State::kIdxExRot, 0) += OJ.transpose();
-                    H_cross.block<6, 6>(imu::State::kIdxExRot, imu::State::kIdxExRot) += J_nav_ex.transpose() * OJ;
-                    b_cross.segment<6>(imu::State::kIdxExRot) += J_nav_ex.transpose() * b_imu.segment<15>(0);
-                    algorithms::lio::add_imu_factor(lio, H_cross, b_cross);
-                } else {
-                    algorithms::lio::add_imu_factor(lio, H_imu, b_imu);
-                }
+                algorithms::lio::add_imu_factor(lio, H_imu, b_imu);
             } else {
                 const float kReg = this->params_.lio.invalid_regularization_factor;
                 lio.H.block<3, 3>(imu::State::kIdxVel, imu::State::kIdxVel) += kReg * Eigen::Matrix3f::Identity();
@@ -627,15 +505,11 @@ private:
                     kReg * Eigen::Matrix3f::Identity();
                 lio.H.block<3, 3>(imu::State::kIdxGyrBias, imu::State::kIdxGyrBias) +=
                     kReg * Eigen::Matrix3f::Identity();
-                // Always pin extrinsic when IMU is invalid — ICP provides no extrinsic information.
-                constexpr float kPin = 1e6f;
-                lio.H.block<6, 6>(imu::State::kIdxExRot, imu::State::kIdxExRot) +=
-                    kPin * Eigen::Matrix<float, 6, 6>::Identity();
             }
 
-            Eigen::Matrix<float, 21, 1> delta;
+            Eigen::Matrix<float, 15, 1> delta;
             const float lambda = this->params_.registration.pipeline.registration.gn.lambda;
-            if (!algorithms::lio::solve_ldlt(lio.H + lambda * Eigen::Matrix<float, 21, 21>::Identity(), lio.b, delta,
+            if (!algorithms::lio::solve_ldlt(lio.H + lambda * Eigen::Matrix<float, 15, 15>::Identity(), lio.b, delta,
                                              &this->P_post_))
                 break;
 
@@ -651,15 +525,11 @@ private:
         this->x_.rotation = x_op.rotation;
         this->x_.accel_bias = x_op.accel_bias;
         this->x_.gyro_bias = x_op.gyro_bias;
-        if (this->params_.lio.estimate_extrinsic) {
-            this->x_.offset_R_L_I = x_op.offset_R_L_I;
-            this->x_.offset_T_L_I = x_op.offset_T_L_I;
-        }
         if (this->dt_ > 0.0f) {
             const Eigen::Vector3f v_fd = (this->x_.position - prev_position) / this->dt_;
             const auto c = this->imu_preintegration_->get_corrected(imu::IMUBias{x_op.gyro_bias, x_op.accel_bias});
             if (c.dt_total > 1e-6) {
-                const Eigen::Matrix3f R_world_imu_prev = prev_rotation * effective_extrinsic_from(x_op).rotation();
+                const Eigen::Matrix3f R_world_imu_prev = prev_rotation * this->params_.imu.T_imu_to_lidar.rotation();
                 const Eigen::Vector3f a_world = this->params_.imu.preintegration.gravity +
                                                 R_world_imu_prev * c.Delta_v / static_cast<float>(c.dt_total);
                 this->x_.velocity = v_fd + 0.5f * a_world * this->dt_;
@@ -749,19 +619,6 @@ private:
         // before the first frame's state initialization runs.
         this->x_.accel_bias = this->params_.imu.bias.accel_bias;
         this->x_.gyro_bias = this->params_.imu.bias.gyro_bias;
-        this->x_.offset_R_L_I = this->params_.imu.T_imu_to_lidar.rotation();
-        this->x_.offset_T_L_I = this->params_.imu.T_imu_to_lidar.translation();
-
-        // Initialize P_post_ extrinsic blocks with the initial uncertainty from params.
-        // The navigation blocks start at zero; the extrinsic blocks hold the prior sigma.
-        if (this->params_.lio.estimate_extrinsic) {
-            const float sr2 = this->params_.lio.extrinsic_rotation_sigma * this->params_.lio.extrinsic_rotation_sigma;
-            const float st2 =
-                this->params_.lio.extrinsic_translation_sigma * this->params_.lio.extrinsic_translation_sigma;
-            this->P_post_.block<3, 3>(imu::State::kIdxExRot, imu::State::kIdxExRot) = sr2 * Eigen::Matrix3f::Identity();
-            this->P_post_.block<3, 3>(imu::State::kIdxExTrans, imu::State::kIdxExTrans) =
-                st2 * Eigen::Matrix3f::Identity();
-        }
 
         this->clear_total_processing_times();
     }

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry_params.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry_params.hpp
@@ -30,17 +30,6 @@ struct Parameters : public lidar_odometry::Parameters {
         /// Choose so that 1/icp_rotation_sigma² ≲ H_icp[rot,rot]
         /// (≈ 1e4–1e5 for outdoor LiDAR with ~1000 inliers → σ ≈ 0.003–0.01 rad).
         float icp_rotation_sigma = 0.01f;
-
-        /// Enable online extrinsic calibration (LiDAR-IMU offset_R_L_I / offset_T_L_I).
-        /// When true the extrinsic is part of the 21-DOF IEKF state and updated each frame.
-        /// When false the extrinsic is fixed to T_imu_to_lidar (15-DOF equivalent behaviour).
-        bool estimate_extrinsic = false;
-
-        /// Initial 1-sigma uncertainty for the extrinsic rotation [rad].
-        float extrinsic_rotation_sigma = 0.01f;  ///< ≈ 0.57°
-
-        /// Initial 1-sigma uncertainty for the extrinsic translation [m].
-        float extrinsic_translation_sigma = 0.01f;  ///< ≈ 1 cm
     };
 
     LIO lio;

--- a/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
@@ -176,10 +176,6 @@ lidar_inertial_odometry_node:
     # icp_rotation_sigma: σ_rot [rad]  → P_pred[φ,φ] ≳ σ_rot²
     #   choose so 1/σ_rot² ≲ H_icp[rot,rot]  (≈ 1e4–1e5 → σ ≈ 0.003–0.01 rad)
     lio/icp_rotation_sigma: 0.01  # [rad]
-    # Online extrinsic calibration (LiDAR-IMU offset_R_L_I / offset_T_L_I)
-    lio/estimate_extrinsic: true
-    lio/extrinsic_rotation_sigma: 0.01     # Initial 1-sigma uncertainty [rad] (~0.57°)
-    lio/extrinsic_translation_sigma: 0.01  # Initial 1-sigma uncertainty [m]  (~1 cm)
 
     # ICP registration backend (used for linearization inside the LIO loop)
     # registration/max_iterations is unused; outer loop count is lio/max_iterations.

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_inertial_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_inertial_odometry_params.hpp
@@ -36,13 +36,6 @@ inline pipeline::lidar_inertial_odometry::Parameters declare_lidar_inertial_odom
         static_cast<float>(node->declare_parameter<double>("lio/fd_velocity_sigma", params.lio.fd_velocity_sigma));
     params.lio.icp_rotation_sigma =
         static_cast<float>(node->declare_parameter<double>("lio/icp_rotation_sigma", params.lio.icp_rotation_sigma));
-
-    params.lio.estimate_extrinsic =
-        node->declare_parameter<bool>("lio/estimate_extrinsic", params.lio.estimate_extrinsic);
-    params.lio.extrinsic_rotation_sigma = static_cast<float>(
-        node->declare_parameter<double>("lio/extrinsic_rotation_sigma", params.lio.extrinsic_rotation_sigma));
-    params.lio.extrinsic_translation_sigma = static_cast<float>(
-        node->declare_parameter<double>("lio/extrinsic_translation_sigma", params.lio.extrinsic_translation_sigma));
     return params;
 }
 


### PR DESCRIPTION
Closes #168.

## Summary

\`estimate_extrinsic\` (online LiDAR-IMU extrinsic calibration, 3a95e1c 2026-04-29) は実運用で効果が薄い印象だったため、機能ごと削除。IEKF state を **21-DOF → 15-DOF** に縮小し、外部キャリは \`params_.imu.T_imu_to_lidar\` の静的値を直参照する形に統一する。

## 変更内容

### imu::State (cpp/include/sycl_points/algorithms/imu/imu_factor.hpp)
- \`offset_R_L_I\` / \`offset_T_L_I\` フィールド削除
- \`kIdxExRot\` / \`kIdxExTrans\` インデックス削除
- \`kDOF\`: 21 → 15
- \`compute_manifold_residual\` / \`compute_imu_hessian_gradient\` / \`compute_imu_gradient\` を 15×15 / 15-D に縮小

### lio_registration.hpp
- \`LIOLinearizedResult.H/b\` を 15×15 / 15-D に
- \`add_icp_factor\` / \`add_imu_factor\` / \`solve_ldlt\` / \`retract\` を 15-DOF へ
- 共分散変換 (\`transform_covariance_*\`) は 15×15 のままで変更なし

### lidar_inertial_odometry.hpp (LIO pipeline)
- \`effective_extrinsic\` / \`effective_extrinsic_from\` ヘルパ削除 — 常に \`params_.imu.T_imu_to_lidar\` 直参照
- \`compute_extrinsic_jacobian\` (15×6 cross Jacobian) と cross-term 注入ロジック削除
- 21×21 \`P_pred_21\` ステージングと extrinsic ピン留め (\`kPin = 1e6f\`) ロジック削除 → 単一 15×15 法方程式へ
- \`predict_state_with\` を \`predict_state\` に統合 (extrinsic 引数不要に)
- \`initialize()\` の extrinsic 事前分散初期化を削除

### Config / ROS2 wiring
- \`lidar_inertial_odometry_params.hpp\`: \`estimate_extrinsic\` / \`extrinsic_rotation_sigma\` / \`extrinsic_translation_sigma\` 削除
- \`declare_lidar_inertial_odometry_params.hpp\`: 該当 \`declare_parameter\` 削除
- \`config/lidar_inertial_odometry.yaml\`: キー削除

## 数値的効果

| | Before | After |
|---|---|---|
| IEKF state | 21-DOF | 15-DOF |
| LDLT factorisation | 21³/3 ≈ 3087 flop | 15³/3 ≈ 1125 flop (~2.7× cheaper) |
| Hessian conditioning | kPin=1e6f vs ~1.0 (navigation) 混在 | navigation スケール均一 |
| 外部キャリ | \`estimate_extrinsic\` で実行時更新可 | \`params_.imu.T_imu_to_lidar\` 静的固定 |

## 互換性

- 既存ユーザの yaml に残った \`lio/estimate_extrinsic\` / \`lio/extrinsic_*\` キーは ROS2 が unknown parameter として silent ignore (エラーなし)
- 外部キャリは事前キャリブして \`T_imu_to_lidar/*\` に焼く運用に統一

## Test plan

- [x] \`colcon build\` 成功
- [x] LIO ノードを既存 rosbag で起動し、世界系 odom 出力に大きな退行がないことを確認
- [ ] \`lio/estimate_extrinsic\` 旧キーを残した yaml を読み込んでもクラッシュしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)