### PR TITLE
feat(gicp): source-side range/incidence-angle-aware covariance regularization

### DIFF
--- a/cpp/include/sycl_points/algorithms/feature/covariance.hpp
+++ b/cpp/include/sycl_points/algorithms/feature/covariance.hpp
@@ -17,8 +17,10 @@ namespace covariance {
 struct NoiseModel {
     float sigma_range = 0.0f;      // [m/m] range-proportional std-dev (variance contribution: (sigma_range * d)^2)
     float sigma_grazing = 0.0f;    // [dimensionless] tan(theta)-proportional std-dev for incidence-angle noise
-    float min_eigenvalue = 1e-3f;  // numerical floor for lambda_min (planar regularization baseline; lambda_min when sigma_sq = 0)
-    float max_eigenvalue = 1.0f;   // upper cap; clamping here drives source covariance toward isotropy (target-driven point-to-plane behavior)
+    float min_eigenvalue = 1e-3f;  // numerical floor for lambda_min
+                                   //  (planar regularization baseline; lambda_min when sigma_sq = 0)
+    float max_eigenvalue = 1.0f;   // upper cap; clamping here drives source covariance toward isotropy (target-driven
+                                   // point-to-plane behavior)
     float cos_min = 0.1f;          // clamp on |cos(theta)| to avoid tan() divergence near grazing rays
 };
 
@@ -106,10 +108,10 @@ SYCL_EXTERNAL inline void update_covariance_plane_noise_aware(Covariance& cov, c
     if (d > 1e-6f) {
         // Smallest-eigenvalue eigenvector = local surface normal.
         const Eigen::Vector3f n = eigenvectors.col(0);
-        const float cos_theta = sycl::fabs(eigen_utils::dot<3>(n, p)) / d;
+        float cos_theta = sycl::fabs(eigen_utils::dot<3>(n, p)) / d;
         // Guard against misconfigured nm.cos_min <= 0 to keep tan2 finite.
-        const float cos_c = sycl::fmax(cos_theta, sycl::fmax(nm.cos_min, 1e-6f));
-        const float cos2 = cos_c * cos_c;
+        cos_theta = sycl::clamp(cos_theta, sycl::fmax(nm.cos_min, 1e-6f), 1.0f);
+        const float cos2 = cos_theta * cos_theta;
         tan2 = 1.0f / cos2 - 1.0f;
     }
 
@@ -117,7 +119,8 @@ SYCL_EXTERNAL inline void update_covariance_plane_noise_aware(Covariance& cov, c
     // min_eigenvalue acts as a numerical floor (planar regularization baseline);
     // max_eigenvalue caps lambda_min so the source covariance does not exceed isotropic scale.
     const float sigma_sq = nm.sigma_range * nm.sigma_range * d_sq + nm.sigma_grazing * nm.sigma_grazing * tan2;
-    const float lambda_min = sycl::clamp(sigma_sq, nm.min_eigenvalue, nm.max_eigenvalue);
+    const float lambda_min =
+        sycl::clamp(sigma_sq, sycl::fmax(nm.min_eigenvalue, 1e-6f), sycl::fmax(nm.max_eigenvalue, 1e-6f));
 
     const auto diag = eigen_utils::as_diagonal<3>({lambda_min, 1.0f, 1.0f});
     cov.block<3, 3>(0, 0) = eigen_utils::multiply<3, 3, 3>(eigen_utils::multiply<3, 3, 3>(eigenvectors, diag),

--- a/cpp/include/sycl_points/algorithms/feature/covariance.hpp
+++ b/cpp/include/sycl_points/algorithms/feature/covariance.hpp
@@ -105,12 +105,12 @@ SYCL_EXTERNAL inline void update_covariance_plane_noise_aware(Covariance& cov, c
         // Smallest-eigenvalue eigenvector = local surface normal.
         const Eigen::Vector3f n = eigenvectors.col(0);
         const float cos_theta = sycl::fabs(eigen_utils::dot<3>(n, p)) / d;
-        const float cos_c = sycl::fmax(cos_theta, nm.cos_min);
+        // Guard against misconfigured nm.cos_min <= 0 to keep tan2 finite.
+        const float cos_c = sycl::fmax(cos_theta, sycl::fmax(nm.cos_min, 1e-6f));
         tan2 = (1.0f - cos_c * cos_c) / (cos_c * cos_c);
     }
 
-    const float sigma_sq =
-        nm.sigma_range * nm.sigma_range * d_sq + nm.sigma_grazing * nm.sigma_grazing * tan2;
+    const float sigma_sq = nm.sigma_range * nm.sigma_range * d_sq + nm.sigma_grazing * nm.sigma_grazing * tan2;
 
     float lambda_min = nm.min_eigenvalue + sigma_sq;
     lambda_min = sycl::clamp(lambda_min, nm.min_eigenvalue, nm.max_eigenvalue);

--- a/cpp/include/sycl_points/algorithms/feature/covariance.hpp
+++ b/cpp/include/sycl_points/algorithms/feature/covariance.hpp
@@ -11,6 +11,17 @@ namespace algorithms {
 
 namespace covariance {
 
+/// @brief Source-side sensor noise model for GICP covariance regularization.
+/// @note With sigma_range = sigma_grazing = 0 and min/max = (1e-3, 1.0),
+///       the noise-aware regularizer reduces to the standard {1e-3, 1, 1} planar form.
+struct NoiseModel {
+    float sigma_range = 0.0f;      // [m/m] range-proportional std-dev (added variance grows as (sigma_range * d)^2)
+    float sigma_grazing = 0.0f;    // [dimensionless] tan(theta)-proportional std-dev for incidence-angle noise
+    float min_eigenvalue = 1e-3f;  // lower clamp for the regularized minimum eigenvalue
+    float max_eigenvalue = 1.0f;   // upper clamp for the regularized minimum eigenvalue
+    float cos_min = 0.1f;          // clamp on |cos(theta)| to avoid tan() divergence near grazing rays
+};
+
 namespace kernel {
 
 SYCL_EXTERNAL inline void estimate(Covariance& ret, const PointType* point_ptr, const size_t k_correspondences,
@@ -69,6 +80,42 @@ SYCL_EXTERNAL inline void update_covariance_plane(Covariance& cov) {
     Eigen::Matrix3f eigenvectors;
     eigen_utils::symmetric_eigen_decomposition_3x3(cov.block<3, 3>(0, 0), eigenvalues, eigenvectors);
     const auto diag = eigen_utils::as_diagonal<3>({1e-3f, 1.0f, 1.0f});
+    cov.block<3, 3>(0, 0) = eigen_utils::multiply<3, 3, 3>(eigen_utils::multiply<3, 3, 3>(eigenvectors, diag),
+                                                           eigen_utils::transpose<3, 3>(eigenvectors));
+}
+
+/// @brief Planar regularization with sensor-noise-aware minimum eigenvalue.
+/// @param cov Covariance to regularize (in place)
+/// @param pt_in_sensor_frame Source point in the LiDAR sensor frame (pre-transform)
+/// @param nm Noise model parameters
+/// @note Reduces to update_covariance_plane when nm.sigma_range == 0 && nm.sigma_grazing == 0
+///       (then lambda_min = clamp(min_eigenvalue + 0, min_eigenvalue, max_eigenvalue) = min_eigenvalue).
+SYCL_EXTERNAL inline void update_covariance_plane_noise_aware(Covariance& cov, const PointType& pt_in_sensor_frame,
+                                                              const NoiseModel& nm) {
+    Eigen::Vector3f eigenvalues;
+    Eigen::Matrix3f eigenvectors;
+    eigen_utils::symmetric_eigen_decomposition_3x3(cov.block<3, 3>(0, 0), eigenvalues, eigenvectors);
+
+    const Eigen::Vector3f p(pt_in_sensor_frame.x(), pt_in_sensor_frame.y(), pt_in_sensor_frame.z());
+    const float d_sq = eigen_utils::dot<3>(p, p);
+    const float d = sycl::sqrt(d_sq);
+
+    float tan2 = 0.0f;
+    if (d > 1e-6f) {
+        // Smallest-eigenvalue eigenvector = local surface normal.
+        const Eigen::Vector3f n = eigenvectors.col(0);
+        const float cos_theta = sycl::fabs(eigen_utils::dot<3>(n, p)) / d;
+        const float cos_c = sycl::fmax(cos_theta, nm.cos_min);
+        tan2 = (1.0f - cos_c * cos_c) / (cos_c * cos_c);
+    }
+
+    const float sigma_sq =
+        nm.sigma_range * nm.sigma_range * d_sq + nm.sigma_grazing * nm.sigma_grazing * tan2;
+
+    float lambda_min = nm.min_eigenvalue + sigma_sq;
+    lambda_min = sycl::clamp(lambda_min, nm.min_eigenvalue, nm.max_eigenvalue);
+
+    const auto diag = eigen_utils::as_diagonal<3>({lambda_min, 1.0f, 1.0f});
     cov.block<3, 3>(0, 0) = eigen_utils::multiply<3, 3, 3>(eigen_utils::multiply<3, 3, 3>(eigenvectors, diag),
                                                            eigen_utils::transpose<3, 3>(eigenvectors));
 }

--- a/cpp/include/sycl_points/algorithms/feature/covariance.hpp
+++ b/cpp/include/sycl_points/algorithms/feature/covariance.hpp
@@ -15,10 +15,10 @@ namespace covariance {
 /// @note With sigma_range = sigma_grazing = 0 and min/max = (1e-3, 1.0),
 ///       the noise-aware regularizer reduces to the standard {1e-3, 1, 1} planar form.
 struct NoiseModel {
-    float sigma_range = 0.0f;      // [m/m] range-proportional std-dev (added variance grows as (sigma_range * d)^2)
+    float sigma_range = 0.0f;      // [m/m] range-proportional std-dev (variance contribution: (sigma_range * d)^2)
     float sigma_grazing = 0.0f;    // [dimensionless] tan(theta)-proportional std-dev for incidence-angle noise
-    float min_eigenvalue = 1e-3f;  // lower clamp for the regularized minimum eigenvalue
-    float max_eigenvalue = 1.0f;   // upper clamp for the regularized minimum eigenvalue
+    float min_eigenvalue = 1e-3f;  // numerical floor for lambda_min (planar regularization baseline; lambda_min when sigma_sq = 0)
+    float max_eigenvalue = 1.0f;   // upper cap; clamping here drives source covariance toward isotropy (target-driven point-to-plane behavior)
     float cos_min = 0.1f;          // clamp on |cos(theta)| to avoid tan() divergence near grazing rays
 };
 
@@ -88,8 +88,10 @@ SYCL_EXTERNAL inline void update_covariance_plane(Covariance& cov) {
 /// @param cov Covariance to regularize (in place)
 /// @param pt_in_sensor_frame Source point in the LiDAR sensor frame (pre-transform)
 /// @param nm Noise model parameters
-/// @note Reduces to update_covariance_plane when nm.sigma_range == 0 && nm.sigma_grazing == 0
-///       (then lambda_min = clamp(min_eigenvalue + 0, min_eigenvalue, max_eigenvalue) = min_eigenvalue).
+/// @note sigma_sq is the variance along the local surface normal projected from modeled sensor noise.
+///       With nm.sigma_range == 0 && nm.sigma_grazing == 0, sigma_sq = 0 and
+///       lambda_min = clamp(0, min_eigenvalue, max_eigenvalue) = min_eigenvalue,
+///       reducing exactly to the {min_eigenvalue, 1, 1} planar form used by update_covariance_plane.
 SYCL_EXTERNAL inline void update_covariance_plane_noise_aware(Covariance& cov, const PointType& pt_in_sensor_frame,
                                                               const NoiseModel& nm) {
     Eigen::Vector3f eigenvalues;
@@ -107,13 +109,15 @@ SYCL_EXTERNAL inline void update_covariance_plane_noise_aware(Covariance& cov, c
         const float cos_theta = sycl::fabs(eigen_utils::dot<3>(n, p)) / d;
         // Guard against misconfigured nm.cos_min <= 0 to keep tan2 finite.
         const float cos_c = sycl::fmax(cos_theta, sycl::fmax(nm.cos_min, 1e-6f));
-        tan2 = (1.0f - cos_c * cos_c) / (cos_c * cos_c);
+        const float cos2 = cos_c * cos_c;
+        tan2 = 1.0f / cos2 - 1.0f;
     }
 
+    // sigma_sq IS the variance along the surface normal from modeled sensor noise.
+    // min_eigenvalue acts as a numerical floor (planar regularization baseline);
+    // max_eigenvalue caps lambda_min so the source covariance does not exceed isotropic scale.
     const float sigma_sq = nm.sigma_range * nm.sigma_range * d_sq + nm.sigma_grazing * nm.sigma_grazing * tan2;
-
-    float lambda_min = nm.min_eigenvalue + sigma_sq;
-    lambda_min = sycl::clamp(lambda_min, nm.min_eigenvalue, nm.max_eigenvalue);
+    const float lambda_min = sycl::clamp(sigma_sq, nm.min_eigenvalue, nm.max_eigenvalue);
 
     const auto diag = eigen_utils::as_diagonal<3>({lambda_min, 1.0f, 1.0f});
     cov.block<3, 3>(0, 0) = eigen_utils::multiply<3, 3, 3>(eigen_utils::multiply<3, 3, 3>(eigenvectors, diag),

--- a/cpp/include/sycl_points/algorithms/registration/factor.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/factor.hpp
@@ -239,6 +239,7 @@ SYCL_EXTERNAL inline float calculate_point_to_plane_error(const std::array<sycl:
 SYCL_EXTERNAL inline LinearizedKernelResult linearize_gicp(const std::array<sycl::float4, 4>& T,
                                                            const PointType& source_pt, const Covariance& source_cov,
                                                            const PointType& target_pt, const Covariance& target_cov,
+                                                           const covariance::NoiseModel& source_noise_model,
                                                            float& residual_norm) {
     PointType transform_source_pt;
     transform::kernel::transform_point(source_pt, transform_source_pt, T);
@@ -246,9 +247,11 @@ SYCL_EXTERNAL inline LinearizedKernelResult linearize_gicp(const std::array<sycl
     const PointType residual(target_pt.x() - transform_source_pt.x(), target_pt.y() - transform_source_pt.y(),
                              target_pt.z() - transform_source_pt.z(), 0.0f);
 
+    // Source is in sensor frame; apply range/incidence-angle-aware planar regularization.
     Covariance normalized_source_cov = source_cov;
-    covariance::kernel::update_covariance_plane(normalized_source_cov);
+    covariance::kernel::update_covariance_plane_noise_aware(normalized_source_cov, source_pt, source_noise_model);
 
+    // Target is in map frame (accumulated); use standard planar regularization.
     Covariance normalized_target_cov = target_cov;
     covariance::kernel::update_covariance_plane(normalized_target_cov);
 
@@ -284,7 +287,8 @@ SYCL_EXTERNAL inline LinearizedKernelResult linearize_gicp(const std::array<sycl
 /// @return Squared error
 SYCL_EXTERNAL inline float calculate_gicp_error(const std::array<sycl::float4, 4>& T, const PointType& source_pt,
                                                 const Covariance& source_cov, const PointType& target_pt,
-                                                const Covariance& target_cov) {
+                                                const Covariance& target_cov,
+                                                const covariance::NoiseModel& source_noise_model) {
     PointType transform_source_pt;
     transform::kernel::transform_point(source_pt, transform_source_pt, T);
 
@@ -292,7 +296,7 @@ SYCL_EXTERNAL inline float calculate_gicp_error(const std::array<sycl::float4, 4
                              target_pt.z() - transform_source_pt.z(), 0.0f);
 
     Covariance normalized_source_cov = source_cov;
-    covariance::kernel::update_covariance_plane(normalized_source_cov);
+    covariance::kernel::update_covariance_plane_noise_aware(normalized_source_cov, source_pt, source_noise_model);
 
     Covariance normalized_target_cov = target_cov;
     covariance::kernel::update_covariance_plane(normalized_target_cov);
@@ -414,13 +418,14 @@ SYCL_EXTERNAL inline LinearizedKernelResult linearize_geometry(const std::array<
                                                                const PointType& target_pt, const Covariance& target_cov,
                                                                const Normal& target_normal, float& residual_norm,
                                                                float genz_alpha, float& genz_weight,
+                                                               const covariance::NoiseModel& source_noise_model,
                                                                float genz_planarity_threshold = 0.2f) {
     if constexpr (reg == RegType::POINT_TO_POINT) {
         return linearize_point_to_point(T, source_pt, target_pt, residual_norm);
     } else if constexpr (reg == RegType::POINT_TO_PLANE) {
         return linearize_point_to_plane(T, source_pt, target_pt, target_normal, residual_norm);
     } else if constexpr (reg == RegType::GICP) {
-        return linearize_gicp(T, source_pt, source_cov, target_pt, target_cov, residual_norm);
+        return linearize_gicp(T, source_pt, source_cov, target_pt, target_cov, source_noise_model, residual_norm);
     } else if constexpr (reg == RegType::GENZ) {
         const bool is_planar = is_genz_planar_correspondence(target_cov, genz_planarity_threshold);
         genz_weight = is_planar ? genz_alpha : (1.0f - genz_alpha);
@@ -460,13 +465,14 @@ SYCL_EXTERNAL inline float calculate_geometry_error(const std::array<sycl::float
                                                     const PointType& target_pt, const Covariance& target_cov,  //
                                                     const Normal& target_normal,                               //
                                                     const float genz_alpha, float& genz_weight,
+                                                    const covariance::NoiseModel& source_noise_model,
                                                     const float genz_planarity_threshold = 0.2f) {
     if constexpr (reg == RegType::POINT_TO_POINT) {
         return calculate_point_to_point_error(T, source_pt, target_pt);
     } else if constexpr (reg == RegType::POINT_TO_PLANE) {
         return calculate_point_to_plane_error(T, source_pt, target_pt, target_normal);
     } else if constexpr (reg == RegType::GICP) {
-        return calculate_gicp_error(T, source_pt, source_cov, target_pt, target_cov);
+        return calculate_gicp_error(T, source_pt, source_cov, target_pt, target_cov, source_noise_model);
     } else if constexpr (reg == RegType::GENZ) {
         const bool is_planar = is_genz_planar_correspondence(target_cov, genz_planarity_threshold);
         genz_weight = is_planar ? genz_alpha : (1.0f - genz_alpha);

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -428,6 +428,7 @@ private:
                 this->params_.max_correspondence_distance * this->params_.max_correspondence_distance;
             const float genz_alpha = this->genz_alpha_;
             const float genz_planarity_threshold = this->params_.genz.planarity_threshold;
+            const covariance::NoiseModel source_noise_model = this->params_.source_noise_model;
             auto weights_ptr = out.data();
 
             h.depends_on(depends);
@@ -444,7 +445,7 @@ private:
                     float genz_weight = 1.0f;  // compute, but not use
                     const float squared_error = kernel::calculate_geometry_error<reg>(
                         cur_T, source_ptr[index], source_cov, target_ptr[target_idx], target_cov, target_normal,
-                        genz_alpha, genz_weight, genz_planarity_threshold);
+                        genz_alpha, genz_weight, source_noise_model, genz_planarity_threshold);
                     const float residual_norm = sycl::sqrt(squared_error);
 
                     weight = robust::kernel::compute_weight<loss>(residual_norm, robust_scale);
@@ -557,6 +558,7 @@ private:
                 this->params_.max_correspondence_distance * this->params_.max_correspondence_distance;
             const float genz_alpha = this->genz_alpha_;
             const float genz_planarity_threshold = this->params_.genz.planarity_threshold;
+            const covariance::NoiseModel source_noise_model = this->params_.source_noise_model;
 
             const bool rotation_constraint_enable = this->params_.rotation_constraint.enable;
             const float rotation_constraint_robust_scale = rotation_robust_scale;
@@ -622,7 +624,8 @@ private:
                                                             source_ptr[index], source_cov,                      //
                                                             target_ptr[target_idx], target_cov, target_normal,  //
                                                             residual_norm,                                      //
-                                                            genz_alpha, genz_weight, genz_planarity_threshold);
+                                                            genz_alpha, genz_weight, source_noise_model,
+                                                            genz_planarity_threshold);
 
                         // Apply robust kernel
                         const float robust_weight = robust::kernel::compute_weight<loss>(residual_norm, robust_scale);
@@ -776,6 +779,7 @@ private:
 
             const float genz_alpha = this->genz_alpha_;
             const float genz_planarity_threshold = this->params_.genz.planarity_threshold;
+            const covariance::NoiseModel source_noise_model = this->params_.source_noise_model;
 
             const float photometric_weight = this->params_.photometric.enable ? this->params_.photometric.weight : 0.0f;
             const float photometric_robust_scale =
@@ -822,7 +826,7 @@ private:
                             cur_T,                                              //
                             source_ptr[index], source_cov,                      // source
                             target_ptr[target_idx], target_cov, target_normal,  // target
-                            genz_alpha, genz_weight, genz_planarity_threshold);
+                            genz_alpha, genz_weight, source_noise_model, genz_planarity_threshold);
                         const float residual_norm = sycl::sqrt(squared_error);
 
                         // Apply robust kernel

--- a/cpp/include/sycl_points/algorithms/registration/registration_params.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration_params.hpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "sycl_points/algorithms/feature/covariance.hpp"
 #include "sycl_points/algorithms/registration/degenerate_regularization.hpp"
 #include "sycl_points/algorithms/registration/map_prior.hpp"
 #include "sycl_points/algorithms/registration/factor.hpp"
@@ -106,6 +107,10 @@ struct RegistrationParams {
 
     DegenerateRegularizationParams degenerate_reg;  // Degenerate Regularization
     MapPriorParams map_prior;                        // MAP estimation prior using previous-frame Hessian
+
+    // Source-side sensor noise model for GICP planar regularization.
+    // Defaults (sigma_range = sigma_grazing = 0, min/max = 1e-3/1.0) reproduce the original {1e-3, 1, 1} behavior.
+    covariance::NoiseModel source_noise_model;
 
     bool verbose = false;  // If true, print debug messages
 };

--- a/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
@@ -210,13 +210,15 @@ lidar_inertial_odometry_node:
     registration/genz/planarity_threshold: 0.2
 
     # GICP source-side sensor noise model (range/incidence-angle-aware planar regularization).
-    # Inflates the minimum eigenvalue of the source covariance for distant or grazing points.
+    # Models the source covariance's minimum eigenvalue (normal-direction variance) as
+    #   lambda_min = clamp(sigma_range^2 * d^2 + sigma_grazing^2 * tan^2(theta), min_eigenvalue, max_eigenvalue)
+    # so that distant or grazing source points contribute less to the planar constraint.
     # Set sigma_range = sigma_grazing = 0.0 to disable (reproduces the original {1e-3, 1, 1} behavior).
-    registration/source_noise_model/sigma_range: 0.0     # [m/m]   range-proportional std-dev (variance grows as (sigma_range * d)^2)
-    registration/source_noise_model/sigma_grazing: 0.0   # [-]     tan(theta)-proportional std-dev for incidence-angle noise
-    registration/source_noise_model/min_eigenvalue: 1.0e-3
-    registration/source_noise_model/max_eigenvalue: 1.0
-    registration/source_noise_model/cos_min: 0.1         # clamp on |cos(theta)| to avoid tan() divergence near grazing rays
+    registration/source_noise_model/sigma_range: 0.0     # [m/m] range-proportional std-dev (variance contribution: (sigma_range * d)^2)
+    registration/source_noise_model/sigma_grazing: 0.0   # [-]   tan(theta)-proportional std-dev for incidence-angle noise
+    registration/source_noise_model/min_eigenvalue: 1.0e-3  # numerical floor for lambda_min (planar regularization baseline)
+    registration/source_noise_model/max_eigenvalue: 1.0     # upper cap; clamping here drives source covariance toward isotropy (target-driven point-to-plane behavior)
+    registration/source_noise_model/cos_min: 0.1            # clamp on |cos(theta)| to avoid tan() divergence near grazing rays
 
     registration/gn/lambda: 1.0e-3
 

--- a/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
@@ -209,6 +209,15 @@ lidar_inertial_odometry_node:
 
     registration/genz/planarity_threshold: 0.2
 
+    # GICP source-side sensor noise model (range/incidence-angle-aware planar regularization).
+    # Inflates the minimum eigenvalue of the source covariance for distant or grazing points.
+    # Set sigma_range = sigma_grazing = 0.0 to disable (reproduces the original {1e-3, 1, 1} behavior).
+    registration/source_noise_model/sigma_range: 0.0     # [m/m]   range-proportional std-dev (variance grows as (sigma_range * d)^2)
+    registration/source_noise_model/sigma_grazing: 0.0   # [-]     tan(theta)-proportional std-dev for incidence-angle noise
+    registration/source_noise_model/min_eigenvalue: 1.0e-3
+    registration/source_noise_model/max_eigenvalue: 1.0
+    registration/source_noise_model/cos_min: 0.1         # clamp on |cos(theta)| to avoid tan() divergence near grazing rays
+
     registration/gn/lambda: 1.0e-3
 
     registration/degenerate_regularization/type: "NL_REG" # NONE, NL_REG

--- a/ros2/sycl_points_ros2/config/lidar_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_odometry.yaml
@@ -214,6 +214,15 @@ lidar_odometry_node:
 
     registration/genz/planarity_threshold: 0.2
 
+    # GICP source-side sensor noise model (range/incidence-angle-aware planar regularization).
+    # Inflates the minimum eigenvalue of the source covariance for distant or grazing points.
+    # Set sigma_range = sigma_grazing = 0.0 to disable (reproduces the original {1e-3, 1, 1} behavior).
+    registration/source_noise_model/sigma_range: 0.0     # [m/m]   range-proportional std-dev (variance grows as (sigma_range * d)^2)
+    registration/source_noise_model/sigma_grazing: 0.0   # [-]     tan(theta)-proportional std-dev for incidence-angle noise
+    registration/source_noise_model/min_eigenvalue: 1.0e-3
+    registration/source_noise_model/max_eigenvalue: 1.0
+    registration/source_noise_model/cos_min: 0.1         # clamp on |cos(theta)| to avoid tan() divergence near grazing rays
+
     # Anderson Acceleration
     registration/anderson/enabled: false    # If true, apply Anderson acceleration to the outer iteration
     registration/anderson/window_size: 5    # History window size m (Anderson(m))

--- a/ros2/sycl_points_ros2/config/lidar_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_odometry.yaml
@@ -215,13 +215,15 @@ lidar_odometry_node:
     registration/genz/planarity_threshold: 0.2
 
     # GICP source-side sensor noise model (range/incidence-angle-aware planar regularization).
-    # Inflates the minimum eigenvalue of the source covariance for distant or grazing points.
+    # Models the source covariance's minimum eigenvalue (normal-direction variance) as
+    #   lambda_min = clamp(sigma_range^2 * d^2 + sigma_grazing^2 * tan^2(theta), min_eigenvalue, max_eigenvalue)
+    # so that distant or grazing source points contribute less to the planar constraint.
     # Set sigma_range = sigma_grazing = 0.0 to disable (reproduces the original {1e-3, 1, 1} behavior).
-    registration/source_noise_model/sigma_range: 0.0     # [m/m]   range-proportional std-dev (variance grows as (sigma_range * d)^2)
-    registration/source_noise_model/sigma_grazing: 0.0   # [-]     tan(theta)-proportional std-dev for incidence-angle noise
-    registration/source_noise_model/min_eigenvalue: 1.0e-3
-    registration/source_noise_model/max_eigenvalue: 1.0
-    registration/source_noise_model/cos_min: 0.1         # clamp on |cos(theta)| to avoid tan() divergence near grazing rays
+    registration/source_noise_model/sigma_range: 0.0     # [m/m] range-proportional std-dev (variance contribution: (sigma_range * d)^2)
+    registration/source_noise_model/sigma_grazing: 0.0   # [-]   tan(theta)-proportional std-dev for incidence-angle noise
+    registration/source_noise_model/min_eigenvalue: 1.0e-3  # numerical floor for lambda_min (planar regularization baseline)
+    registration/source_noise_model/max_eigenvalue: 1.0     # upper cap; clamping here drives source covariance toward isotropy (target-driven point-to-plane behavior)
+    registration/source_noise_model/cos_min: 0.1            # clamp on |cos(theta)| to avoid tan() divergence near grazing rays
 
     # Anderson Acceleration
     registration/anderson/enabled: false    # If true, apply Anderson acceleration to the outer iteration

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
@@ -284,6 +284,20 @@ inline pipeline::lidar_odometry::Parameters declare_lidar_odometry_parameters(rc
             genz.planarity_threshold =
                 node->declare_parameter<double>("registration/genz/planarity_threshold", genz.planarity_threshold);
         }
+        // Source noise model (GICP planar regularization)
+        // sigma_range = sigma_grazing = 0 reproduces the standard {1e-3, 1, 1} behavior.
+        {
+            auto& nm = solver.source_noise_model;
+            nm.sigma_range = node->declare_parameter<double>("registration/source_noise_model/sigma_range",
+                                                             nm.sigma_range);
+            nm.sigma_grazing = node->declare_parameter<double>("registration/source_noise_model/sigma_grazing",
+                                                               nm.sigma_grazing);
+            nm.min_eigenvalue = node->declare_parameter<double>("registration/source_noise_model/min_eigenvalue",
+                                                                nm.min_eigenvalue);
+            nm.max_eigenvalue = node->declare_parameter<double>("registration/source_noise_model/max_eigenvalue",
+                                                                nm.max_eigenvalue);
+            nm.cos_min = node->declare_parameter<double>("registration/source_noise_model/cos_min", nm.cos_min);
+        }
         // Rotation Constraint
         {
             auto& rotation_constraint = solver.rotation_constraint;

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
@@ -288,15 +288,16 @@ inline pipeline::lidar_odometry::Parameters declare_lidar_odometry_parameters(rc
         // sigma_range = sigma_grazing = 0 reproduces the standard {1e-3, 1, 1} behavior.
         {
             auto& nm = solver.source_noise_model;
-            nm.sigma_range = node->declare_parameter<double>("registration/source_noise_model/sigma_range",
-                                                             nm.sigma_range);
-            nm.sigma_grazing = node->declare_parameter<double>("registration/source_noise_model/sigma_grazing",
-                                                               nm.sigma_grazing);
-            nm.min_eigenvalue = node->declare_parameter<double>("registration/source_noise_model/min_eigenvalue",
-                                                                nm.min_eigenvalue);
-            nm.max_eigenvalue = node->declare_parameter<double>("registration/source_noise_model/max_eigenvalue",
-                                                                nm.max_eigenvalue);
-            nm.cos_min = node->declare_parameter<double>("registration/source_noise_model/cos_min", nm.cos_min);
+            nm.sigma_range = static_cast<float>(
+                node->declare_parameter<double>("registration/source_noise_model/sigma_range", nm.sigma_range));
+            nm.sigma_grazing = static_cast<float>(
+                node->declare_parameter<double>("registration/source_noise_model/sigma_grazing", nm.sigma_grazing));
+            nm.min_eigenvalue = static_cast<float>(
+                node->declare_parameter<double>("registration/source_noise_model/min_eigenvalue", nm.min_eigenvalue));
+            nm.max_eigenvalue = static_cast<float>(
+                node->declare_parameter<double>("registration/source_noise_model/max_eigenvalue", nm.max_eigenvalue));
+            nm.cos_min = static_cast<float>(
+                node->declare_parameter<double>("registration/source_noise_model/cos_min", nm.cos_min));
         }
         // Rotation Constraint
         {


### PR DESCRIPTION
## Summary
- Extends GICP source covariance planar regularization with a configurable sensor noise model: the minimum eigenvalue is inflated by `sigma_range^2 * d^2 + sigma_grazing^2 * tan^2(theta)` then clamped to `[min_eigenvalue, max_eigenvalue]`, down-weighting distant and grazing-angle source points.
- Target covariance keeps the original `{1e-3, 1, 1}` regularization since accumulated map points lack a meaningful sensor-frame range/incidence-angle.
- Feature is opt-in via new `registration/source_noise_model/*` ROS2 parameters; defaults (`sigma_range = sigma_grazing = 0`) reproduce the original behavior bit-exactly.

## Design notes
- Implemented as a covariance-preprocessing extension rather than a new `RegType` variant, since the GICP residual and Jacobian are unchanged — only the regularization step varies.
- `update_covariance_plane_noise_aware()` runs inside the SYCL kernel alongside the existing `update_covariance_plane()`. This matches the baseline structure (target side still does in-kernel regularization). A future optimization could pre-compute source covariance once per frame.
- Source `pt` is confirmed to be in LiDAR sensor frame (see [lidar_odometry.hpp:309](https://github.com/fateshelled/sycl_points/blob/main/cpp/include/sycl_points/pipeline/lidar_odometry.hpp#L309) and [lidar_inertial_odometry.hpp:233](https://github.com/fateshelled/sycl_points/blob/main/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp#L233)), so `d = |pt|` and the incidence-angle calculation against the local plane normal (smallest-eigenvalue eigenvector) are physically valid.

## Test plan
- [x] Build passes (`source scripts/build.bash`, AdaptiveCpp/CUDA, Release).
- [ ] Run `source scripts/run.bash` / `source scripts/run_lio.bash` with defaults to confirm baseline behavior is unchanged.
- [ ] Enable `registration/source_noise_model/sigma_range` (e.g. `0.005`) and `sigma_grazing` (e.g. `0.05`) on a dataset with grazing surfaces and verify trajectory quality (ATE/RPE) vs. baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)