### PR TITLE
refactor: rename iteration parameters to reflect loop semantics

### DIFF
--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -474,11 +474,11 @@ private:
         last_icp.inlier = 0;
         size_t actual_iterations = 0;
 
-        for (size_t iter = 0; iter < this->params_.lio.max_iterations; ++iter) {
+        for (size_t iter = 0; iter < this->params_.lio.total_iterations; ++iter) {
             ++actual_iterations;
 
-            if (robust.auto_scale && this->params_.lio.max_iterations > 1) {
-                const float t = static_cast<float>(iter) / static_cast<float>(this->params_.lio.max_iterations - 1);
+            if (robust.auto_scale && this->params_.lio.total_iterations > 1) {
+                const float t = static_cast<float>(iter) / static_cast<float>(this->params_.lio.total_iterations - 1);
                 options.robust_scale =
                     std::max(robust.init_scale * std::pow(robust.min_scale / robust.init_scale, t), robust.min_scale);
             }

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry_params.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry_params.hpp
@@ -13,8 +13,11 @@ namespace lidar_inertial_odometry {
 /// IMU is always required; params_.imu.enable is forced true in the pipeline.
 struct Parameters : public lidar_odometry::Parameters {
     struct LIO {
-        /// Maximum number of Gauss-Newton iterations per frame.
-        size_t max_iterations = 10;
+        /// Total number of IEKF/Gauss-Newton iterations per frame.
+        /// The IEKF loop is flat: each iteration runs one linearize+solve, and the
+        /// robust scale is annealed across these iterations. So this value is the
+        /// total linearize+solve count (unlike the nested LO solver loop).
+        size_t total_iterations = 10;
         // Convergence threshold
         algorithms::registration::RegistrationParams::Criteria criteria;
         /// Regularization factor for velocity and bias when P_pred is singular.

--- a/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
@@ -163,7 +163,9 @@ lidar_inertial_odometry_node:
     submap/occupancy_grid_map/stale_frame_threshold: 600
 
     # LIO optimization (Gauss-Newton combining ICP + IMU Hessians)
-    lio/max_iterations: 8
+    # Total IEKF iterations per frame: each iteration = one linearize+solve,
+    # with the robust scale annealed across these iterations (flat loop).
+    lio/total_iterations: 8
     lio/criteria/translation: 0.01  # [m]
     lio/criteria/rotation: 0.01     # [rad]
     lio/invalid_regularization_factor: 1.0e+4
@@ -178,7 +180,7 @@ lidar_inertial_odometry_node:
     lio/icp_rotation_sigma: 0.01  # [rad]
 
     # ICP registration backend (used for linearization inside the LIO loop)
-    # registration/max_iterations is unused; outer loop count is lio/max_iterations.
+    # registration/solver_iterations is unused; the loop count is lio/total_iterations.
     registration/type: gicp # point_to_point, point_to_plane, point_to_distribution, gicp, genz
     registration/min_num_points: 300
     registration/random_sampling/enable: true

--- a/ros2/sycl_points_ros2/config/lidar_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_odometry.yaml
@@ -177,7 +177,11 @@ lidar_odometry_node:
     # Silently falls back to uniform sampling when the source has no intensity field.
     registration/random_sampling/use_intensities: false
     registration/random_sampling/weighted_ratio: 0.8  # Fraction of samples from the weighted distribution [0.0, 1.0]
-    registration/max_iterations: 4
+    # Iterations of the innermost solver only. The actual max loop count is the
+    # product of the three nested loops:
+    #   auto_scaling_iter x velocity_update/iter x solver_iterations
+    #   (current config: 4 x 2 x 4 = 32; LM inner iterations are additional)
+    registration/solver_iterations: 4
     registration/max_correspondence_distance: 2.0
     registration/criteria/translation: 1.0e-3  # [m]
     registration/criteria/rotation: 1.0e-6     # [rad]

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_inertial_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_inertial_odometry_params.hpp
@@ -24,8 +24,8 @@ inline pipeline::lidar_inertial_odometry::Parameters declare_lidar_inertial_odom
         "imu/preintegration/accel_bias_rw_density", params.imu.preintegration.accel_bias_rw_density));
 
     // LIO-specific optimization parameters
-    params.lio.max_iterations =
-        static_cast<size_t>(node->declare_parameter<int64_t>("lio/max_iterations", params.lio.max_iterations));
+    params.lio.total_iterations =
+        static_cast<size_t>(node->declare_parameter<int64_t>("lio/total_iterations", params.lio.total_iterations));
     params.lio.criteria.rotation =
         node->declare_parameter<double>("lio/criteria/rotation", params.lio.criteria.rotation);
     params.lio.criteria.translation =

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
@@ -227,8 +227,10 @@ inline pipeline::lidar_odometry::Parameters declare_lidar_odometry_parameters(rc
 
             const std::string reg_type = node->declare_parameter<std::string>("registration/type", "gicp");
             solver.reg_type = algorithms::registration::RegType_from_string(reg_type);
+            // Innermost solver iterations. The total max loop count is
+            // auto_scaling_iter x velocity_update/iter x solver_iterations.
             solver.max_iterations =
-                node->declare_parameter<int64_t>("registration/max_iterations", solver.max_iterations);
+                node->declare_parameter<int64_t>("registration/solver_iterations", solver.max_iterations);
             solver.criteria.translation =
                 node->declare_parameter<double>("registration/criteria/translation", solver.criteria.translation);
             solver.criteria.rotation =


### PR DESCRIPTION
## 概要

イテレーション回数を表すパラメータ名を、実際のループ構造を正しく反映するようにリネームしました。誤解を招く `max_iterations` を、各ループの実際の意味に沿った名前に変更しています。

## 変更内容

### LIO: `lio/max_iterations` → `lio/total_iterations`
- IEKF ループはフラットな構造で、各イテレーションが 1 回の linearize+solve を実行し、robust scale はこのイテレーション全体でアニーリングされる。
- したがってこの値は「最大回数」ではなく linearize+solve の**総数**であるため、`total_iterations` にリネーム。

### LO: `registration/max_iterations` → `registration/solver_iterations`
- これは最内ソルバのイテレーション回数のみを指す。
- 実際の最大ループ回数は 3 つのネストしたループの積:
  `auto_scaling_iter × velocity_update/iter × solver_iterations`（現行設定では 4 × 2 × 4 = 32、LM の内部反復は別途追加）。
- 意味を明確にするため `solver_iterations` にリネームし、関連するコメントも更新。

## 変更ファイル
- `cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp`
- `cpp/include/sycl_points/pipeline/lidar_inertial_odometry_params.hpp`
- `ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml`
- `ros2/sycl_points_ros2/config/lidar_odometry.yaml`
- `ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_inertial_odometry_params.hpp`
- `ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)