### PR TITLE
refactor(tf): 3段TFチェーンを廃止し標準的な単一段 (odom→base_link→sensor) へ再設計

### DIFF
--- a/cpp/include/sycl_points/algorithms/imu/imu_initial_alignment.hpp
+++ b/cpp/include/sycl_points/algorithms/imu/imu_initial_alignment.hpp
@@ -211,7 +211,9 @@ namespace detail {
 inline float yaw_from_rotation(const Eigen::Matrix3f& R) {
     const float cy = R(0, 0);
     const float sy = R(1, 0);
-    if (std::hypot(cy, sy) < 1e-6f) return 0.0f;
+    // Rotation-matrix elements are bounded in [-1, 1], so a direct squared-sum
+    // comparison is safe and avoids std::hypot's under/overflow guarding overhead.
+    if ((cy * cy + sy * sy) < 1e-12f) return 0.0f;
     return std::atan2(sy, cy);
 }
 

--- a/cpp/include/sycl_points/algorithms/imu/imu_initial_alignment.hpp
+++ b/cpp/include/sycl_points/algorithms/imu/imu_initial_alignment.hpp
@@ -203,21 +203,34 @@ inline InitialAlignmentResult estimate_initial_alignment(const std::deque<IMUMea
     return res;
 }
 
+namespace detail {
+
+/// @brief Extract the yaw component (ZYX convention) of a rotation matrix using atan2 on
+///        the first column.  Avoids gimbal-lock corner cases at pitch = ±π/2 by returning
+///        0 when the horizontal projection of the first column collapses.
+inline float yaw_from_rotation(const Eigen::Matrix3f& R) {
+    const float cy = R(0, 0);
+    const float sy = R(1, 0);
+    if (std::hypot(cy, sy) < 1e-6f) return 0.0f;
+    return std::atan2(sy, cy);
+}
+
+}  // namespace detail
+
 /// @brief Stationary-IMU initial roll/pitch alignment.
 ///
 /// Wraps estimate_initial_alignment and owns:
 ///   - the wait/timeout clock (started at the first try),
-///   - the gravity-aligned LiDAR rotation in the imu_attitude frame.
+///   - the gravity-aligned LiDAR rotation (yaw ≈ 0).
 ///
 /// The caller polls try_align() once per scan while is_done() is false.  On success
 /// the result is applied by the caller to its own state (pose, gyro bias, IMU
 /// preintegration reset) because state layouts differ between LO and LIO.
 ///
-/// Frame convention (see 3-stage TF chain in lidar_inertial_odometry.hpp):
-///   world ──TF1(user yaw+pos)──▶ init_pose ──TF2──▶ imu_attitude ──x_──▶ lidar
-/// User yaw is held externally by TF1, so this estimator no longer composes it back
-/// into its output.  The returned R_imu_att_lidar is the LiDAR's rotation in the
-/// imu_attitude frame at startup (carries the gravity-corrected roll/pitch).
+/// The returned R_gravity_lidar is the LiDAR's gravity-aligned rotation with yaw ≈ 0
+/// (gravity constrains roll/pitch only).  The caller layers the user-specified yaw on
+/// the left (Rz(yaw_user) * R_gravity_lidar) to obtain the initial T_odom_to_lidar in
+/// the gravity-aligned odom/world frame.
 class InitialAlignmentEstimator {
 public:
     using Ptr = std::shared_ptr<InitialAlignmentEstimator>;
@@ -232,12 +245,11 @@ public:
         std::string error_message;  ///< populated on Status::waiting (diagnostic)
 
         // Valid only when status == success.
-        /// LiDAR rotation in the imu_attitude frame after gravity-aligned roll/pitch
-        /// correction.  Yaw is approximately zero by construction (FromTwoVectors
-        /// returns the minimum rotation that maps body_up → world_up, whose axis lies
-        /// in the gravity-orthogonal plane).  The caller assigns this directly to its
-        /// LIO state rotation; user-specified yaw is preserved separately via TF1.
-        Eigen::Matrix3f R_imu_att_lidar = Eigen::Matrix3f::Identity();
+        /// Gravity-aligned LiDAR rotation with yaw ≈ 0 by construction (FromTwoVectors
+        /// returns the minimum rotation that maps body_up → world_up, whose axis lies in
+        /// the gravity-orthogonal plane).  The caller layers the user-specified yaw on
+        /// the left to obtain the initial T_odom_to_lidar rotation.
+        Eigen::Matrix3f R_gravity_lidar = Eigen::Matrix3f::Identity();
         Eigen::Vector3f gyro_bias = Eigen::Vector3f::Zero();
         float roll_rad = 0.0f;
         float pitch_rad = 0.0f;
@@ -298,15 +310,15 @@ public:
             return out;
         }
 
-        // R_imu_att_lidar = R_world_imu_aligned * R_imu_to_lidar^T.
+        // R_gravity_lidar = R_world_imu_aligned * R_imu_to_lidar^T.
         // The result's yaw is ≈ 0 because FromTwoVectors returns the minimum rotation
-        // (whose axis lies in the gravity-orthogonal plane); user yaw is layered on
-        // externally by the caller through TF1, not here.
+        // (whose axis lies in the gravity-orthogonal plane); user yaw is layered on the
+        // left by the caller, not here.
         const Eigen::Matrix3f R_imu_to_lidar = this->T_imu_to_lidar_.linear();
-        const Eigen::Matrix3f R_imu_att_lidar = result.R_world_imu * R_imu_to_lidar.transpose();
+        const Eigen::Matrix3f R_gravity_lidar = result.R_world_imu * R_imu_to_lidar.transpose();
 
         out.status = Status::success;
-        out.R_imu_att_lidar = R_imu_att_lidar;
+        out.R_gravity_lidar = R_gravity_lidar;
         out.gyro_bias = result.gyro_bias;
         out.roll_rad = result.roll_rad;
         out.pitch_rad = result.pitch_rad;

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -24,26 +24,20 @@
 // (6×6, from SYCL parallel reduction) with the IMU prior Hessian/gradient
 // (15×15) into a unified 15-DOF normal equation solved by LDLT.
 //
-// Frame convention: 3-stage TF chain
-//   world ──TF1──▶ init_pose ──TF2──▶ imu_attitude ──TF3 (= x_)──▶ lidar
+// Frame convention: single-stage, REP-105 style (FAST-LIO2-like).
+//   odom ──(estimated, dynamic)──▶ lidar     (odom is the gravity-aligned world frame)
 //
-//   TF1 = T_world_init_   : static, captured at init from params_.pose.initial.
-//                           Holds user-specified initial pose (yaw + position).
-//                           init_pose is gravity-aligned by user definition
-//                           (the user is expected to specify a level pose).
-//   TF2 = R_init_imu_att_ : rotation only.  Identity in Phase 1; a placeholder
-//                           for future online gravity correction (Phase 3).
-//                           imu_attitude is therefore gravity-aligned in Phase 1
-//                           (= init_pose), so gravity stays (0,0,-g) canonical.
-//   TF3 = x_              : 15-DOF LIO state (the time-varying pose tracked by
-//                           the IEKF, expressed in the imu_attitude frame).
+//   The 15-DOF IEKF state x_ is the LiDAR pose expressed directly in the gravity-
+//   aligned odom (world) frame:
+//     x_.position  = odom-frame position of the LiDAR origin [m]
+//     x_.rotation  = R_odom_lidar  (SO(3))
+//     x_.velocity  = odom-frame velocity of the LiDAR body [m/s]
+//     x_.accel_bias / gyro_bias = IMU biases (body frame)
 //
-//   x_.position  = imu_attitude-frame position of the LiDAR origin [m]
-//   x_.rotation  = R_imu_att_lidar  (SO(3))
-//   x_.velocity  = imu_attitude-frame velocity of the LiDAR body [m/s]
-//   x_.accel_bias / gyro_bias = IMU biases (body frame)
-//
-//   Composed world pose:  T_world_lidar = T_world_init_ * R_init_imu_att_ * x_
+//   The initial orientation is Rz(user_yaw) * R_gravity (roll/pitch from the IMU
+//   initial alignment), so odom is gravity-aligned and the preintegration gravity
+//   stays (0,0,-g) canonical.  The ROS node converts to base_link via the static
+//   T_base_link_to_lidar extrinsic when broadcasting odom → base_link.
 //
 // The ICP Hessian is embedded into the 15-DOF LiDAR-frame error-state.  The
 // IMU preintegration covariance lives in the IMU error-state and is rotated
@@ -93,23 +87,14 @@ public:
     const auto& get_current_processing_time() const { return this->current_processing_time_; }
     const auto& get_total_processing_times() const { return this->total_processing_times_; }
 
-    /// @brief Composed world-frame LiDAR pose: TF1 * TF2 * x_ (back-compat with the
-    ///        previous get_odom() semantics).  Returns by value because the world-frame
-    ///        pose is derived on demand from the imu_att-frame state.
-    Eigen::Isometry3f get_odom() const { return this->compose_world(this->odom_); }
-    Eigen::Isometry3f get_prev_odom() const { return this->compose_world(this->prev_odom_); }
-    Eigen::Isometry3f get_last_keyframe_pose() const {
-        return this->compose_world(this->submap_->get_last_keyframe_pose());
-    }
+    /// @brief Current / previous LiDAR pose in the odom (world) frame.
+    ///        odom is gravity-aligned; T_odom_to_lidar is tracked directly (single-stage).
+    const auto& get_odom() const { return this->odom_; }
+    const auto& get_prev_odom() const { return this->prev_odom_; }
+    const auto& get_last_keyframe_pose() const { return this->submap_->get_last_keyframe_pose(); }
 
-    /// @brief Keyframe poses in the imu_attitude frame.  Compose with
-    ///        get_T_world_init() * get_R_init_imu_att() to obtain world-frame poses.
+    /// @brief Keyframe poses in the odom (world) frame.
     const auto& get_keyframe_poses() const { return this->submap_->get_keyframe_poses(); }
-
-    // 3-stage TF chain accessors (for ROS TF broadcast and inspection).
-    const Eigen::Isometry3f& get_T_world_init() const { return this->T_world_init_; }
-    const Eigen::Matrix3f& get_R_init_imu_att() const { return this->R_init_imu_att_; }
-    const Eigen::Isometry3f& get_odom_imu_att() const { return this->odom_; }
 
     const PointCloudShared& get_preprocessed_point_cloud() const { return *this->preprocessed_pc_; }
     const PointCloudShared& get_submap_point_cloud() const { return this->submap_->get_submap_point_cloud(); }
@@ -228,11 +213,11 @@ public:
         if (this->is_first_frame_) {
             try {
                 // Anchor the first keyframe at the post-alignment LiDAR pose (odom_ in
-                // imu_attitude frame) so that subsequent add_frame() calls share the
+                // the odom/world frame) so that subsequent add_frame() calls share the
                 // same reference frame.  Without this, the first submap content lives
-                // in the sensor frame while later frames live in imu_attitude — visible
-                // as a small (gravity-correction) tilt mismatch in rviz until the voxel
-                // hash map accumulates enough data to swap in.
+                // in the sensor frame while later frames live in odom — visible as a
+                // small (gravity-correction) tilt mismatch in rviz until the voxel hash
+                // map accumulates enough data to swap in.
                 this->submap_->add_first_frame(*this->preprocessed_pc_, timestamp, this->odom_);
             } catch (const std::exception& e) {
                 this->error_message_ = std::string("build_submap (first frame): ") + e.what();
@@ -312,15 +297,8 @@ private:
 
     algorithms::registration::RegistrationResult::Ptr reg_result_ = nullptr;
 
-    /// TF1 (world → init_pose).  Static.  Captures the user-specified initial pose
-    /// (yaw + position) from params_.pose.initial at init time.
-    Eigen::Isometry3f T_world_init_ = Eigen::Isometry3f::Identity();
-    /// TF2 (init_pose → imu_attitude), rotation only.  Identity in Phase 1; a
-    /// placeholder for future online gravity correction (Phase 3).
-    Eigen::Matrix3f R_init_imu_att_ = Eigen::Matrix3f::Identity();
-
-    /// Previous / current LiDAR pose in the imu_attitude frame.  Compose with
-    /// T_world_init_ * R_init_imu_att_ via compose_world() for world-frame output.
+    /// Previous / current LiDAR pose (T_odom_to_lidar) in the odom (world) frame.
+    /// Kept in sync with the IEKF state x_ (odom_ == state_to_pose(x_) after each frame).
     Eigen::Isometry3f prev_odom_;
     Eigen::Isometry3f odom_;
 
@@ -369,13 +347,6 @@ private:
         T.linear() = s.rotation;
         T.translation() = s.position;
         return T;
-    }
-
-    /// @brief Compose an imu_attitude-frame pose into world frame: TF1 * TF2 * pose.
-    Eigen::Isometry3f compose_world(const Eigen::Isometry3f& pose_imu_att) const {
-        Eigen::Isometry3f T_init_imu_att = Eigen::Isometry3f::Identity();
-        T_init_imu_att.linear() = this->R_init_imu_att_;
-        return this->T_world_init_ * T_init_imu_att * pose_imu_att;
     }
 
     bool is_lio_converged(const Eigen::Matrix<float, 15, 1>& delta) const {
@@ -566,15 +537,10 @@ private:
 
         this->icp_weights_ = std::make_shared<shared_vector<float>>(*this->queue_ptr_->ptr);
 
-        // Capture user-specified initial pose into TF1 (T_world_init_), then reset
-        // params_.pose.initial to Identity so all downstream code (Submap, IEKF state,
-        // IMU preintegration linearization point) operates in the imu_attitude frame
-        // (= init_pose in Phase 1, since TF2 = R_init_imu_att_ = Identity).
-        this->T_world_init_ = this->params_.pose.initial;
-        this->R_init_imu_att_ = Eigen::Matrix3f::Identity();
-        this->params_.pose.initial = Eigen::Isometry3f::Identity();
-
-        // Initial pose in imu_attitude frame (Identity until alignment fires).
+        // Initial pose (T_odom_to_lidar in the gravity-aligned odom/world frame).
+        // params_.pose.initial = initial_base_link * T_base_link_to_lidar (composed by
+        // the ROS node).  IMU initial alignment overwrites the rotation with the
+        // gravity-corrected value in apply_initial_alignment().
         this->odom_ = this->params_.pose.initial;
         this->prev_odom_ = this->params_.pose.initial;
 
@@ -597,11 +563,9 @@ private:
         }
 
         // IMU preintegration.
-        // The "world" rotation here lives in the imu_attitude frame (x_'s frame); since
-        // params_.pose.initial was just reset to Identity, this evaluates to R_lidar_imu
-        // (the LiDAR-IMU extrinsic) — the IMU's rotation in imu_attitude when x_ = Identity.
+        // R_world_imu is the IMU's rotation in the odom (world) frame at startup.
         // The first-frame reset_imu_preintegration() will overwrite this with the
-        // post-alignment value before any IMU integration runs.
+        // post-alignment value (gravity-corrected) before any IMU integration runs.
         {
             this->imu_preintegration_ = std::make_shared<imu::IMUPreintegration>(this->params_.imu.preintegration);
             const Eigen::Matrix3f R_world_imu =
@@ -629,21 +593,25 @@ private:
     // -------------------------------------------------------------------------
 
     /// @brief Apply a successful alignment result to the LIO state.
-    /// Updates the navigation-state rotation (the LiDAR's pose in the imu_attitude
-    /// frame), the held gyro bias, and odometry.  The IMU preintegration reset is
-    /// intentionally left to the subsequent first-frame block (which calls
-    /// reset_imu_preintegration() with proper covariance handling) to avoid a
-    /// redundant reset that would discard the P_post_ floor adjustments.
-    /// @note In Phase 1 the alignment result is absorbed into x_.rotation (which lives
-    ///       in the imu_attitude frame).  R_init_imu_att_ stays Identity; Phase 3
-    ///       online correction will repurpose it.
+    /// Replaces the navigation-state rotation with the gravity-corrected initial
+    /// orientation (user yaw preserved, roll/pitch from gravity), updates the held gyro
+    /// bias, and odometry.  The IMU preintegration reset is intentionally left to the
+    /// subsequent first-frame block (which calls reset_imu_preintegration() with proper
+    /// covariance handling) to avoid a redundant reset that would discard the P_post_
+    /// floor adjustments.
+    /// @note out.R_gravity_lidar is the gravity-aligned LiDAR rotation with yaw ≈ 0.
+    ///       The user-specified yaw (from params_.pose.initial) is layered on the left so
+    ///       x_/odom_ stay in the gravity-aligned odom/world frame.
     /// @note Currently only gyro_bias is updated.  If the estimator gains accel_bias
     ///       estimation, extend this method accordingly.
     void apply_initial_alignment(const imu::InitialAlignmentEstimator::Output& out) {
-        this->x_.rotation = out.R_imu_att_lidar;
+        const float yaw_user = imu::detail::yaw_from_rotation(this->params_.pose.initial.rotation());
+        const Eigen::Matrix3f R_odom_lidar =
+            Eigen::AngleAxisf(yaw_user, Eigen::Vector3f::UnitZ()).toRotationMatrix() * out.R_gravity_lidar;
+        this->x_.rotation = R_odom_lidar;
         this->x_.gyro_bias = out.gyro_bias;
-        this->odom_.linear() = out.R_imu_att_lidar;
-        this->prev_odom_.linear() = out.R_imu_att_lidar;
+        this->odom_.linear() = R_odom_lidar;
+        this->prev_odom_.linear() = R_odom_lidar;
     }
 
     // -------------------------------------------------------------------------

--- a/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
@@ -56,23 +56,14 @@ public:
     const auto& get_current_processing_time() const { return this->current_processing_time_; }
     const auto& get_total_processing_times() const { return this->total_processing_times_; }
 
-    /// @brief Composed world-frame LiDAR pose: TF1 * TF2 * x_ (back-compat with the
-    ///        previous get_odom() semantics).  Returns by value because the world-frame
-    ///        pose is derived on demand from the imu_att-frame internal odometry.
-    Eigen::Isometry3f get_odom() const { return this->compose_world(this->odom_); }
-    Eigen::Isometry3f get_prev_odom() const { return this->compose_world(this->prev_odom_); }
-    Eigen::Isometry3f get_last_keyframe_pose() const {
-        return this->compose_world(this->submap_->get_last_keyframe_pose());
-    }
+    /// @brief Current / previous LiDAR pose in the odom (world) frame.
+    ///        odom is gravity-aligned; T_odom_to_lidar is tracked directly (single-stage).
+    const auto& get_odom() const { return this->odom_; }
+    const auto& get_prev_odom() const { return this->prev_odom_; }
+    const auto& get_last_keyframe_pose() const { return this->submap_->get_last_keyframe_pose(); }
 
-    /// @brief Keyframe poses in the imu_attitude frame.  Compose with
-    ///        get_T_world_init() * get_R_init_imu_att() to obtain world-frame poses.
+    /// @brief Keyframe poses in the odom (world) frame.
     const auto& get_keyframe_poses() const { return this->submap_->get_keyframe_poses(); }
-
-    // 3-stage TF chain accessors (for ROS TF broadcast and inspection).
-    const Eigen::Isometry3f& get_T_world_init() const { return this->T_world_init_; }
-    const Eigen::Matrix3f& get_R_init_imu_att() const { return this->R_init_imu_att_; }
-    const Eigen::Isometry3f& get_odom_imu_att() const { return this->odom_; }
 
     const PointCloudShared& get_preprocessed_point_cloud() const { return *this->preprocessed_pc_; }
     const PointCloudShared& get_submap_point_cloud() const { return this->submap_->get_submap_point_cloud(); }
@@ -196,11 +187,11 @@ public:
         if (this->is_first_frame_) {
             try {
                 // Anchor the first keyframe at the post-alignment LiDAR pose (odom_ in
-                // imu_attitude frame) so that subsequent add_frame() calls share the
+                // the odom/world frame) so that subsequent add_frame() calls share the
                 // same reference frame.  Without this, the first submap content lives
-                // in the sensor frame while later frames live in imu_attitude — visible
-                // as a small (gravity-correction) tilt mismatch in rviz until the voxel
-                // hash map accumulates enough data to swap in.
+                // in the sensor frame while later frames live in odom — visible as a
+                // small (gravity-correction) tilt mismatch in rviz until the voxel hash
+                // map accumulates enough data to swap in.
                 this->submap_->add_first_frame(*this->preprocessed_pc_, timestamp, this->odom_);
             } catch (const std::exception& e) {
                 this->error_message_ = std::string("build_submap (first frame): ") + e.what();
@@ -318,17 +309,9 @@ private:
     bool registrated_ = false;
     algorithms::registration::RegistrationResult::Ptr reg_result_ = nullptr;
 
-    /// TF1 (world → init_pose).  Static.  Captures the user-specified initial pose
-    /// (yaw + position) from params_.pose.initial at init time.
-    Eigen::Isometry3f T_world_init_ = Eigen::Isometry3f::Identity();
-    /// TF2 (init_pose → imu_attitude), rotation only.  Identity in Phase 1; a
-    /// placeholder for future online gravity correction (Phase 3).
-    Eigen::Matrix3f R_init_imu_att_ = Eigen::Matrix3f::Identity();
-
     Eigen::Vector3f linear_velocity_;     // [m/s] in previous LiDAR body frame
     Eigen::AngleAxisf angular_velocity_;  // [rad/s]
-    /// Previous / current LiDAR pose in the imu_attitude frame.  Compose with
-    /// T_world_init_ * R_init_imu_att_ via compose_world() for world-frame output.
+    /// Previous / current LiDAR pose (T_odom_to_lidar) in the odom (world) frame.
     Eigen::Isometry3f prev_odom_;
     Eigen::Isometry3f odom_;
 
@@ -396,13 +379,6 @@ private:
 
     bool is_imu_deskew_enabled() const { return this->params_.imu.enable && this->params_.imu.deskew.enable; }
 
-    /// @brief Compose an imu_attitude-frame pose into world frame: TF1 * TF2 * pose.
-    Eigen::Isometry3f compose_world(const Eigen::Isometry3f& pose_imu_att) const {
-        Eigen::Isometry3f T_init_imu_att = Eigen::Isometry3f::Identity();
-        T_init_imu_att.linear() = this->R_init_imu_att_;
-        return this->T_world_init_ * T_init_imu_att * pose_imu_att;
-    }
-
     void initialize() {
         // SYCL queue
         {
@@ -419,15 +395,10 @@ private:
             this->preprocessed_pc_ = std::make_shared<PointCloudShared>(*this->queue_ptr_);
         }
 
-        // Capture user-specified initial pose into TF1 (T_world_init_), then reset
-        // params_.pose.initial to Identity so all downstream code (Submap, odom_,
-        // IMU preintegration linearization point) operates in the imu_attitude frame
-        // (= init_pose in Phase 1, since TF2 = R_init_imu_att_ = Identity).
-        this->T_world_init_ = this->params_.pose.initial;
-        this->R_init_imu_att_ = Eigen::Matrix3f::Identity();
-        this->params_.pose.initial = Eigen::Isometry3f::Identity();
-
-        // set Initial pose (in imu_attitude frame, Identity until alignment fires)
+        // set Initial pose (T_odom_to_lidar in the gravity-aligned odom/world frame).
+        // params_.pose.initial = initial_base_link * T_base_link_to_lidar (composed by
+        // the ROS node).  When IMU initial alignment is enabled it overwrites the
+        // rotation with the gravity-corrected value in apply_initial_alignment().
         {
             this->odom_ = this->params_.pose.initial;
             this->prev_odom_ = this->params_.pose.initial;
@@ -473,11 +444,9 @@ private:
         this->imu_bias_ = this->params_.imu.bias;
 
         // IMU preintegration (optional).
-        // The "world" rotation here lives in the imu_attitude frame (odom_'s frame);
-        // since params_.pose.initial was reset to Identity above, this evaluates to
-        // R_lidar_imu (the LiDAR-IMU extrinsic) — the IMU's rotation in imu_attitude
-        // when odom_ = Identity.  The first-frame block will overwrite this with the
-        // post-alignment value before any IMU integration runs.
+        // R_world_imu is the IMU's rotation in the odom (world) frame at startup.
+        // The first-frame block will overwrite this with the post-alignment value
+        // (gravity-corrected) before any IMU integration runs.
         if (this->params_.imu.enable) {
             this->imu_preintegration_ = std::make_shared<imu::IMUPreintegration>(this->params_.imu.preintegration);
             const Eigen::Matrix3f R_world_imu =
@@ -494,18 +463,22 @@ private:
     }
 
     /// @brief Apply a successful alignment result to the LO state.
-    /// Updates odometry rotation (the LiDAR's pose in the imu_attitude frame) and the
-    /// held IMU bias.  The IMU preintegration reset is intentionally left to the
-    /// subsequent first-frame block, which uses the just-updated odom_/imu_bias_ to
-    /// produce identical post-state without a redundant reset.
-    /// @note In Phase 1 the alignment result is absorbed into odom_.linear() (which
-    ///       lives in the imu_attitude frame).  R_init_imu_att_ stays Identity;
-    ///       Phase 3 online correction will repurpose it.
+    /// Replaces the odometry rotation with the gravity-corrected initial orientation
+    /// (user yaw preserved, roll/pitch from gravity) and updates the held IMU bias.
+    /// The IMU preintegration reset is intentionally left to the subsequent first-frame
+    /// block, which uses the just-updated odom_/imu_bias_ to produce identical post-state
+    /// without a redundant reset.
+    /// @note out.R_gravity_lidar is the gravity-aligned LiDAR rotation with yaw ≈ 0.
+    ///       The user-specified yaw (from params_.pose.initial) is layered on the left so
+    ///       odom_ stays in the gravity-aligned odom/world frame.
     /// @note Currently only gyro_bias is updated.  If the estimator gains accel_bias
     ///       estimation, extend this method accordingly.
     void apply_initial_alignment(const imu::InitialAlignmentEstimator::Output& out) {
-        this->odom_.linear() = out.R_imu_att_lidar;
-        this->prev_odom_.linear() = out.R_imu_att_lidar;
+        const float yaw_user = imu::detail::yaw_from_rotation(this->params_.pose.initial.rotation());
+        const Eigen::Matrix3f R_odom_lidar =
+            Eigen::AngleAxisf(yaw_user, Eigen::Vector3f::UnitZ()).toRotationMatrix() * out.R_gravity_lidar;
+        this->odom_.linear() = R_odom_lidar;
+        this->prev_odom_.linear() = R_odom_lidar;
         this->imu_bias_.gyro_bias = out.gyro_bias;
     }
 

--- a/cpp/include/sycl_points/pipeline/submapping.hpp
+++ b/cpp/include/sycl_points/pipeline/submapping.hpp
@@ -81,11 +81,11 @@ public:
 
     /// @brief Build the very first keyframe of the submap.
     /// @param current_pose  Pose at which the first scan is anchored.  Must match the
-    ///                      pipeline's current odom_ (in the imu_attitude frame in the
-    ///                      3-stage TF convention) so that subsequent frames added via
-    ///                      add_frame() share the same reference frame.  If alignment
-    ///                      fired before the first frame, this is the gravity-corrected
-    ///                      pose, not the constructor-time default.
+    ///                      pipeline's current odom_ (T_odom_to_lidar in the odom/world
+    ///                      frame) so that subsequent frames added via add_frame() share
+    ///                      the same reference frame.  If alignment fired before the first
+    ///                      frame, this is the gravity-corrected pose, not the
+    ///                      constructor-time default.
     void add_first_frame(const PointCloudShared& cloud, double timestamp, const Eigen::Isometry3f& current_pose) {
         this->last_keyframe_pose_ = current_pose;
         if (this->keyframe_poses_.empty()) {

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/lidar_inertial_odometry_base_node.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/lidar_inertial_odometry_base_node.hpp
@@ -60,13 +60,6 @@ protected:
     geometry_msgs::msg::TransformStamped make_transform_message(const std_msgs::msg::Header& header,
                                                                 const Eigen::Isometry3f& odom) const;
 
-    /// @brief Build the 3-stage TF chain matching the pipeline's
-    /// world → init_pose → imu_attitude → base_link decomposition.  Returned as a
-    /// vector so callers can pass the whole batch to TransformBroadcaster::sendTransform()
-    /// in a single TFMessage rather than emitting one per hop.
-    std::vector<geometry_msgs::msg::TransformStamped> make_decomposed_transform_messages(
-        const std_msgs::msg::Header& header) const;
-
     bool publish_debug_clouds_enabled() const { return this->publish_options_.publish_debug_clouds; }
     bool publish_odom_enabled() const { return this->publish_options_.publish_odom; }
     bool publish_tf_enabled() const { return this->publish_options_.publish_tf; }
@@ -101,12 +94,6 @@ protected:
 
     std::string odom_frame_id_ = "odom";
     std::string base_link_id_ = "base_link";
-    /// Intermediate frame between `odom` and `imu_attitude` in the 3-stage TF chain.
-    /// Holds the user-specified initial yaw + position (TF1).
-    std::string init_pose_frame_id_ = "init_pose";
-    /// Intermediate frame between `init_pose` and `base_link` in the 3-stage TF chain.
-    /// Holds the gravity-aligned attitude (TF2; Identity in Phase 1).
-    std::string imu_attitude_frame_id_ = "imu_attitude";
     Eigen::Isometry3f T_base_link_to_lidar_ = Eigen::Isometry3f::Identity();
     Eigen::Isometry3f T_lidar_to_base_link_ = Eigen::Isometry3f::Identity();
 

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/lidar_odometry_base_node.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/lidar_odometry_base_node.hpp
@@ -88,13 +88,6 @@ protected:
     geometry_msgs::msg::TransformStamped make_transform_message(const std_msgs::msg::Header& header,
                                                                 const Eigen::Isometry3f& odom) const;
 
-    /// @brief Build the 3-stage TF chain matching the pipeline's
-    /// world → init_pose → imu_attitude → base_link decomposition.  Returned as a
-    /// vector so callers can pass the whole batch to TransformBroadcaster::sendTransform()
-    /// in a single TFMessage rather than emitting one per hop.
-    std::vector<geometry_msgs::msg::TransformStamped> make_decomposed_transform_messages(
-        const std_msgs::msg::Header& header) const;
-
     bool publish_debug_clouds_enabled() const { return this->publish_options_.publish_debug_clouds; }
     bool publish_odom_enabled() const { return this->publish_options_.publish_odom; }
     bool publish_tf_enabled() const { return this->publish_options_.publish_tf; }
@@ -121,12 +114,6 @@ protected:
     // ROS2/TF frame parameters
     std::string odom_frame_id_ = "odom";
     std::string base_link_id_ = "base_link";
-    /// Intermediate frame between `odom` and `imu_attitude` in the 3-stage TF chain.
-    /// Holds the user-specified initial yaw + position (TF1).
-    std::string init_pose_frame_id_ = "init_pose";
-    /// Intermediate frame between `init_pose` and `base_link` in the 3-stage TF chain.
-    /// Holds the gravity-aligned attitude (TF2; Identity in Phase 1).
-    std::string imu_attitude_frame_id_ = "imu_attitude";
     Eigen::Isometry3f T_base_link_to_lidar_ = Eigen::Isometry3f::Identity();
     Eigen::Isometry3f T_lidar_to_base_link_ = Eigen::Isometry3f::Identity();
 

--- a/ros2/sycl_points_ros2/src/lidar_inertial_odometry_base_node.cpp
+++ b/ros2/sycl_points_ros2/src/lidar_inertial_odometry_base_node.cpp
@@ -45,9 +45,6 @@ void LidarInertialOdometryBaseNode::initialize_processing() {
 
     this->odom_frame_id_ = this->declare_parameter<std::string>("odom_frame_id", this->odom_frame_id_);
     this->base_link_id_ = this->declare_parameter<std::string>("base_link_id", this->base_link_id_);
-    this->init_pose_frame_id_ = this->declare_parameter<std::string>("init_pose_frame_id", this->init_pose_frame_id_);
-    this->imu_attitude_frame_id_ =
-        this->declare_parameter<std::string>("imu_attitude_frame_id", this->imu_attitude_frame_id_);
     {
         const auto x = this->declare_parameter<double>("T_base_link_to_lidar/x", 0.0);
         const auto y = this->declare_parameter<double>("T_base_link_to_lidar/y", 0.0);
@@ -216,11 +213,9 @@ void LidarInertialOdometryBaseNode::publish_processed_frame(const std_msgs::msg:
     time_utils::measure_execution(
         [&]() {
             if (this->publish_tf_enabled() && this->tf_broadcaster_ != nullptr) {
-                // Publish the 3-stage TF chain in a single TFMessage:
-                //   odom → init_pose → imu_attitude → base_link
-                // Downstream consumers using lookupTransform(odom, base_link) recover
-                // the same composed pose via TF tree traversal.
-                this->tf_broadcaster_->sendTransform(this->make_decomposed_transform_messages(header));
+                // Single dynamic transform odom → base_link (REP-105).  The static
+                // base_link → sensor extrinsic is published separately (launch).
+                this->tf_broadcaster_->sendTransform(this->make_transform_message(header, frame.odom));
             }
 
             if (this->publish_odom_enabled()) {
@@ -249,10 +244,8 @@ void LidarInertialOdometryBaseNode::publish_processed_frame(const std_msgs::msg:
             if (this->pub_submap_ != nullptr && this->pub_submap_->get_subscription_count() > 0) {
                 auto submap_msg = toROS2msg(this->pipeline_->get_submap_point_cloud(), header);
                 if (submap_msg != nullptr) {
-                    // The submap point cloud is stored in the imu_attitude frame.
-                    // Downstream consumers apply TF (imu_attitude → init_pose → odom) to
-                    // recover world coordinates with the user-specified yaw and position.
-                    submap_msg->header.frame_id = this->imu_attitude_frame_id_;
+                    // The submap point cloud is stored in the odom (world) frame.
+                    submap_msg->header.frame_id = this->odom_frame_id_;
                     this->pub_submap_->publish(*submap_msg);
                 }
             }
@@ -316,50 +309,6 @@ geometry_msgs::msg::TransformStamped LidarInertialOdometryBaseNode::make_transfo
     return tf;
 }
 
-namespace {
-
-geometry_msgs::msg::TransformStamped to_transform_stamped(const std_msgs::msg::Header& header,
-                                                          const std::string& parent_frame,
-                                                          const std::string& child_frame, const Eigen::Isometry3f& T) {
-    const auto t = T.translation();
-    const Eigen::Quaternionf q(T.rotation());
-    geometry_msgs::msg::TransformStamped tf;
-    tf.header.stamp = header.stamp;
-    tf.header.frame_id = parent_frame;
-    tf.child_frame_id = child_frame;
-    tf.transform.translation.x = t.x();
-    tf.transform.translation.y = t.y();
-    tf.transform.translation.z = t.z();
-    tf.transform.rotation.x = q.x();
-    tf.transform.rotation.y = q.y();
-    tf.transform.rotation.z = q.z();
-    tf.transform.rotation.w = q.w();
-    return tf;
-}
-
-}  // namespace
-
-std::vector<geometry_msgs::msg::TransformStamped> LidarInertialOdometryBaseNode::make_decomposed_transform_messages(
-    const std_msgs::msg::Header& header) const {
-    // TF1: world → init_pose (user-specified initial yaw + position; static).
-    const Eigen::Isometry3f& T_world_init = this->pipeline_->get_T_world_init();
-
-    // TF2: init_pose → imu_attitude (gravity correction; Identity in Phase 1).
-    Eigen::Isometry3f T_init_imu_att = Eigen::Isometry3f::Identity();
-    T_init_imu_att.linear() = this->pipeline_->get_R_init_imu_att();
-
-    // TF3: imu_attitude → base_link (dynamic; LiDAR-frame state composed with the
-    // base_link extrinsic).
-    const Eigen::Isometry3f T_imu_att_base_link = this->pipeline_->get_odom_imu_att() * this->T_lidar_to_base_link_;
-
-    std::vector<geometry_msgs::msg::TransformStamped> tfs;
-    tfs.reserve(3);
-    tfs.push_back(to_transform_stamped(header, this->odom_frame_id_, this->init_pose_frame_id_, T_world_init));
-    tfs.push_back(
-        to_transform_stamped(header, this->init_pose_frame_id_, this->imu_attitude_frame_id_, T_init_imu_att));
-    tfs.push_back(to_transform_stamped(header, this->imu_attitude_frame_id_, this->base_link_id_, T_imu_att_base_link));
-    return tfs;
-}
 
 void LidarInertialOdometryBaseNode::record_processing_times(const ProcessedFrame& frame) {
     const double total_time = frame.processing_subtotal + frame.publish_time;

--- a/ros2/sycl_points_ros2/src/lidar_odometry_base_node.cpp
+++ b/ros2/sycl_points_ros2/src/lidar_odometry_base_node.cpp
@@ -44,9 +44,6 @@ void LiDAROdometryBaseNode::initialize_processing() {
     // tf and pose (ROS2/TF specific)
     this->odom_frame_id_ = this->declare_parameter<std::string>("odom_frame_id", this->odom_frame_id_);
     this->base_link_id_ = this->declare_parameter<std::string>("base_link_id", this->base_link_id_);
-    this->init_pose_frame_id_ = this->declare_parameter<std::string>("init_pose_frame_id", this->init_pose_frame_id_);
-    this->imu_attitude_frame_id_ =
-        this->declare_parameter<std::string>("imu_attitude_frame_id", this->imu_attitude_frame_id_);
     {
         const auto x = this->declare_parameter<double>("T_base_link_to_lidar/x", 0.0);
         const auto y = this->declare_parameter<double>("T_base_link_to_lidar/y", 0.0);
@@ -242,11 +239,9 @@ void LiDAROdometryBaseNode::publish_processed_frame(const std_msgs::msg::Header&
     time_utils::measure_execution(
         [&]() {
             if (this->publish_tf_enabled() && this->tf_broadcaster_ != nullptr) {
-                // Publish the 3-stage TF chain in a single TFMessage:
-                //   odom → init_pose → imu_attitude → base_link
-                // Downstream consumers using lookupTransform(odom, base_link) recover
-                // the same composed pose via TF tree traversal.
-                this->tf_broadcaster_->sendTransform(this->make_decomposed_transform_messages(header));
+                // Single dynamic transform odom → base_link (REP-105).  The static
+                // base_link → sensor extrinsic is published separately (launch).
+                this->tf_broadcaster_->sendTransform(this->make_transform_message(header, frame.odom));
             }
 
             if (this->publish_odom_enabled()) {
@@ -286,10 +281,8 @@ void LiDAROdometryBaseNode::publish_processed_frame(const std_msgs::msg::Header&
             if (this->pub_submap_ != nullptr && this->pub_submap_->get_subscription_count() > 0) {
                 auto submap_msg = toROS2msg(this->pipeline_->get_submap_point_cloud(), header);
                 if (submap_msg != nullptr) {
-                    // The submap point cloud is stored in the imu_attitude frame.
-                    // Downstream consumers apply TF (imu_attitude → init_pose → odom) to
-                    // recover world coordinates with the user-specified yaw and position.
-                    submap_msg->header.frame_id = this->imu_attitude_frame_id_;
+                    // The submap point cloud is stored in the odom (world) frame.
+                    submap_msg->header.frame_id = this->odom_frame_id_;
                     this->pub_submap_->publish(*submap_msg);
                 }
             }
@@ -379,51 +372,6 @@ geometry_msgs::msg::TransformStamped LiDAROdometryBaseNode::make_transform_messa
     tf.transform.rotation.z = odom_quat.z();
     tf.transform.rotation.w = odom_quat.w();
     return tf;
-}
-
-namespace {
-
-geometry_msgs::msg::TransformStamped to_transform_stamped(const std_msgs::msg::Header& header,
-                                                          const std::string& parent_frame,
-                                                          const std::string& child_frame, const Eigen::Isometry3f& T) {
-    const auto t = T.translation();
-    const Eigen::Quaternionf q(T.rotation());
-    geometry_msgs::msg::TransformStamped tf;
-    tf.header.stamp = header.stamp;
-    tf.header.frame_id = parent_frame;
-    tf.child_frame_id = child_frame;
-    tf.transform.translation.x = t.x();
-    tf.transform.translation.y = t.y();
-    tf.transform.translation.z = t.z();
-    tf.transform.rotation.x = q.x();
-    tf.transform.rotation.y = q.y();
-    tf.transform.rotation.z = q.z();
-    tf.transform.rotation.w = q.w();
-    return tf;
-}
-
-}  // namespace
-
-std::vector<geometry_msgs::msg::TransformStamped> LiDAROdometryBaseNode::make_decomposed_transform_messages(
-    const std_msgs::msg::Header& header) const {
-    // TF1: world → init_pose (user-specified initial yaw + position; static).
-    const Eigen::Isometry3f& T_world_init = this->pipeline_->get_T_world_init();
-
-    // TF2: init_pose → imu_attitude (gravity correction; Identity in Phase 1).
-    Eigen::Isometry3f T_init_imu_att = Eigen::Isometry3f::Identity();
-    T_init_imu_att.linear() = this->pipeline_->get_R_init_imu_att();
-
-    // TF3: imu_attitude → base_link (dynamic; LiDAR-frame state composed with the
-    // base_link extrinsic).
-    const Eigen::Isometry3f T_imu_att_base_link = this->pipeline_->get_odom_imu_att() * this->T_lidar_to_base_link_;
-
-    std::vector<geometry_msgs::msg::TransformStamped> tfs;
-    tfs.reserve(3);
-    tfs.push_back(to_transform_stamped(header, this->odom_frame_id_, this->init_pose_frame_id_, T_world_init));
-    tfs.push_back(
-        to_transform_stamped(header, this->init_pose_frame_id_, this->imu_attitude_frame_id_, T_init_imu_att));
-    tfs.push_back(to_transform_stamped(header, this->imu_attitude_frame_id_, this->base_link_id_, T_imu_att_base_link));
-    return tfs;
 }
 
 void LiDAROdometryBaseNode::record_processing_times(const ProcessedFrame& frame) {


### PR DESCRIPTION
## 概要
Issue #173 の実装。Issue #167 で導入された3段TFチェーン (`world → init_pose → imu_attitude → lidar`) を廃止し、標準的な単一段 (REP-105 / FAST-LIO2 流) へ再設計する。

## 背景（不具合）
- 3段の `T_world_init_ = initial_base_link * T_base_link_to_lidar` がセンサ外部パラメータを TF1 に焼き込んでおり、`imu_attitude` フレームが実体として「初期センサ光学フレーム」になっていた。
- submap を `imu_attitude` で publish していたため、外部パラメータが非単位な深度カメラ（Orbbec の90°光学回転）で submap が scan に対して回転して見えた。RealSense（外部パラメータ＝単位）では露呈しない。
- registration(ICP) は相対量で左不変のため**軌跡自体は数値的に正しい**。破綻は可視化フレームと責務分離。

## 変更
- **パイプライン (LO/LIO)**: `T_odom_to_lidar`（`odom_`/`x_`）を重力整列の `odom` フレームで直接追跡。`T_world_init_`/`R_init_imu_att_`/`compose_world()` を削除。`params_.pose.initial` のリセットを廃止しそこから初期化。`apply_initial_alignment()` で `Rz(user_yaw) · R_gravity_lidar` を合成。
- **InitialAlignmentEstimator**: `Output.R_imu_att_lidar` → `R_gravity_lidar`（yaw≈0 の重力整列回転）にリネーム。`detail::yaw_from_rotation` を復活。
- **ROSノード (LO/LIO base)**: 単一の動的 `odom → base_link` TF のみ broadcast（静的 `base_link → sensor` は launch 側）。submap を `odom` フレームで publish。`make_decomposed_transform_messages` と `init_pose_frame_id`/`imu_attitude_frame_id` パラメータを削除。
- 内部 IEKF 状態は lidar フレーム維持（IMU↔lidar 共分散変換は不変、低リスク）。

## 検証
- ビルド成功
- Gemini diff レビュー: Approve（CRITICAL/MAJOR なし）
- 実機/rosbag での可視確認は手元で実施予定

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)