### PR TITLE
feat(launch): rosbag再生のトピック除外をopt-in対応 (/tf_static競合の回避)

### DIFF
--- a/ros2/sycl_points_ros2/launch/lidar_inertial_odometry_launch.py
+++ b/ros2/sycl_points_ros2/launch/lidar_inertial_odometry_launch.py
@@ -78,16 +78,27 @@ def generate_launch_description():
         exclude_raw = LaunchConfiguration("rosbag/exclude_topics").perform(context)
         exclude_topics = [t.strip() for t in exclude_raw.split(",") if t.strip()]
 
+        # Resolve substitutions to concrete Python types here so the rosbag2 Player
+        # (which is strict about parameter types) receives int/bool/str rather than
+        # raw substitution strings.
+        try:
+            start_offset_sec = int(
+                LaunchConfiguration("rosbag/start_offset/sec").perform(context)
+            )
+        except ValueError:
+            start_offset_sec = 0
+        sim_time = LaunchConfiguration("use_sim_time").perform(context).lower() == "true"
+
         player_params = {
             "play.read_ahead_queue_size": 1000,
             "play.node_prefix": "",
             "play.rate": 1.0,
             "play.loop": False,
             "play.start_paused": False,
-            "play.start_offset.sec": LaunchConfiguration("rosbag/start_offset/sec"),
-            "storage.uri": LaunchConfiguration("rosbag/uri"),
+            "play.start_offset.sec": start_offset_sec,
+            "storage.uri": LaunchConfiguration("rosbag/uri").perform(context),
             "storage.storage_config_uri": "",
-            "use_sim_time": use_sim_time,
+            "use_sim_time": sim_time,
         }
         if exclude_topics:
             player_params["play.exclude_topics_to_filter"] = exclude_topics

--- a/ros2/sycl_points_ros2/launch/lidar_inertial_odometry_launch.py
+++ b/ros2/sycl_points_ros2/launch/lidar_inertial_odometry_launch.py
@@ -1,7 +1,7 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch.conditions import IfCondition
 from launch.actions import TimerAction
@@ -56,18 +56,43 @@ def generate_launch_description():
                 default_value="0",
                 description="rosbag start offset in seconds",
             ),
+            DeclareLaunchArgument(
+                "rosbag/exclude_topics",
+                default_value="",
+                description=(
+                    "Comma-separated topics to exclude from rosbag playback "
+                    "(e.g. '/tf_static' when the bag's static TF conflicts with the "
+                    "node's odom->base_link->lidar tree). Empty = exclude nothing. "
+                    "Does NOT affect odometry results (the pipeline never consumes TF); "
+                    "visualization only."
+                ),
+            ),
         ]
     )
     use_sim_time = LaunchConfiguration("use_sim_time")
 
-    nodes = [
-        Node(
-            package="rviz2",
-            executable="rviz2",
-            arguments=["-d", os.path.join(package_dir, "rviz2", "rviz2.rviz")],
-            condition=IfCondition(LaunchConfiguration("rviz2")),
-        ),
-        TimerAction(
+    def launch_setup(context, *args, **kwargs):
+        # Parse the comma-separated exclude list at runtime.  Omit the parameter
+        # entirely when empty: an empty array param has an ambiguous type and would
+        # otherwise error, and omitting it keeps the default "exclude nothing".
+        exclude_raw = LaunchConfiguration("rosbag/exclude_topics").perform(context)
+        exclude_topics = [t.strip() for t in exclude_raw.split(",") if t.strip()]
+
+        player_params = {
+            "play.read_ahead_queue_size": 1000,
+            "play.node_prefix": "",
+            "play.rate": 1.0,
+            "play.loop": False,
+            "play.start_paused": False,
+            "play.start_offset.sec": LaunchConfiguration("rosbag/start_offset/sec"),
+            "storage.uri": LaunchConfiguration("rosbag/uri"),
+            "storage.storage_config_uri": "",
+            "use_sim_time": use_sim_time,
+        }
+        if exclude_topics:
+            player_params["play.exclude_topics_to_filter"] = exclude_topics
+
+        container = TimerAction(
             period=1.0,
             actions=[
                 ComposableNodeContainer(
@@ -119,21 +144,7 @@ def generate_launch_description():
                             package="rosbag2_transport",
                             plugin="rosbag2_transport::Player",
                             name="player",
-                            parameters=[
-                                {
-                                    "play.read_ahead_queue_size": 1000,
-                                    "play.node_prefix": "",
-                                    "play.rate": 1.0,
-                                    "play.loop": False,
-                                    "play.start_paused": False,
-                                    "play.start_offset.sec": LaunchConfiguration(
-                                        "rosbag/start_offset/sec"
-                                    ),
-                                    "storage.uri": LaunchConfiguration("rosbag/uri"),
-                                    "storage.storage_config_uri": "",
-                                    "use_sim_time": use_sim_time,
-                                }
-                            ],
+                            parameters=[player_params],
                             condition=IfCondition(LaunchConfiguration("rosbag/play")),
                             extra_arguments=[{"use_intra_process_comms": True}],
                         ),
@@ -150,7 +161,14 @@ def generate_launch_description():
                     ],
                 ),
             ],
-        ),
-    ]
+        )
+        return [container]
 
-    return LaunchDescription(launch_args + nodes)
+    rviz = Node(
+        package="rviz2",
+        executable="rviz2",
+        arguments=["-d", os.path.join(package_dir, "rviz2", "rviz2.rviz")],
+        condition=IfCondition(LaunchConfiguration("rviz2")),
+    )
+
+    return LaunchDescription(launch_args + [rviz, OpaqueFunction(function=launch_setup)])

--- a/ros2/sycl_points_ros2/launch/lidar_odometry_launch.py
+++ b/ros2/sycl_points_ros2/launch/lidar_odometry_launch.py
@@ -78,16 +78,27 @@ def generate_launch_description():
         exclude_raw = LaunchConfiguration("rosbag/exclude_topics").perform(context)
         exclude_topics = [t.strip() for t in exclude_raw.split(",") if t.strip()]
 
+        # Resolve substitutions to concrete Python types here so the rosbag2 Player
+        # (which is strict about parameter types) receives int/bool/str rather than
+        # raw substitution strings.
+        try:
+            start_offset_sec = int(
+                LaunchConfiguration("rosbag/start_offset/sec").perform(context)
+            )
+        except ValueError:
+            start_offset_sec = 0
+        sim_time = LaunchConfiguration("use_sim_time").perform(context).lower() == "true"
+
         player_params = {
             "play.read_ahead_queue_size": 1000,
             "play.node_prefix": "",
             "play.rate": 1.0,
             "play.loop": False,
             "play.start_paused": False,
-            "play.start_offset.sec": LaunchConfiguration("rosbag/start_offset/sec"),
-            "storage.uri": LaunchConfiguration("rosbag/uri"),
+            "play.start_offset.sec": start_offset_sec,
+            "storage.uri": LaunchConfiguration("rosbag/uri").perform(context),
             "storage.storage_config_uri": "",
-            "use_sim_time": use_sim_time,
+            "use_sim_time": sim_time,
         }
         if exclude_topics:
             player_params["play.exclude_topics_to_filter"] = exclude_topics

--- a/ros2/sycl_points_ros2/launch/lidar_odometry_launch.py
+++ b/ros2/sycl_points_ros2/launch/lidar_odometry_launch.py
@@ -1,7 +1,7 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
 from ament_index_python.packages import get_package_share_directory
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch.conditions import IfCondition
 from launch.actions import TimerAction
@@ -56,18 +56,43 @@ def generate_launch_description():
                 default_value="0",
                 description="rosbag start offset in seconds",
             ),
+            DeclareLaunchArgument(
+                "rosbag/exclude_topics",
+                default_value="",
+                description=(
+                    "Comma-separated topics to exclude from rosbag playback "
+                    "(e.g. '/tf_static' when the bag's static TF conflicts with the "
+                    "node's odom->base_link->lidar tree). Empty = exclude nothing. "
+                    "Does NOT affect odometry results (the pipeline never consumes TF); "
+                    "visualization only."
+                ),
+            ),
         ]
     )
     use_sim_time = LaunchConfiguration("use_sim_time")
 
-    nodes = [
-        Node(
-            package="rviz2",
-            executable="rviz2",
-            arguments=["-d", os.path.join(package_dir, "rviz2", "rviz2.rviz")],
-            condition=IfCondition(LaunchConfiguration("rviz2")),
-        ),
-        TimerAction(
+    def launch_setup(context, *args, **kwargs):
+        # Parse the comma-separated exclude list at runtime.  Omit the parameter
+        # entirely when empty: an empty array param has an ambiguous type and would
+        # otherwise error, and omitting it keeps the default "exclude nothing".
+        exclude_raw = LaunchConfiguration("rosbag/exclude_topics").perform(context)
+        exclude_topics = [t.strip() for t in exclude_raw.split(",") if t.strip()]
+
+        player_params = {
+            "play.read_ahead_queue_size": 1000,
+            "play.node_prefix": "",
+            "play.rate": 1.0,
+            "play.loop": False,
+            "play.start_paused": False,
+            "play.start_offset.sec": LaunchConfiguration("rosbag/start_offset/sec"),
+            "storage.uri": LaunchConfiguration("rosbag/uri"),
+            "storage.storage_config_uri": "",
+            "use_sim_time": use_sim_time,
+        }
+        if exclude_topics:
+            player_params["play.exclude_topics_to_filter"] = exclude_topics
+
+        container = TimerAction(
             period=1.0,
             actions=[
                 ComposableNodeContainer(
@@ -119,21 +144,7 @@ def generate_launch_description():
                             package="rosbag2_transport",
                             plugin="rosbag2_transport::Player",
                             name="player",
-                            parameters=[
-                                {
-                                    "play.read_ahead_queue_size": 1000,
-                                    "play.node_prefix": "",
-                                    "play.rate": 1.0,
-                                    "play.loop": False,
-                                    "play.start_paused": False,
-                                    "play.start_offset.sec": LaunchConfiguration(
-                                        "rosbag/start_offset/sec"
-                                    ),
-                                    "storage.uri": LaunchConfiguration("rosbag/uri"),
-                                    "storage.storage_config_uri": "",
-                                    "use_sim_time": use_sim_time,
-                                }
-                            ],
+                            parameters=[player_params],
                             condition=IfCondition(LaunchConfiguration("rosbag/play")),
                             extra_arguments=[{"use_intra_process_comms": True}],
                         ),
@@ -150,7 +161,14 @@ def generate_launch_description():
                     ],
                 ),
             ],
-        ),
-    ]
+        )
+        return [container]
 
-    return LaunchDescription(launch_args + nodes)
+    rviz = Node(
+        package="rviz2",
+        executable="rviz2",
+        arguments=["-d", os.path.join(package_dir, "rviz2", "rviz2.rviz")],
+        condition=IfCondition(LaunchConfiguration("rviz2")),
+    )
+
+    return LaunchDescription(launch_args + [rviz, OpaqueFunction(function=launch_setup)])


### PR DESCRIPTION
## 概要
rosbag 再生時に指定トピックを除外できる launch 引数 `rosbag/exclude_topics` を追加（opt-in、デフォルト空＝除外なし）。

> [!NOTE]
> このPRは #174 (`fix-tf`) の上にスタックしています。base を `fix-tf` にしているため、#174 マージ後に main へ付け替えてください。

## 背景
Orbbec の bag の `/tf_static` は `camera_color_optical_frame` を **2つの親**（`base_link` と `camera_color_frame`）で宣言しており、ノードが publish する `odom → base_link → camera_color_optical_frame` ツリーと競合する。これにより RViz で `camera_color_optical_frame → base_link` の lookup が失敗し、Preprocess 点群が表示できなかった。

bag の `/tf_static` を再生から除外し、ノードが TF ツリーを単独所有することで解消する。

## 変更
- `lidar_odometry_launch.py` / `lidar_inertial_odometry_launch.py`:
  - launch 引数 `rosbag/exclude_topics`（カンマ区切り）を追加。
  - `OpaqueFunction` で実行時にリスト化し Player の `play.exclude_topics_to_filter` へ渡す。
  - 空のときはパラメータ自体を付けない（空配列の型推論回避＋デフォルト挙動維持）。

## 影響
- **オドメトリ計算には影響なし**（パイプラインは TF を消費しない。可視化のみ）。
- デフォルト（引数なし）では除外しないため、既存データセットの挙動は不変。
- 必要なデータセット（Orbbec 等）でのみ `rosbag/exclude_topics:=/tf_static` を渡す。

注: `scripts/` 系（run.bash / dataset config の `EXCLUDE_TOPICS` 配線）はワークスペース実体側にあり当リポジトリ管理外のため本PRには含まれない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)