### PR TITLE
lio: chi-squared ICP weighting, undamped P_post, LM/Dogleg solvers

### DIFF
--- a/cpp/include/sycl_points/algorithms/lio/lio_registration.hpp
+++ b/cpp/include/sycl_points/algorithms/lio/lio_registration.hpp
@@ -110,22 +110,25 @@ struct LIOLinearizedResult {
 /// @param result        LIO normal equation to accumulate into.
 /// @param icp           ICP linearization from registration::Registration.
 /// @param R_world_lidar Current body-to-world rotation (x_op.rotation).
+/// @param weight        Scalar information weight applied to H/b/error (e.g. the
+///                      reduced chi-squared calibration 1/s² computed by the caller).
 inline void add_icp_factor(LIOLinearizedResult& result, const registration::LinearizedResult& icp,
-                           const Eigen::Matrix3f& R_world_lidar) {
+                           const Eigen::Matrix3f& R_world_lidar, float weight = 1.0f) {
     // Rotation block: δω (ICP body frame) == δφ (LIO body frame) — embed directly
-    result.H.block<3, 3>(imu::State::kIdxRot, imu::State::kIdxRot) += icp.H.block<3, 3>(0, 0);
-    result.b.segment<3>(imu::State::kIdxRot) += icp.b.segment<3>(0);
+    result.H.block<3, 3>(imu::State::kIdxRot, imu::State::kIdxRot) += weight * icp.H.block<3, 3>(0, 0);
+    result.b.segment<3>(imu::State::kIdxRot) += weight * icp.b.segment<3>(0);
 
     // Translation block: rotate ICP body-frame δt into LIO world-frame δp
     const Eigen::Matrix3f& R = R_world_lidar;
-    result.H.block<3, 3>(imu::State::kIdxPos, imu::State::kIdxPos) += R * icp.H.block<3, 3>(3, 3) * R.transpose();
-    result.b.segment<3>(imu::State::kIdxPos) += R * icp.b.segment<3>(3);
+    result.H.block<3, 3>(imu::State::kIdxPos, imu::State::kIdxPos) +=
+        weight * (R * icp.H.block<3, 3>(3, 3) * R.transpose());
+    result.b.segment<3>(imu::State::kIdxPos) += weight * (R * icp.b.segment<3>(3));
 
     // Cross terms: φ remains body-frame, p becomes world-frame
-    result.H.block<3, 3>(imu::State::kIdxPos, imu::State::kIdxRot) += R * icp.H.block<3, 3>(3, 0);
-    result.H.block<3, 3>(imu::State::kIdxRot, imu::State::kIdxPos) += icp.H.block<3, 3>(0, 3) * R.transpose();
+    result.H.block<3, 3>(imu::State::kIdxPos, imu::State::kIdxRot) += weight * (R * icp.H.block<3, 3>(3, 0));
+    result.H.block<3, 3>(imu::State::kIdxRot, imu::State::kIdxPos) += weight * (icp.H.block<3, 3>(0, 3) * R.transpose());
 
-    result.error_icp += icp.error;
+    result.error_icp += weight * icp.error;
     result.inlier += icp.inlier;
 }
 

--- a/cpp/include/sycl_points/algorithms/registration/dogleg_step.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/dogleg_step.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <Eigen/Dense>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace sycl_points {
+namespace algorithms {
+namespace registration {
+
+/// @brief Result of one Powell dogleg step computation.
+template <int N>
+struct DoglegStep {
+    Eigen::Vector<float, N> p = Eigen::Vector<float, N>::Zero();  ///< Dogleg update δx
+    float step_norm = 0.0f;                                       ///< ‖p‖
+    float predicted_reduction = 0.0f;                             ///< Model reduction −(gᵀp + ½·pᵀHp)
+};
+
+/// @brief Compute the Powell dogleg step for the normal equation H·δ = −g within
+///        a trust region.
+///
+/// Dimension-generic: used by the 6-DOF registration solver
+/// (Registration::optimize_powell_dogleg) and the 15-DOF LIO update loop.
+/// Trust-region bookkeeping (radius clamping, gain-ratio acceptance, radius
+/// update) stays with the caller; this function only computes the step and the
+/// predicted model reduction.
+///
+/// @param H                   Normal-equation Hessian (N×N, symmetric).
+/// @param g                   Gradient vector (N×1); the descent direction is −g.
+/// @param trust_region_radius Current trust-region radius (must be > 0).
+/// @return Dogleg step, its norm, and the predicted model cost reduction.
+template <int N>
+inline DoglegStep<N> compute_dogleg_step(const Eigen::Matrix<float, N, N>& H, const Eigen::Vector<float, N>& g,
+                                         float trust_region_radius) {
+    DoglegStep<N> result;
+
+    // Gauss-Newton step: H·p_gn = −g
+    Eigen::Vector<float, N> p_gn = Eigen::Vector<float, N>::Zero();
+    float norm_p_gn = 0.0f;
+    bool has_valid_gn = false;
+    {
+        Eigen::LDLT<Eigen::Matrix<float, N, N>> ldlt;
+        ldlt.compute(H);
+        if (ldlt.info() == Eigen::Success) {
+            p_gn = ldlt.solve(-g);
+            norm_p_gn = p_gn.norm();
+            has_valid_gn = std::isfinite(norm_p_gn);
+        }
+    }
+
+    // Steepest-descent (Cauchy) step: p_sd = −α·g with α = ‖g‖² / gᵀHg
+    const float g_norm_sq = g.squaredNorm();
+    const Eigen::Vector<float, N> Hg = H * g;
+    const float g_H_g = g.dot(Hg);
+    Eigen::Vector<float, N> p_sd = -g;
+    if (g_H_g > std::numeric_limits<float>::epsilon()) {
+        const float alpha = g_norm_sq / g_H_g;
+        if (std::isfinite(alpha)) {
+            p_sd = -alpha * g;
+        }
+    }
+    const float norm_p_sd = p_sd.norm();
+
+    // Dogleg combination
+    if (has_valid_gn && norm_p_gn <= trust_region_radius) {
+        result.p = p_gn;
+        result.step_norm = norm_p_gn;
+    } else if (norm_p_sd >= trust_region_radius) {
+        if (norm_p_sd > std::numeric_limits<float>::epsilon()) {
+            result.p = (trust_region_radius / norm_p_sd) * p_sd;
+        }
+        result.step_norm = trust_region_radius;
+    } else if (has_valid_gn) {
+        // Walk from p_sd toward p_gn until the trust-region boundary is hit.
+        const Eigen::Vector<float, N> diff = p_gn - p_sd;
+        const float a = diff.squaredNorm();
+        const float b = 2.0f * p_sd.dot(diff);
+        const float c = p_sd.squaredNorm() - trust_region_radius * trust_region_radius;
+        float discriminant = b * b - 4.0f * a * c;
+        discriminant = std::max(discriminant, 0.0f);
+        float tau = 0.0f;
+        if (a > std::numeric_limits<float>::epsilon()) {
+            tau = (-b + std::sqrt(discriminant)) / (2.0f * a);
+        }
+        tau = std::clamp(tau, 0.0f, 1.0f);
+        result.p = p_sd + tau * diff;
+        result.step_norm = result.p.norm();
+    } else {
+        result.p = p_sd;
+        if (norm_p_sd > trust_region_radius && norm_p_sd > std::numeric_limits<float>::epsilon()) {
+            const float scale = trust_region_radius / norm_p_sd;
+            result.p *= scale;
+            result.step_norm = trust_region_radius;
+        } else {
+            result.step_norm = norm_p_sd;
+        }
+    }
+
+    result.predicted_reduction = -(g.dot(result.p) + 0.5f * result.p.dot(H * result.p));
+    return result;
+}
+
+}  // namespace registration
+}  // namespace algorithms
+}  // namespace sycl_points

--- a/cpp/include/sycl_points/algorithms/registration/dogleg_step.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/dogleg_step.hpp
@@ -42,7 +42,7 @@ inline DoglegStep<N> compute_dogleg_step(const Eigen::Matrix<float, N, N>& H, co
     {
         Eigen::LDLT<Eigen::Matrix<float, N, N>> ldlt;
         ldlt.compute(H);
-        if (ldlt.info() == Eigen::Success) {
+        if (ldlt.info() == Eigen::Success && ldlt.vectorD().minCoeff() > 0.0f) {
             p_gn = ldlt.solve(-g);
             norm_p_gn = p_gn.norm();
             has_valid_gn = std::isfinite(norm_p_gn);

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -8,6 +8,7 @@
 #include "sycl_points/algorithms/knn/knn.hpp"
 #include "sycl_points/algorithms/registration/anderson_acceleration.hpp"
 #include "sycl_points/algorithms/registration/degenerate_regularization.hpp"
+#include "sycl_points/algorithms/registration/dogleg_step.hpp"
 #include "sycl_points/algorithms/registration/factor.hpp"
 #include "sycl_points/algorithms/registration/linearized_result.hpp"
 #include "sycl_points/algorithms/registration/photometric_factor.hpp"
@@ -1055,63 +1056,11 @@ private:
 
         trust_region_radius = clamp_radius(trust_region_radius);
 
-        Eigen::Vector<float, 6> p_gn = Eigen::Vector<float, 6>::Zero();
-        float norm_p_gn = 0.0f;
-        bool has_valid_gn = false;
-        const bool success = this->solve_linear_system(H, g, p_gn);
-        if (success) {
-            norm_p_gn = p_gn.norm();
-            has_valid_gn = std::isfinite(norm_p_gn);
-        }
-
-        const float g_norm_sq = g.squaredNorm();
-        const Eigen::Vector<float, 6> Hg = H * g;
-        const float g_H_g = g.dot(Hg);
-        Eigen::Vector<float, 6> p_sd = -g;
-        if (g_H_g > std::numeric_limits<float>::epsilon()) {
-            const float alpha = g_norm_sq / g_H_g;
-            if (std::isfinite(alpha)) {
-                p_sd = -alpha * g;
-            }
-        }
-        const float norm_p_sd = p_sd.norm();
-
-        Eigen::Vector<float, 6> p_dl = Eigen::Vector<float, 6>::Zero();
-        float step_norm = 0.0f;
-        if (has_valid_gn && norm_p_gn <= trust_region_radius) {
-            p_dl = p_gn;
-            step_norm = norm_p_gn;
-        } else if (norm_p_sd >= trust_region_radius) {
-            if (norm_p_sd > std::numeric_limits<float>::epsilon()) {
-                p_dl = (trust_region_radius / norm_p_sd) * p_sd;
-            }
-            step_norm = trust_region_radius;
-        } else if (has_valid_gn) {
-            const Eigen::Vector<float, 6> diff = p_gn - p_sd;
-            const float a = diff.squaredNorm();
-            const float b = 2.0f * p_sd.dot(diff);
-            const float c = p_sd.squaredNorm() - trust_region_radius * trust_region_radius;
-            float discriminant = b * b - 4.0f * a * c;
-            discriminant = std::max(discriminant, 0.0f);
-            float tau = 0.0f;
-            if (a > std::numeric_limits<float>::epsilon()) {
-                tau = (-b + std::sqrt(discriminant)) / (2.0f * a);
-            }
-            tau = std::clamp(tau, 0.0f, 1.0f);
-            p_dl = p_sd + tau * diff;
-            step_norm = p_dl.norm();
-        } else {
-            p_dl = p_sd;
-            if (norm_p_sd > trust_region_radius && norm_p_sd > std::numeric_limits<float>::epsilon()) {
-                const float scale = trust_region_radius / norm_p_sd;
-                p_dl *= scale;
-                step_norm = trust_region_radius;
-            } else {
-                step_norm = norm_p_sd;
-            }
-        }
-
-        const float predicted_reduction = -(g.dot(p_dl) + 0.5f * p_dl.dot(H * p_dl));
+        // Step geometry is shared with the 15-DOF LIO solver (dogleg_step.hpp).
+        const DoglegStep<6> dl = compute_dogleg_step<6>(H, g, trust_region_radius);
+        const Eigen::Vector<float, 6>& p_dl = dl.p;
+        const float step_norm = dl.step_norm;
+        const float predicted_reduction = dl.predicted_reduction;
 
         if (predicted_reduction <= 0.0f) {
             trust_region_radius = clamp_radius(trust_region_radius * this->params_.dogleg.gamma_decrease);

--- a/cpp/include/sycl_points/algorithms/registration/registration.hpp
+++ b/cpp/include/sycl_points/algorithms/registration/registration.hpp
@@ -353,6 +353,34 @@ public:
         return compute_linearized_result(source, target, target_knn, pose, pose, options);
     }
 
+    /// @brief Evaluate the robust ICP error at @p pose using the correspondences cached by
+    ///        the most recent compute_linearized_result() call (frozen neighbours).
+    ///
+    /// Runs only the error parallel-reduction pass — no KNN re-search and no
+    /// linearization — so the correspondences stay fixed at whatever pose the last
+    /// compute_linearized_result() used.  This is the building block for the
+    /// trust-region / line-search step-acceptance tests in the LIO LM and dogleg
+    /// optimisers, which must compare the cost of a trial pose against the
+    /// linearisation point without re-establishing correspondences.
+    ///
+    /// @param source   Source point cloud (must be the same cloud passed to the
+    ///                 preceding compute_linearized_result() call, so the cached
+    ///                 neighbours line up with the source points).
+    /// @param target   Target point cloud (map/submap frame).
+    /// @param pose     Trial pose T_world_sensor (4×4 matrix) to evaluate.
+    /// @param options  Per-call execution overrides (robust scale etc.).
+    /// @return {robust ICP error, inlier count} at @p pose with frozen correspondences.
+    std::tuple<float, uint32_t> compute_error_frozen(const PointCloudShared& source, const PointCloudShared& target,
+                                                     const TransformMatrix& pose,
+                                                     const ExecutionOptions& options = ExecutionOptions()) const {
+        const float robust_scale =
+            options.robust_scale > 0.0f ? options.robust_scale : this->params_.robust.default_scale;
+        const float rotation_robust_scale = options.rotation_robust_scale > 0.0f
+                                                ? options.rotation_robust_scale
+                                                : this->params_.rotation_constraint.robust.default_scale;
+        return this->compute_error(source, target, this->neighbors_->at(0), pose, robust_scale, rotation_robust_scale);
+    }
+
 private:
     RegistrationParams params_;
     sycl_utils::DeviceQueue queue_;

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -628,11 +628,13 @@ private:
             Eigen::Matrix<float, 15, 1> delta = Eigen::Matrix<float, 15, 1>::Zero();
             // step_accepted: a usable increment was produced and should be retracted.
             //   GN  — true unless the damped solve fails (then we stop: cannot progress).
-            //   LM  — true when an inner trial lowered the combined cost.
+            //   LM  — true when an inner trial lowered the combined cost; if no trial
+            //         does (lambda already at max_lambda), we stop: re-linearising at
+            //         the same x_op would reproduce the same H/b and fail again.
             //   DL  — true when the gain ratio cleared eta1.
-            // A rejected LM/dogleg step leaves x_op untouched and re-linearises next
-            // iteration with the adjusted lambda / trust-region radius, so it must NOT
-            // run the convergence test (delta == 0 would otherwise falsely converge).
+            // A rejected dogleg step leaves x_op untouched and re-linearises next
+            // iteration with the adjusted trust-region radius, so it must NOT run the
+            // convergence test (delta == 0 would otherwise falsely converge).
             bool step_accepted = false;
             bool stop = false;
 
@@ -668,6 +670,11 @@ private:
                         }
                         lm_lambda =
                             std::clamp(lm_lambda * lm_params.lambda_factor, lm_params.min_lambda, lm_params.max_lambda);
+                    }
+                    if (!step_accepted) {
+                        // lambda is already at max_lambda; re-linearising at the same
+                        // x_op would reproduce the same H/b and fail again.
+                        stop = true;
                     }
                     break;
                 }
@@ -712,8 +719,8 @@ private:
             } else if (stop) {
                 break;
             }
-            // LM / dogleg rejection: x_op unchanged; retry next iteration with the
-            // updated lambda / trust-region radius.
+            // Dogleg rejection: x_op unchanged; retry next iteration with the
+            // updated trust-region radius.
         }
 
         // Posterior covariance from the undamped Hessian.  delta is solved with the

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -732,9 +732,24 @@ private:
             if (ldlt.info() == Eigen::Success && ldlt.vectorD().minCoeff() > 0.0f) {
                 this->P_post_.setIdentity();
                 ldlt.solveInPlace(this->P_post_);  // P_post = H⁻¹
+            } else {
+                // H_undamped is singular along unobserved directions (e.g. at startup
+                // before any well-conditioned frame, or during a degenerate window).
+                // Keeping the previous P_post_ (Zero() at startup) would mean exactly
+                // zero covariance -- i.e. infinite confidence -- in those directions,
+                // which can later make P_pred singular.  A tiny diagonal regularization
+                // restores invertibility while leaving well-observed directions (large
+                // H entries) essentially unchanged; unobserved directions get a
+                // correspondingly large (low-confidence) P_post entry instead.
+                Eigen::Matrix<float, 15, 15> H_damped = H_undamped;
+                H_damped.diagonal().array() += 1e-4f;
+                Eigen::LDLT<Eigen::Matrix<float, 15, 15>> ldlt_damped(H_damped);
+                if (ldlt_damped.info() == Eigen::Success && ldlt_damped.vectorD().minCoeff() > 0.0f) {
+                    this->P_post_.setIdentity();
+                    ldlt_damped.solveInPlace(this->P_post_);
+                }
+                // If even the damped solve fails, keep the previous P_post_ as a last resort.
             }
-            // When H is not positive definite, keep the previous posterior instead of
-            // collapsing it to zero (zero would mean perfect confidence at the reset).
         }
 
         // ---- Update state and reset IMU preintegration ----

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -488,6 +488,16 @@ private:
         // fixed for this frame so the optimizer does not absorb noise into them.
         const bool update_bias = imu_bias_observable();
 
+        // Per-point residual dimension for the chi-squared DOF estimate:
+        // point-to-plane constrains 1 dimension per correspondence; point-to-point /
+        // GICP / point-to-distribution use 3-D residuals.  GenZ blends both — using
+        // the smaller dimension is the conservative (loosening-only) choice.
+        const auto reg_type = this->params_.registration.pipeline.registration.reg_type;
+        const float icp_residual_dim = (reg_type == algorithms::registration::RegType::POINT_TO_PLANE ||
+                                        reg_type == algorithms::registration::RegType::GENZ)
+                                           ? 1.0f
+                                           : 3.0f;
+
 
         algorithms::registration::LinearizedResult last_icp;
         last_icp.inlier = 0;
@@ -519,8 +529,26 @@ private:
             }
 
             // Combine ICP + IMU into 15×15 normal equations.
+            // Reduced chi-squared calibration of the ICP information (same scheme as
+            // MapPrior::update): the ICP Hessian assumes unit-variance Mahalanobis
+            // residuals, which real data violates.  Calibrate by the actual residual
+            // statistics so a poor fit (map mismatch, degeneracy, sensor noise above
+            // the model) loosens the ICP factor relative to the IMU prior:
+            //   DOF = d·N_inlier − 6        (d = per-point residual dim, 6 = SE(3) params)
+            //   s²  = max(1, 2·error/DOF)   (factor 2 cancels the ½ in the robust error;
+            //                                clamp ≥ 1 so the factor is never tightened)
+            //   w   = 1 / s²
+            // Note: error is evaluated at the current annealed robust scale.  Early
+            // (coarse-scale) iterations see larger error → stronger downweighting →
+            // prediction-driven steps; the calibration relaxes toward w = 1 as the
+            // scale shrinks and the fit converges, which matches the GNC intent.
+            float icp_weight = 1.0f;
+            const float icp_dof = icp_residual_dim * static_cast<float>(last_icp.inlier) - 6.0f;
+            if (icp_dof > 0.0f && std::isfinite(last_icp.error) && last_icp.error >= 0.0f) {
+                icp_weight = 1.0f / std::max(1.0f, 2.0f * last_icp.error / icp_dof);
+            }
             algorithms::lio::LIOLinearizedResult lio;
-            algorithms::lio::add_icp_factor(lio, last_icp, x_op.rotation);
+            algorithms::lio::add_icp_factor(lio, last_icp, x_op.rotation, icp_weight);
             if (imu_valid) {
                 algorithms::lio::add_imu_factor(lio, H_imu, b_imu);
             } else {

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <deque>
 #include <map>
@@ -11,6 +12,7 @@
 #include "sycl_points/algorithms/imu/imu_initial_alignment.hpp"
 #include "sycl_points/algorithms/imu/imu_preintegration.hpp"
 #include "sycl_points/algorithms/lio/lio_registration.hpp"
+#include "sycl_points/algorithms/registration/dogleg_step.hpp"
 #include "sycl_points/algorithms/registration/registration.hpp"
 #include "sycl_points/pipeline/lidar_inertial_odometry_params.hpp"
 #include "sycl_points/pipeline/pointcloud_processing.hpp"
@@ -498,7 +500,6 @@ private:
                                            ? 1.0f
                                            : 3.0f;
 
-
         algorithms::registration::LinearizedResult last_icp;
         last_icp.inlier = 0;
         size_t actual_iterations = 0;
@@ -507,6 +508,21 @@ private:
         // recover the posterior covariance without the damping term.
         Eigen::Matrix<float, 15, 15> H_undamped = Eigen::Matrix<float, 15, 15>::Zero();
         bool has_H_undamped = false;
+
+        // Optimizer selection shared with the LO registration backend.
+        // GN: cheapest — damped solve only (λ escalated when H is ill-conditioned).
+        // LM/DOGLEG: step acceptance on the combined cost (weighted robust ICP error
+        //            with frozen correspondences + IMU prior Mahalanobis cost), at one
+        //            extra device error-evaluation pass per trial step.
+        const auto opt_method = this->params_.registration.pipeline.registration.optimization_method;
+        const auto& gn_params = this->params_.registration.pipeline.registration.gn;
+        const auto& lm_params = this->params_.registration.pipeline.registration.lm;
+        const auto& dl_params = this->params_.registration.pipeline.registration.dogleg;
+        float lm_lambda = lm_params.init_lambda;
+        float trust_region_radius = dl_params.initial_trust_region_radius;
+        const auto clamp_radius = [&](float radius) {
+            return std::clamp(radius, dl_params.min_trust_region_radius, dl_params.max_trust_region_radius);
+        };
 
         for (size_t iter = 0; iter < this->params_.lio.total_iterations; ++iter) {
             ++actual_iterations;
@@ -560,10 +576,25 @@ private:
                     kReg * Eigen::Matrix3f::Identity();
             }
 
-            Eigen::Matrix<float, 15, 1> delta;
-            const float lambda = this->params_.registration.pipeline.registration.gn.lambda;
-            if (!algorithms::lio::solve_ldlt(lio.H + lambda * Eigen::Matrix<float, 15, 15>::Identity(), lio.b, delta))
-                break;
+            Eigen::Matrix<float, 15, 1> delta = Eigen::Matrix<float, 15, 1>::Zero();
+
+            switch (opt_method) {
+                case algorithms::registration::OptimizationMethod::GAUSS_NEWTON: {
+                    const float lambda = gn_params.lambda;
+                    if (!algorithms::lio::solve_ldlt(lio.H + lambda * Eigen::Matrix<float, 15, 15>::Identity(), lio.b,
+                                                     delta))
+                        break;
+                    break;
+                }
+                case algorithms::registration::OptimizationMethod::LEVENBERG_MARQUARDT: {
+                    // TODO
+                    break;
+                }
+                case algorithms::registration::OptimizationMethod::POWELL_DOGLEG: {
+                    // TODO
+                    break;
+                }
+            }
             H_undamped = lio.H;
             has_H_undamped = true;
 

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -22,9 +22,13 @@
 // ---------------------------------------------------------------------------
 // LiDAR-Inertial Odometry Pipeline
 //
-// Each frame runs a Gauss-Newton loop that combines the ICP Hessian/gradient
-// (6×6, from SYCL parallel reduction) with the IMU prior Hessian/gradient
-// (15×15) into a unified 15-DOF normal equation solved by LDLT.
+// Each frame runs an iterative optimisation loop (Gauss-Newton, Levenberg-
+// Marquardt, or Powell dogleg, selected by optimization_method) that combines
+// the ICP Hessian/gradient (6×6, from SYCL parallel reduction) with the IMU
+// prior Hessian/gradient (15×15) into a unified 15-DOF normal equation solved
+// by LDLT.  GN commits the damped step unconditionally; LM and dogleg accept or
+// reject each trial step on the combined cost (reduced-chi²-weighted robust ICP
+// error with frozen correspondences + IMU prior Mahalanobis distance).
 //
 // Frame convention: single-stage, REP-105 style (FAST-LIO2-like).
 //   odom ──(estimated, dynamic)──▶ lidar     (odom is the gravity-aligned world frame)
@@ -524,6 +528,39 @@ private:
             return std::clamp(radius, dl_params.min_trust_region_radius, dl_params.max_trust_region_radius);
         };
 
+        // ---- Step-acceptance cost helpers (LM / dogleg) ----
+        // The combined LIO cost evaluated at an arbitrary operating state x:
+        //   J(x) = icp_weight · E_icp(x) + ½ · r(x)ᵀ H_imu r(x)
+        // where E_icp is the robust ICP error evaluated with the correspondences
+        // frozen at the current linearisation point (compute_error_frozen), and the
+        // IMU term is the prior Mahalanobis distance (H_imu = P_pred⁻¹ is constant
+        // across iterations; only the residual r = x ⊖ x_pred changes).  GN does not
+        // need this — it commits the damped step unconditionally — but LM and dogleg
+        // accept/reject trial steps by comparing J(x_trial) against J(x_op).
+        const auto imu_cost = [&](const imu::State& x) -> float {
+            if (!imu_valid) return 0.0f;
+            const Eigen::Matrix<float, 15, 1> r = imu::compute_manifold_residual(x_pred, x);
+            return 0.5f * r.dot(H_imu * r);
+        };
+
+        // First-order bias freeze: solve the full coupled system and then drop the bias
+        // increment when the window lacks excitation (update_bias == false).  Because H
+        // couples pose/velocity with the bias states, the retained pose/velocity step
+        // technically assumes the bias also moves, so this is a slight inconsistency.
+        // The iterative re-linearization absorbs most of it and the approximation is
+        // empirically stable (PR #177 eval).  Applied to every trial step so that the
+        // state evaluated by the LM/dogleg acceptance test matches the state retracted
+        // on acceptance.  A fully consistent freeze would, when !update_bias, zero the
+        // bias cross-terms / set the bias block of lio.H to identity and lio.b's bias
+        // segment to zero BEFORE the solve, and restore P_post_'s bias block from P_pred
+        // (zero cross-covariance) after it.
+        const auto apply_bias_freeze = [&](Eigen::Matrix<float, 15, 1>& d) {
+            if (!update_bias) {
+                d.segment<3>(imu::State::kIdxAccBias).setZero();
+                d.segment<3>(imu::State::kIdxGyrBias).setZero();
+            }
+        };
+
         for (size_t iter = 0; iter < this->params_.lio.total_iterations; ++iter) {
             ++actual_iterations;
 
@@ -576,44 +613,107 @@ private:
                     kReg * Eigen::Matrix3f::Identity();
             }
 
+            // ICP error at a trial state, reusing the correspondences frozen by the
+            // compute_linearized_result() call above (same source cloud).  Scaled by the
+            // reduced chi-squared icp_weight so the trial cost matches the information
+            // baked into lio.H/lio.b.
+            const auto icp_cost = [&](const imu::State& x) -> float {
+                const auto [e, in] = this->registration_->compute_error_frozen(
+                    *source, this->submap_->get_submap_point_cloud(), state_to_pose(x).matrix(), options);
+                (void)in;
+                return icp_weight * e;
+            };
+
+            const Eigen::Matrix<float, 15, 15> I15 = Eigen::Matrix<float, 15, 15>::Identity();
             Eigen::Matrix<float, 15, 1> delta = Eigen::Matrix<float, 15, 1>::Zero();
+            // step_accepted: a usable increment was produced and should be retracted.
+            //   GN  — true unless the damped solve fails (then we stop: cannot progress).
+            //   LM  — true when an inner trial lowered the combined cost.
+            //   DL  — true when the gain ratio cleared eta1.
+            // A rejected LM/dogleg step leaves x_op untouched and re-linearises next
+            // iteration with the adjusted lambda / trust-region radius, so it must NOT
+            // run the convergence test (delta == 0 would otherwise falsely converge).
+            bool step_accepted = false;
+            bool stop = false;
 
             switch (opt_method) {
                 case algorithms::registration::OptimizationMethod::GAUSS_NEWTON: {
-                    const float lambda = gn_params.lambda;
-                    if (!algorithms::lio::solve_ldlt(lio.H + lambda * Eigen::Matrix<float, 15, 15>::Identity(), lio.b,
-                                                     delta))
-                        break;
+                    if (algorithms::lio::solve_ldlt(lio.H + gn_params.lambda * I15, lio.b, delta)) {
+                        apply_bias_freeze(delta);
+                        step_accepted = true;
+                    } else {
+                        stop = true;  // ill-conditioned: keep x_op and end the loop
+                    }
                     break;
                 }
                 case algorithms::registration::OptimizationMethod::LEVENBERG_MARQUARDT: {
-                    // TODO
+                    // Damped trials around the fixed linearisation point: accept the first
+                    // λ whose step lowers the combined cost (then relax λ), otherwise grow
+                    // λ and retry up to max_inner_iterations.  One frozen-correspondence
+                    // error pass per trial.
+                    const float current_cost = icp_cost(x_op) + imu_cost(x_op);
+                    for (size_t inner = 0; inner < lm_params.max_inner_iterations; ++inner) {
+                        Eigen::Matrix<float, 15, 1> trial_delta = Eigen::Matrix<float, 15, 1>::Zero();
+                        if (algorithms::lio::solve_ldlt(lio.H + lm_lambda * I15, lio.b, trial_delta)) {
+                            apply_bias_freeze(trial_delta);
+                            const imu::State x_trial = algorithms::lio::retract(x_op, trial_delta);
+                            const float trial_cost = icp_cost(x_trial) + imu_cost(x_trial);
+                            if (trial_cost <= current_cost) {
+                                delta = trial_delta;
+                                step_accepted = true;
+                                lm_lambda = std::clamp(lm_lambda / lm_params.lambda_factor, lm_params.min_lambda,
+                                                       lm_params.max_lambda);
+                                break;
+                            }
+                        }
+                        lm_lambda =
+                            std::clamp(lm_lambda * lm_params.lambda_factor, lm_params.min_lambda, lm_params.max_lambda);
+                    }
                     break;
                 }
                 case algorithms::registration::OptimizationMethod::POWELL_DOGLEG: {
-                    // TODO
+                    // Trust-region step (GN / Cauchy / dogleg blend) accepted on the gain
+                    // ratio rho = actual / predicted cost reduction.  predicted_reduction is
+                    // recomputed on the (possibly bias-frozen) step so it stays consistent
+                    // with the increment actually evaluated and retracted.
+                    const float current_cost = icp_cost(x_op) + imu_cost(x_op);
+                    trust_region_radius = clamp_radius(trust_region_radius);
+                    const algorithms::registration::DoglegStep<15> dl =
+                        algorithms::registration::compute_dogleg_step<15>(lio.H, lio.b, trust_region_radius);
+                    Eigen::Matrix<float, 15, 1> trial_delta = dl.p;
+                    apply_bias_freeze(trial_delta);
+                    const float predicted_reduction =
+                        -(lio.b.dot(trial_delta) + 0.5f * trial_delta.dot(lio.H * trial_delta));
+                    if (predicted_reduction <= 0.0f) {
+                        trust_region_radius = clamp_radius(trust_region_radius * dl_params.gamma_decrease);
+                        break;
+                    }
+                    const imu::State x_trial = algorithms::lio::retract(x_op, trial_delta);
+                    const float trial_cost = icp_cost(x_trial) + imu_cost(x_trial);
+                    const float rho = (current_cost - trial_cost) / predicted_reduction;
+                    if (rho < dl_params.eta1) {
+                        trust_region_radius = clamp_radius(trust_region_radius * dl_params.gamma_decrease);
+                        break;
+                    }
+                    delta = trial_delta;
+                    step_accepted = true;
+                    if (rho > dl_params.eta2 && dl.step_norm >= trust_region_radius * 0.99f) {
+                        trust_region_radius = clamp_radius(trust_region_radius * dl_params.gamma_increase);
+                    }
                     break;
                 }
             }
             H_undamped = lio.H;
             has_H_undamped = true;
 
-            // First-order bias freeze: we solve the full coupled system and then drop the
-            // bias increment. Because H couples pose/velocity with the bias states, the
-            // retained pose/velocity step technically assumes the bias also moves, so this
-            // is a slight inconsistency. The iterative re-linearization absorbs most of it
-            // and the approximation is empirically stable (PR #177 eval). A fully consistent
-            // freeze would, when !update_bias, zero the bias cross-terms / set the bias block
-            // of lio.H to identity and lio.b's bias segment to zero BEFORE solve_ldlt, and
-            // restore P_post_'s bias block from P_pred (zero cross-covariance) after it.
-            if (!update_bias) {
-                delta.segment<3>(imu::State::kIdxAccBias).setZero();
-                delta.segment<3>(imu::State::kIdxGyrBias).setZero();
+            if (step_accepted) {
+                x_op = algorithms::lio::retract(x_op, delta);
+                if (is_lio_converged(delta)) break;
+            } else if (stop) {
+                break;
             }
-
-            x_op = algorithms::lio::retract(x_op, delta);
-
-            if (is_lio_converged(delta)) break;
+            // LM / dogleg rejection: x_op unchanged; retry next iteration with the
+            // updated lambda / trust-region radius.
         }
 
         // Posterior covariance from the undamped Hessian.  delta is solved with the

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -747,8 +747,13 @@ private:
                 if (ldlt_damped.info() == Eigen::Success && ldlt_damped.vectorD().minCoeff() > 0.0f) {
                     this->P_post_.setIdentity();
                     ldlt_damped.solveInPlace(this->P_post_);
+                } else {
+                    // H_undamped likely contains NaN/Inf from upstream (preintegration
+                    // or degenerate point matching); keep the previous P_post_.
+                    std::cerr << "[LidarInertialOdometry] WARNING: damped posterior solve failed; "
+                                 "keeping previous P_post_."
+                              << std::endl;
                 }
-                // If even the damped solve fails, keep the previous P_post_ as a last resort.
             }
         }
 

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -803,13 +803,6 @@ private:
         {
             auto& reg_params = this->params_.registration.pipeline;
             reg_params.velocity_update.enable = false;  // LIO controls its own update loop
-            // In LIO the IMU prior already constrains degenerate pose directions toward
-            // the prediction; the ICP degenerate regularization would double-count along
-            // the same directions, so disable it unless explicitly requested.
-            if (!this->params_.lio.use_icp_degenerate_regularization) {
-                reg_params.registration.degenerate_reg.type =
-                    algorithms::registration::DegenerateRegularizationType::none;
-            }
             this->registration_ =
                 std::make_shared<algorithms::registration::Registration>(*this->queue_ptr_, reg_params.registration);
             this->reg_result_ = std::make_shared<algorithms::registration::RegistrationResult>();

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -493,6 +493,11 @@ private:
         last_icp.inlier = 0;
         size_t actual_iterations = 0;
 
+        // Undamped normal-equation Hessian of the last solved iteration; used to
+        // recover the posterior covariance without the damping term.
+        Eigen::Matrix<float, 15, 15> H_undamped = Eigen::Matrix<float, 15, 15>::Zero();
+        bool has_H_undamped = false;
+
         for (size_t iter = 0; iter < this->params_.lio.total_iterations; ++iter) {
             ++actual_iterations;
 
@@ -529,9 +534,10 @@ private:
 
             Eigen::Matrix<float, 15, 1> delta;
             const float lambda = this->params_.registration.pipeline.registration.gn.lambda;
-            if (!algorithms::lio::solve_ldlt(lio.H + lambda * Eigen::Matrix<float, 15, 15>::Identity(), lio.b, delta,
-                                             &this->P_post_))
+            if (!algorithms::lio::solve_ldlt(lio.H + lambda * Eigen::Matrix<float, 15, 15>::Identity(), lio.b, delta))
                 break;
+            H_undamped = lio.H;
+            has_H_undamped = true;
 
             // First-order bias freeze: we solve the full coupled system and then drop the
             // bias increment. Because H couples pose/velocity with the bias states, the
@@ -549,6 +555,19 @@ private:
             x_op = algorithms::lio::retract(x_op, delta);
 
             if (is_lio_converged(delta)) break;
+        }
+
+        // Posterior covariance from the undamped Hessian.  delta is solved with the
+        // damping term λI for step control, but including λI in the inverse would
+        // understate P_post_ and over-tighten the next window's IMU prior.
+        if (has_H_undamped) {
+            Eigen::LDLT<Eigen::Matrix<float, 15, 15>> ldlt(H_undamped);
+            if (ldlt.info() == Eigen::Success && ldlt.vectorD().minCoeff() > 0.0f) {
+                this->P_post_.setIdentity();
+                ldlt.solveInPlace(this->P_post_);  // P_post = H⁻¹
+            }
+            // When H is not positive definite, keep the previous posterior instead of
+            // collapsing it to zero (zero would mean perfect confidence at the reset).
         }
 
         // ---- Update state and reset IMU preintegration ----

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -628,9 +628,9 @@ private:
             Eigen::Matrix<float, 15, 1> delta = Eigen::Matrix<float, 15, 1>::Zero();
             // step_accepted: a usable increment was produced and should be retracted.
             //   GN  — true unless the damped solve fails (then we stop: cannot progress).
-            //   LM  — true when an inner trial lowered the combined cost; if no trial
-            //         does (lambda already at max_lambda), we stop: re-linearising at
-            //         the same x_op would reproduce the same H/b and fail again.
+            //   LM  — true when an inner trial lowered the combined cost; if none does
+            //         within max_inner_iterations, we stop: re-linearising at the same
+            //         x_op would reproduce the same H/b and fail again.
             //   DL  — true when the gain ratio cleared eta1.
             // A rejected dogleg step leaves x_op untouched and re-linearises next
             // iteration with the adjusted trust-region radius, so it must NOT run the
@@ -672,8 +672,9 @@ private:
                             std::clamp(lm_lambda * lm_params.lambda_factor, lm_params.min_lambda, lm_params.max_lambda);
                     }
                     if (!step_accepted) {
-                        // lambda is already at max_lambda; re-linearising at the same
-                        // x_op would reproduce the same H/b and fail again.
+                        // max_inner_iterations exhausted without a cost-reducing step;
+                        // re-linearising at the same x_op would reproduce the same H/b
+                        // and fail again.
                         stop = true;
                     }
                     break;

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry_params.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry_params.hpp
@@ -64,15 +64,6 @@ struct Parameters : public lidar_odometry::Parameters {
             float max_gyro_bias = 0.0f;   ///< [rad/s]
         };
         BiasEstimation bias_estimation;
-
-        /// Keep the ICP degenerate regularization (registration.degenerate_reg)
-        /// active inside the LIO loop.  In LIO the IMU prior already constrains
-        /// poorly-observed (degenerate) pose directions toward the IMU prediction,
-        /// so the ICP-side Tikhonov term double-counts along the same directions and
-        /// can over-stiffen the solution.  Set false to disable it in the LIO
-        /// registration and let the IMU prior handle degeneracy alone.  The C++
-        /// default (true) preserves the previous behavior.
-        bool use_icp_degenerate_regularization = true;
     };
 
     LIO lio;

--- a/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
@@ -241,7 +241,24 @@ lidar_inertial_odometry_node:
     registration/source_noise_model/max_eigenvalue: 1.0     # upper cap; clamping here drives source covariance toward isotropy (target-driven point-to-plane behavior)
     registration/source_noise_model/cos_min: 0.1            # clamp on |cos(theta)| to avoid tan() divergence near grazing rays
 
+    # Optimizer for the LIO 15-DOF update loop (mirrors the LO solver options).
+    # GN: damped solve only (fastest).
+    # LM / DOGLEG: step acceptance on the combined ICP+IMU cost, costing one extra
+    #   error-evaluation pass per trial step.
+    registration/optimization_method: GN  # GN, LM, DOGLEG
     registration/gn/lambda: 1.0e-3
+    registration/lm/max_inner_iterations: 5
+    registration/lm/lambda_factor: 2.0
+    registration/lm/init_lambda: 1.0
+    registration/lm/max_lambda: 1.0e+3
+    registration/lm/min_lambda: 1.0e-3
+    registration/dogleg/initial_trust_region_radius: 2.0
+    registration/dogleg/max_trust_region_radius: 10.0
+    registration/dogleg/min_trust_region_radius: 1.0e-3
+    registration/dogleg/eta1: 0.25
+    registration/dogleg/eta2: 0.75
+    registration/dogleg/gamma_decrease: 0.80
+    registration/dogleg/gamma_increase: 1.25
 
     registration/degenerate_regularization/type: "NL_REG" # NONE, NL_REG
     registration/degenerate_regularization/nl_reg/trans_eigenvalue_threshold: 10.0

--- a/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
@@ -192,11 +192,6 @@ lidar_inertial_odometry_node:
     # Hard clamp on estimated bias L2 norm (0 = disabled). Bounds runaway/drift.
     lio/bias_estimation/max_accel_bias: 1.0   # [m/s^2]
     lio/bias_estimation/max_gyro_bias: 0.2    # [rad/s]
-    # Keep the ICP degenerate regularization (registration/degenerate_regularization)
-    # active inside the LIO loop. In LIO the IMU prior already constrains degenerate
-    # pose directions toward the prediction, so the ICP-side Tikhonov term double-counts
-    # along the same directions. Set false to let the IMU prior handle degeneracy alone.
-    lio/use_icp_degenerate_regularization: false
 
     # ICP registration backend (used for linearization inside the LIO loop)
     # registration/solver_iterations is unused; the loop count is lio/total_iterations.
@@ -260,7 +255,7 @@ lidar_inertial_odometry_node:
     registration/dogleg/gamma_decrease: 0.80
     registration/dogleg/gamma_increase: 1.25
 
-    registration/degenerate_regularization/type: "NL_REG" # NONE, NL_REG
+    registration/degenerate_regularization/type: "NONE" # NONE, NL_REG
     registration/degenerate_regularization/nl_reg/trans_eigenvalue_threshold: 10.0
     registration/degenerate_regularization/nl_reg/rot_eigenvalue_threshold: 10.0
     registration/degenerate_regularization/nl_reg/base_factor: 0.2

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_inertial_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_inertial_odometry_params.hpp
@@ -42,18 +42,14 @@ inline pipeline::lidar_inertial_odometry::Parameters declare_lidar_inertial_odom
     // Bias-estimation safeguards
     params.lio.bias_estimation.freeze_on_low_excitation = node->declare_parameter<bool>(
         "lio/bias_estimation/freeze_on_low_excitation", params.lio.bias_estimation.freeze_on_low_excitation);
-    params.lio.bias_estimation.gyro_excitation_threshold =
-        static_cast<float>(node->declare_parameter<double>("lio/bias_estimation/gyro_excitation_threshold",
-                                                           params.lio.bias_estimation.gyro_excitation_threshold));
-    params.lio.bias_estimation.accel_excitation_threshold =
-        static_cast<float>(node->declare_parameter<double>("lio/bias_estimation/accel_excitation_threshold",
-                                                           params.lio.bias_estimation.accel_excitation_threshold));
+    params.lio.bias_estimation.gyro_excitation_threshold = static_cast<float>(node->declare_parameter<double>(
+        "lio/bias_estimation/gyro_excitation_threshold", params.lio.bias_estimation.gyro_excitation_threshold));
+    params.lio.bias_estimation.accel_excitation_threshold = static_cast<float>(node->declare_parameter<double>(
+        "lio/bias_estimation/accel_excitation_threshold", params.lio.bias_estimation.accel_excitation_threshold));
     params.lio.bias_estimation.max_accel_bias = static_cast<float>(node->declare_parameter<double>(
         "lio/bias_estimation/max_accel_bias", params.lio.bias_estimation.max_accel_bias));
     params.lio.bias_estimation.max_gyro_bias = static_cast<float>(
         node->declare_parameter<double>("lio/bias_estimation/max_gyro_bias", params.lio.bias_estimation.max_gyro_bias));
-    params.lio.use_icp_degenerate_regularization = node->declare_parameter<bool>(
-        "lio/use_icp_degenerate_regularization", params.lio.use_icp_degenerate_regularization);
     return params;
 }
 


### PR DESCRIPTION
## Summary

- Calibrate the ICP factor each LIO iteration by the reduced chi-squared statistic (same scheme as `MapPrior::update` for the LO path): `add_icp_factor()` now takes an optional weight `1/s²` so a poor fit (map mismatch, degeneracy, sensor noise above the unit-variance model) loosens the ICP factor relative to the IMU prior instead of silently distorting the balance.
- Fix posterior covariance: `P_post_` is now recovered from the **undamped** 15×15 Hessian after the step is solved, instead of inverting `H + λI`. The previous behavior leaked the GN damping term into `P_post_`, understating uncertainty and over-tightening the next window's IMU prior. If the undamped Hessian isn't PD, keep the previous posterior rather than collapsing it to zero.
- Add Levenberg-Marquardt and Powell dogleg optimizers to the LIO 15-DOF update loop (`registration/optimization_method: GN|LM|DOGLEG`). LM/dogleg accept or reject each trial step on the combined ICP (frozen-correspondence, chi²-weighted) + IMU-prior cost; GN keeps the previous unconditional-step behavior.
- Extract the Powell dogleg step geometry (GN step, Cauchy point, dogleg blend, predicted reduction) into a dimension-generic `compute_dogleg_step<N>()` in `dogleg_step.hpp`, shared by the 6-DOF LO registration solver and the new 15-DOF LIO dogleg path.
- Remove the now-dead `lio/use_icp_degenerate_regularization` option and its config/declaration wiring.

## Test plan

- [ ] Build the C++ project and confirm it compiles cleanly
- [ ] Run the LIO pipeline with `registration/optimization_method: GN` (default) — regression check against pre-PR trajectory
- [ ] Same run with `LM` and `DOGLEG` — stable trajectories, no divergence
- [ ] Confirm `P_post_` / IMU prior remain well-conditioned across resets (no spurious covariance collapse when the undamped Hessian is indefinite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)