### PR TITLE
fix(lio): add the actual ICP source cloud to the submap

### DIFF
--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -292,6 +292,12 @@ private:
 
     PointCloudShared::Ptr preprocessed_pc_ = nullptr;
     PointCloudShared::Ptr registration_input_pc_ = nullptr;  // random-sampled source for ICP linearization
+    /// Point cloud actually used as the ICP source in the last lio_registration() call.
+    /// Points either to registration_input_pc_ (when random sampling ran) or to
+    /// preprocessed_pc_ (when sampling was skipped).  submapping() must add this same
+    /// cloud to the map; using registration_input_pc_ unconditionally would feed a
+    /// stale/empty cloud whenever sampling was skipped.
+    const PointCloudShared* registration_source_pc_ = nullptr;
     bool is_first_frame_ = true;
     imu::InitialAlignmentEstimator::Ptr alignment_estimator_ = nullptr;
     pointcloud_processing::ProcessingContext processing_ctx_;
@@ -473,12 +479,16 @@ private:
         const bool imu_valid = imu::compute_imu_hessian_gradient(x_pred, x_pred, P_pred, H_imu, b_imu);
 
         // ---- Prepare ICP source (random sampling) ----
+        // Record the cloud actually used so submapping() adds the same points to the
+        // map.  When sampling is skipped this is preprocessed_pc_, not the (stale)
+        // registration_input_pc_.
         const auto& rs = this->params_.registration.pipeline.random_sampling;
         const PointCloudShared* source =
             (rs.enable && this->preprocessed_pc_->size() > rs.num)
                 ? (this->pc_processor_->random_sampling(*this->preprocessed_pc_, *this->registration_input_pc_, rs.num),
                    this->registration_input_pc_.get())
                 : this->preprocessed_pc_.get();
+        this->registration_source_pc_ = source;
 
         // ---- Gauss-Newton loop ----
         imu::State x_op = x_pred;
@@ -925,7 +935,11 @@ private:
     // Submapping (same as LiDAROdometryPipeline)
     // -------------------------------------------------------------------------
     bool submapping(const algorithms::registration::RegistrationResult& reg_result, double timestamp) {
-        const auto reg_pc_ptr = this->registration_input_pc_;
+        // Add the same cloud that was used as the ICP source.  This is
+        // registration_input_pc_ when random sampling ran, or preprocessed_pc_ when it
+        // was skipped; registration_source_pc_ was set by lio_registration().
+        const PointCloudShared* reg_pc_ptr =
+            this->registration_source_pc_ != nullptr ? this->registration_source_pc_ : this->registration_input_pc_.get();
         bool computed_icp_weights = false;
         const size_t total_samples = this->params_.submap.point_random_sampling_num;
         if (reg_pc_ptr->size() > total_samples) {
@@ -945,10 +959,9 @@ private:
                                        : 0.0f;
 
         if (computed_icp_weights) {
-            return this->submap_->add_frame(*this->registration_input_pc_, reg_result, inlier_ratio, timestamp,
-                                            this->icp_weights_);
+            return this->submap_->add_frame(*reg_pc_ptr, reg_result, inlier_ratio, timestamp, this->icp_weights_);
         }
-        return this->submap_->add_frame(*this->registration_input_pc_, reg_result, inlier_ratio, timestamp);
+        return this->submap_->add_frame(*reg_pc_ptr, reg_result, inlier_ratio, timestamp);
     }
 
     // -------------------------------------------------------------------------

--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -297,7 +297,7 @@ private:
     /// preprocessed_pc_ (when sampling was skipped).  submapping() must add this same
     /// cloud to the map; using registration_input_pc_ unconditionally would feed a
     /// stale/empty cloud whenever sampling was skipped.
-    const PointCloudShared* registration_source_pc_ = nullptr;
+    PointCloudShared::ConstPtr registration_source_pc_ = nullptr;
     bool is_first_frame_ = true;
     imu::InitialAlignmentEstimator::Ptr alignment_estimator_ = nullptr;
     pointcloud_processing::ProcessingContext processing_ctx_;
@@ -483,11 +483,11 @@ private:
         // map.  When sampling is skipped this is preprocessed_pc_, not the (stale)
         // registration_input_pc_.
         const auto& rs = this->params_.registration.pipeline.random_sampling;
-        const PointCloudShared* source =
+        PointCloudShared::ConstPtr source =
             (rs.enable && this->preprocessed_pc_->size() > rs.num)
                 ? (this->pc_processor_->random_sampling(*this->preprocessed_pc_, *this->registration_input_pc_, rs.num),
-                   this->registration_input_pc_.get())
-                : this->preprocessed_pc_.get();
+                   this->registration_input_pc_)
+                : this->preprocessed_pc_;
         this->registration_source_pc_ = source;
 
         // ---- Gauss-Newton loop ----
@@ -938,8 +938,8 @@ private:
         // Add the same cloud that was used as the ICP source.  This is
         // registration_input_pc_ when random sampling ran, or preprocessed_pc_ when it
         // was skipped; registration_source_pc_ was set by lio_registration().
-        const PointCloudShared* reg_pc_ptr =
-            this->registration_source_pc_ != nullptr ? this->registration_source_pc_ : this->registration_input_pc_.get();
+        PointCloudShared::ConstPtr reg_pc_ptr =
+            this->registration_source_pc_ != nullptr ? this->registration_source_pc_ : this->registration_input_pc_;
         bool computed_icp_weights = false;
         const size_t total_samples = this->params_.submap.point_random_sampling_num;
         if (reg_pc_ptr->size() > total_samples) {


### PR DESCRIPTION
### Summary
This PR ensures the actual ICP source cloud is included in the submap, which improves the accuracy of the LIO mapping process.

### Changes
- Updated submap generation logic to use the correct source cloud for ICP.

### Verification
- [x] Code compiled successfully.
- [x] Verified LIO submap generation logic in local tests.