### PR TITLE
fix(lo): snapshot IMU window-start orientation from registered pose

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,35 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        with:
+          model: google/gemini-3.1-flash-lite

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ CLAUDE.md
 *.pyc
 .gemini-session-id
 .agy-conversation-id
+
+.env

--- a/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
@@ -539,14 +539,15 @@ private:
                 init_T = this->motion_predictor_->predict(this->linear_velocity_, this->angular_velocity_, this->odom_,
                                                           this->dt_, this->reg_result_, this->registrated_);
             }
-            const Eigen::Matrix3f R_world_imu = this->odom_.rotation() * this->params_.imu.T_imu_to_lidar.rotation();
-
             // linear_velocity_ is in the prev_odom_ body frame, so use prev_odom_.rotation() to convert to world frame.
             const Eigen::Vector3f v_reset = this->imu_velocity_corrector_.get_reset_velocity(
                 *this->imu_preintegration_, this->imu_bias_, this->prev_odom_.rotation() * this->linear_velocity_);
             this->imu_preintegration_->reset(this->imu_bias_);
-            this->imu_R_world_at_reset_ = R_world_imu;
             this->imu_v_world_at_reset_ = v_reset;
+            // imu_R_world_at_reset_ is set after align() below, from the just-registered pose.
+            // The window being reset here starts at t_k, where the LiDAR orientation is the ICP
+            // result (reg_result.T), not the pre-registration odom_ (= t_{k-1} pose), which would
+            // lag the window-start orientation by one frame.
         } else {
             init_T = this->motion_predictor_->predict(this->linear_velocity_, this->angular_velocity_, this->odom_,
                                                       this->dt_, this->reg_result_, this->registrated_);
@@ -562,8 +563,20 @@ private:
         options.dt = this->dt_;
         options.prev_pose = this->odom_.matrix();
 
-        return this->registration_pipeline_->align(*this->preprocessed_pc_, this->submap_->get_submap_point_cloud(),
-                                                   this->submap_->get_submap_kdtree(), init_T.matrix(), options);
+        auto result = this->registration_pipeline_->align(*this->preprocessed_pc_, this->submap_->get_submap_point_cloud(),
+                                                          this->submap_->get_submap_kdtree(), init_T.matrix(), options);
+
+        // Snapshot the window-start IMU orientation from the just-registered pose (t_k), so the
+        // next frame's imu_motion_prediction() compensates gravity around the correct orientation.
+        // imu_v_world_at_reset_ above intentionally retains the velocity corrector's value, which
+        // carries a known one-frame (~100 ms @ 10 Hz) approximation that IMU gravity/bias
+        // compensation absorbs; only the orientation is corrected here. Fixing the velocity lag too
+        // would require splitting the corrector's snapshot/return protocol (see IMUVelocityCorrector).
+        if (this->imu_preintegration_) {
+            this->imu_R_world_at_reset_ = result.T.rotation() * this->params_.imu.T_imu_to_lidar.rotation();
+        }
+
+        return result;
     }
 
     void submapping(const algorithms::registration::RegistrationResult& reg_result, double timestamp) {


### PR DESCRIPTION
## Summary
Fixes a one-frame lag in the IMU preintegration window-start orientation in the loosely-coupled LiDAR Odometry (`lidar_odometry.hpp`). This is improvement point #4 from the recent LO review.

## Problem
The reset performed in `registration()` for frame *k* establishes the window-start state for the next preintegration window `(t_k, t_{k+1}]`, which frame *k+1* integrates and predicts from. `imu_R_world_at_reset_` was computed from the **pre-registration** `odom_` — still the *t_{k-1}* pose at that point, since `odom_` is only updated to `reg_result.T` later in `process()`. The window truly starts at *t_k*, so the start orientation lagged by one frame, biasing the gravity compensation in the next frame's `imu_motion_prediction()`.

## Fix
Take `imu_R_world_at_reset_` from the `align()` result (`result.T.rotation()` at *t_k*) instead of the pre-update `odom_`. Only the orientation snapshot moves after `align()`; `reset()` and `get_reset_velocity()` ordering is unchanged.

## Velocity lag left as-is (intentional)
`imu_v_world_at_reset_` carries the same one-frame approximation, but correcting it requires splitting `IMUVelocityCorrector`'s snapshot↔update protocol (the snapshot and the matching ICP displacement must refer to the same window). The ~100 ms lag (@10 Hz) is absorbed by IMU gravity/bias compensation, so velocity is left unchanged with a documenting comment. Diagnosis and rotation-only scope were reviewed with Gemini.

## Verification
- [x] Release build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)