### PR TITLE
点群不足時の LIO IMU-only フォールバックを追加

### DIFF
--- a/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp
@@ -61,6 +61,7 @@ public:
         success = 0,
         first_frame,
         waiting_initial_alignment,
+        imu_only,
         error = 100,
         old_timestamp,
         small_number_of_points,
@@ -192,20 +193,22 @@ public:
             this->add_delta_time(ProcessName::preprocessing, dt_preprocessing);
         }
 
-        if (this->preprocessed_pc_->size() <= this->params_.registration.min_num_points) {
+        const bool insufficient_points = this->preprocessed_pc_->size() <= this->params_.registration.min_num_points;
+
+        // The first LiDAR frame initializes the submap and frame convention, so it
+        // cannot fall back to IMU-only propagation.  Keep this check before IMU
+        // integration to avoid advancing the preintegration state on a rejected
+        // first frame.
+        if (this->is_first_frame_ && insufficient_points) {
             this->error_message_ = "point cloud size is too small";
             return ResultType::small_number_of_points;
         }
 
-        // Integrate IMU measurements for this window
-        {
-            this->imu_batch_.clear();
-            std::lock_guard<std::mutex> lock(this->imu_mutex_);
-            this->imu_batch_.reserve(this->imu_buffer_.size());
-            imu::build_measurement_window(this->imu_buffer_, this->last_imu_reset_timestamp_, timestamp,
-                                          this->imu_batch_);
+        this->integrate_imu_window(timestamp);
+
+        if (insufficient_points) {
+            return this->process_imu_only(timestamp);
         }
-        this->imu_preintegration_->integrate_batch(this->imu_batch_);
 
         // First frame: initialize state and submap, no registration
         if (this->is_first_frame_) {
@@ -453,6 +456,56 @@ private:
         pred.accel_bias = this->x_.accel_bias;
         pred.gyro_bias = this->x_.gyro_bias;
         return pred;
+    }
+
+    void integrate_imu_window(double timestamp) {
+        this->imu_batch_.clear();
+        {
+            std::lock_guard<std::mutex> lock(this->imu_mutex_);
+            this->imu_batch_.reserve(this->imu_buffer_.size());
+            imu::build_measurement_window(this->imu_buffer_, this->last_imu_reset_timestamp_, timestamp,
+                                          this->imu_batch_);
+        }
+        this->imu_preintegration_->integrate_batch(this->imu_batch_);
+    }
+
+    ResultType process_imu_only(double timestamp) {
+        const imu::State predicted_state = this->predict_state();
+        const Eigen::Matrix<float, 15, 15> predicted_covariance = algorithms::lio::transform_covariance_imu_to_lidar(
+            this->imu_preintegration_->get_raw().covariance, this->params_.imu.T_imu_to_lidar,
+            predicted_state.rotation);
+
+        if (!predicted_state.position.allFinite() || !predicted_state.rotation.allFinite() ||
+            !predicted_state.velocity.allFinite() || !predicted_covariance.allFinite()) {
+            this->error_message_ = "imu-only propagation produced non-finite state or covariance";
+            return ResultType::error;
+        }
+
+        // Accept the IMU prediction as the posterior because no LiDAR measurement
+        // update is available for this frame.
+        this->prev_odom_ = this->odom_;
+        this->x_ = predicted_state;
+        this->P_post_ = predicted_covariance;
+        this->odom_ = state_to_pose(this->x_);
+
+        // Do not leave the previous ICP result visible as the latest result.
+        this->reg_result_->T = this->odom_;
+        this->reg_result_->converged = true;
+        this->reg_result_->iterations = 0;
+        this->reg_result_->H.setZero();
+        this->reg_result_->b.setZero();
+        this->reg_result_->error = 0.0f;
+        this->reg_result_->H_raw.setZero();
+        this->reg_result_->b_raw.setZero();
+        this->reg_result_->error_raw = 0.0f;
+        this->reg_result_->inlier = 0;
+
+        this->last_frame_time_ = timestamp;
+        this->last_imu_reset_timestamp_ = timestamp;
+        this->reset_imu_preintegration();
+
+        this->error_message_ = "point cloud size is too small; propagated with IMU only";
+        return ResultType::imu_only;
     }
 
     /// @brief Prepare one frame and delegate optimization to algorithms::lio.

--- a/ros2/sycl_points_ros2/src/lidar_inertial_odometry_bag_eval_node.cpp
+++ b/ros2/sycl_points_ros2/src/lidar_inertial_odometry_bag_eval_node.cpp
@@ -118,6 +118,7 @@ void LidarInertialOdometryBagEvalNode::run() {
             this->record_processing_times(frame);
 
             const bool should_write_tum = frame.result == ResultType::success ||
+                                          frame.result == ResultType::imu_only ||
                                           (frame.result == ResultType::first_frame && this->write_first_frame_);
             if (should_write_tum) {
                 const auto pose_msg = this->make_pose_message(msg.header, frame.odom);

--- a/ros2/sycl_points_ros2/src/lidar_inertial_odometry_node.cpp
+++ b/ros2/sycl_points_ros2/src/lidar_inertial_odometry_node.cpp
@@ -44,7 +44,8 @@ LidarInertialOdometryNode::LidarInertialOdometryNode(const rclcpp::NodeOptions& 
 
 void LidarInertialOdometryNode::point_cloud_callback(const sensor_msgs::msg::PointCloud2::UniquePtr msg) {
     auto frame = this->process_point_cloud_message(*msg);
-    if (frame.result == ResultType::success || frame.result == ResultType::first_frame) {
+    if (frame.result == ResultType::success || frame.result == ResultType::first_frame ||
+        frame.result == ResultType::imu_only) {
         this->publish_processed_frame(msg->header, frame);
     }
     this->record_processing_times(frame);


### PR DESCRIPTION
### Motivation
- 点群フィルタ後の有効点数が `registration.min_num_points` 以下の場合でも、LIO が初期化済みであれば処理を停止せず IMU プリインテグレーションにより状態を継続伝搬するためのフォールバックを追加する。

### Description
- `ResultType` に `imu_only` を追加し、IMU-only が正常系の戻り値として扱えるようにした (`cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp`).
- 点群不足の判定を `insufficient_points` にまとめ、初回フレームは従来どおり先行チェックして `small_number_of_points` を返し、初期化済みの場合は IMU ウィンドウを積分して `process_imu_only()` に分岐するよう処理順序を変更した。具体的には点群不足チェックを IMU integration より前に残す一方で、初期化済みは IMU を統合後に IMU-only を実行する。 (`lidar_inertial_odometry.hpp`) 
- IMU ウィンドウ構築を `integrate_imu_window(double timestamp)` に切り出し、バッファロック範囲を限定して `imu_preintegration_->integrate_batch()` を呼ぶ構造にした。 (`lidar_inertial_odometry.hpp`) 
- `process_imu_only(double timestamp)` を追加し、IMU 予測状態と IMU→LiDAR 変換された予測共分散をそのままポステリアとして採用して `x_`, `P_post_`, `odom_`, タイムスタンプを更新し、`reset_imu_preintegration()` を呼ぶ実装を追加した。合わせて古い ICP 結果が最新として残らないよう `reg_result_` を IMU-only 用にリセットしている。 (`lidar_inertial_odometry.hpp`) 
- ROS2 側では IMU-only を publish 対象に含め、ライブノードの odometry publish と bag 評価の TUM 出力が継続されるように `lidar_inertial_odometry_node.cpp` と `lidar_inertial_odometry_bag_eval_node.cpp` を修正した。 
- 変更ファイル: `cpp/include/sycl_points/pipeline/lidar_inertial_odometry.hpp`, `ros2/sycl_points_ros2/src/lidar_inertial_odometry_node.cpp`, `ros2/sycl_points_ros2/src/lidar_inertial_odometry_bag_eval_node.cpp`。

### Testing
- `git diff --check` を実行して差分の整合性を確認済み。 (成功)
- `cmake` ビルドおよびテスト実行を試行したが、環境依存により実行できなかった: `/opt/intel/oneapi/setvars.sh` が存在せず oneAPI 環境初期化ができなかったため最初の試行は中断され、別試行では `Eigen3` の CMake 設定ファイルが見つからずコンフィグレーションが失敗した。（環境依存でビルド不可）
- 上記のビルドブロック以外に、変更はローカルでコミット済み（コミットメッセージ: "Add LIO IMU-only fallback for sparse point clouds"）。
