### PR TITLE
feat: add gyro-only IMU deskew mode

### DIFF
--- a/cpp/include/sycl_points/algorithms/deskew/imu_deskew.hpp
+++ b/cpp/include/sycl_points/algorithms/deskew/imu_deskew.hpp
@@ -117,6 +117,7 @@ SYCL_EXTERNAL inline void interpolate_trajectory_pose(const IMUTrajectoryPose& t
 ///                              (e.g., pure LO); the deskew will then omit the v0 * t term
 ///                              and only correct for rotation and acceleration-induced motion.
 /// @param[out] status           Optional detailed result code.
+/// @param gyro_only             If true, integrate rotation only and omit IMU translation.
 /// @return true on success, false if prerequisites are not met.
 template <imu::imu_measurement_range Range>
 inline bool deskew_point_cloud_imu(const PointCloudShared& input_cloud, PointCloudShared& output_cloud,
@@ -124,7 +125,7 @@ inline bool deskew_point_cloud_imu(const PointCloudShared& input_cloud, PointClo
                                    const Eigen::Isometry3f& T_imu_to_lidar, const imu::IMUBias& bias,
                                    const imu::IMUPreintegrationParams& preintegration_params,
                                    const Eigen::Matrix3f& R_world_body_i, const Eigen::Vector3f& v_world_body_i,
-                                   IMUDeskewStatus* status = nullptr) {
+                                   IMUDeskewStatus* status = nullptr, bool gyro_only = false) {
     auto set_status = [&](IMUDeskewStatus s) {
         if (status) *status = s;
     };
@@ -244,15 +245,21 @@ inline bool deskew_point_cloud_imu(const PointCloudShared& input_cloud, PointClo
             const float t_rel_sec = static_cast<float>(it->timestamp - scan_start_time_sec);
             if (t_rel_sec < 0.0f) continue;
 
-            // predict_relative_transform() applies gravity compensation using dt_total,
-            // which equals t_rel_sec because the integrator was reset at scan_start.
-            const sycl_points::TransformMatrix T_imu_rel =
-                local_integrator.predict_relative_transform(R_world_body_i, v_world_body_i, bias);
+            Eigen::Isometry3f T_imu_rel = Eigen::Isometry3f::Identity();
+            if (gyro_only) {
+                // Rotation is directly constrained by the gyroscope. Do not let
+                // uncertain velocity or double-integrated acceleration affect points.
+                T_imu_rel.linear() = local_integrator.get_corrected(bias).Delta_R;
+            } else {
+                // predict_relative_transform() applies gravity compensation using dt_total,
+                // which equals t_rel_sec because the integrator was reset at scan_start.
+                T_imu_rel = Eigen::Isometry3f(
+                    local_integrator.predict_relative_transform(R_world_body_i, v_world_body_i, bias));
+            }
 
             // Convert to LiDAR-frame relative transform:
             //   T_lidar_rel = T_imu_to_lidar * T_imu_rel * T_imu_to_lidar^{-1}
-            const Eigen::Isometry3f T_lidar_rel =
-                T_imu_to_lidar * Eigen::Isometry3f(T_imu_rel) * T_imu_to_lidar.inverse();
+            const Eigen::Isometry3f T_lidar_rel = T_imu_to_lidar * T_imu_rel * T_imu_to_lidar.inverse();
 
             // Store as flat quaternion + translation for SYCL kernel access.
             const Eigen::Quaternionf q_lidar(T_lidar_rel.rotation());

--- a/cpp/include/sycl_points/pipeline/odometry_common_params.hpp
+++ b/cpp/include/sycl_points/pipeline/odometry_common_params.hpp
@@ -197,6 +197,8 @@ struct CommonParameters {
             /// Enable pre-processing deskew using IMU measurements.
             /// Applied before downsampling and ICP to correct per-point motion distortion.
             bool enable = false;
+            /// If true, omit velocity, gravity, and accelerometer translation integration.
+            bool gyro_only = false;
         };
         Deskew deskew;
 

--- a/cpp/include/sycl_points/pipeline/pointcloud_processing.hpp
+++ b/cpp/include/sycl_points/pipeline/pointcloud_processing.hpp
@@ -106,9 +106,9 @@ private:
                               const Eigen::Vector3f& v_world_body_i) const {
         const double scan_start_sec = src.start_time_ms * 1e-3;
         const Eigen::Matrix3f R_world_imu = current_pose.rotation() * this->imu_params_.T_imu_to_lidar.rotation();
-        algorithms::deskew::deskew_point_cloud_imu(src, dst, imu_buffer, scan_start_sec,
-                                                   this->imu_params_.T_imu_to_lidar, bias,
-                                                   this->imu_params_.preintegration, R_world_imu, v_world_body_i);
+        algorithms::deskew::deskew_point_cloud_imu(
+            src, dst, imu_buffer, scan_start_sec, this->imu_params_.T_imu_to_lidar, bias,
+            this->imu_params_.preintegration, R_world_imu, v_world_body_i, nullptr, this->imu_params_.deskew.gyro_only);
     }
 
     void prefilter_impl(const PointCloudShared& src, PointCloudShared& dst) const {

--- a/cpp/tests/test_imu_deskew.cpp
+++ b/cpp/tests/test_imu_deskew.cpp
@@ -9,7 +9,6 @@
 #include "sycl_points/algorithms/deskew/relative_pose_deskew.hpp"
 #include "sycl_points/algorithms/imu/imu_preintegration.hpp"
 #include "sycl_points/points/point_cloud.hpp"
-#include "sycl_points/utils/eigen_utils.hpp"
 #include "sycl_points/utils/sycl_utils.hpp"
 
 namespace sycl_points::algorithms::deskew {
@@ -111,6 +110,17 @@ TEST(IMUDeskewTest, PureRotationDeskew) {
         EXPECT_NEAR((corrected - world_points[i]).norm(), 0.0f, kEps)
             << "Point " << i << ": corrected=" << corrected.transpose() << "  expected=" << world_points[i].transpose();
     }
+
+    PointCloudShared deskewed_gyro_only(queue);
+    ASSERT_TRUE(deskew_point_cloud_imu(cloud, deskewed_gyro_only, imu_buf, scan_start_sec,
+                                       Eigen::Isometry3f::Identity(), imu::IMUBias(), preint_params,
+                                       Eigen::Matrix3f::Identity(), Eigen::Vector3f::Zero(), &status, true));
+    for (size_t i = 0; i < world_points.size(); ++i) {
+        const Eigen::Vector3f corrected = (*deskewed_gyro_only.points)[i].head<3>();
+        EXPECT_NEAR((corrected - world_points[i]).norm(), 0.0f, kEps)
+            << "Gyro-only point " << i << ": corrected=" << corrected.transpose()
+            << "  expected=" << world_points[i].transpose();
+    }
 }
 
 // 2. Pure translation (zero gyro, zero gravity): constant acceleration.
@@ -168,6 +178,44 @@ TEST(IMUDeskewTest, PureTranslationDeskew) {
     for (size_t i = 0; i < world_pts.size(); ++i) {
         const Eigen::Vector3f corrected = (*deskewed.points)[i].head<3>();
         EXPECT_NEAR((corrected - world_pts[i]).norm(), 0.0f, kEps) << "Point " << i << " mismatch";
+    }
+}
+
+TEST(IMUDeskewTest, GyroOnlyIgnoresAccelerationAndInitialVelocity) {
+    auto queue = make_queue();
+    PointCloudShared cloud(queue);
+
+    constexpr double scan_start_sec = 3.0;
+    constexpr double scan_duration_sec = 0.1;
+    cloud.start_time_ms = scan_start_sec * 1e3;
+    cloud.end_time_ms = (scan_start_sec + scan_duration_sec) * 1e3;
+
+    const std::vector<Eigen::Vector3f> input_points = {
+        {1.0f, 2.0f, 3.0f},
+        {-2.0f, 0.5f, 1.0f},
+        {0.25f, -0.75f, 4.0f},
+    };
+    const std::vector<float> offsets_ms = {0.0f, 50.0f, 100.0f};
+    for (size_t i = 0; i < input_points.size(); ++i) {
+        PointType point;
+        point << input_points[i].x(), input_points[i].y(), input_points[i].z(), 1.0f;
+        cloud.points->push_back(point);
+        cloud.timestamp_offsets->push_back(offsets_ms[i]);
+    }
+
+    const auto imu_buf = make_imu_buffer(scan_start_sec - 0.02, scan_duration_sec + 0.04, 24, Eigen::Vector3f::Zero(),
+                                         Eigen::Vector3f(3.0f, -2.0f, 11.0f));
+
+    imu::IMUPreintegrationParams preint_params;
+    PointCloudShared deskewed(queue);
+    IMUDeskewStatus status;
+    const bool ok = deskew_point_cloud_imu(cloud, deskewed, imu_buf, scan_start_sec, Eigen::Isometry3f::Identity(),
+                                           imu::IMUBias(), preint_params, Eigen::Matrix3f::Identity(),
+                                           Eigen::Vector3f(5.0f, -4.0f, 2.0f), &status, true);
+
+    ASSERT_TRUE(ok) << "deskew failed with status " << static_cast<int>(status);
+    for (size_t i = 0; i < input_points.size(); ++i) {
+        EXPECT_NEAR(((*deskewed.points)[i].head<3>() - input_points[i]).norm(), 0.0f, kEps);
     }
 }
 

--- a/cpp/tests/test_imu_preintegration.cpp
+++ b/cpp/tests/test_imu_preintegration.cpp
@@ -485,7 +485,10 @@ TEST(IMUPreintegration, GetCorrectedSameBiasEqualsRaw) {
 //     interval's half-step rotation on Delta_v and Delta_p.
 TEST(IMUPreintegration, MidpointGyroBiasJacobiansMatchFiniteDifference) {
     constexpr double dt = 0.2;
-    constexpr float eps = 1e-3f;
+    // Delta_p changes by only O(1e-5) at eps=1e-3, which is too close to
+    // float round-off after subtracting two O(1e-1) positions. A larger
+    // central-difference step keeps the numerical derivative well resolved.
+    constexpr float eps = 1e-2f;
     const Eigen::Vector3f gyro(0.2f, -0.1f, 1.0f);
     const Eigen::Vector3f accel(4.0f, 1.0f, 8.0f);
     const auto measurements = make_constant_imu(0.0, dt, 1, gyro, accel);
@@ -510,7 +513,7 @@ TEST(IMUPreintegration, MidpointGyroBiasJacobiansMatchFiniteDifference) {
 
     EXPECT_TRUE(nominal.get_raw().J.J_v_bg.col(2).isApprox(numerical_v, 5e-4f))
         << "analytic=" << nominal.get_raw().J.J_v_bg.col(2).transpose() << " numerical=" << numerical_v.transpose();
-    EXPECT_TRUE(nominal.get_raw().J.J_p_bg.col(2).isApprox(numerical_p, 1e-4f))
+    EXPECT_TRUE(nominal.get_raw().J.J_p_bg.col(2).isApprox(numerical_p, 5e-4f))
         << "analytic=" << nominal.get_raw().J.J_p_bg.col(2).transpose() << " numerical=" << numerical_p.transpose();
 }
 

--- a/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_inertial_odometry.yaml
@@ -52,6 +52,7 @@ lidar_inertial_odometry_node:
     imu/accel_unit: "m_s2"              # IMU acceleration unit: "m_s2" (m/s^2) or "G" (1G = 9.80665 m/s^2). Use "G" for Livox built-in IMU.
     imu/buffer_duration_sec: 2.0        # IMU buffering duration
     imu/deskew/enable: true             # IMU-based pre-processing deskew
+    imu/deskew/gyro_only: false         # If true, use rotation only and omit accelerometer/velocity translation
     imu/preintegration/gravity/x: 0.0   # Gravity vector in world frame [m/s^2]
     imu/preintegration/gravity/y: 0.0
     imu/preintegration/gravity/z: -9.80665

--- a/ros2/sycl_points_ros2/config/lidar_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_odometry.yaml
@@ -53,6 +53,7 @@ lidar_odometry_node:
     imu/accel_unit: "m_s2"              # IMU acceleration unit: "m_s2" (m/s^2) or "G" (1G = 9.80665 m/s^2). Use "G" for Livox built-in IMU.
     imu/buffer_duration_sec: 1.0        # IMU buffering duration
     imu/deskew/enable: true             # IMU-based pre-processing deskew (applied before downsampling and ICP)
+    imu/deskew/gyro_only: false         # If true, use rotation only and omit accelerometer/velocity translation
     imu/preintegration/gravity/x: 0.0   # Gravity vector in world frame [m/s^2]
     imu/preintegration/gravity/y: 0.0
     imu/preintegration/gravity/z: -9.80665

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_odometry_common_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_odometry_common_params.hpp
@@ -308,6 +308,8 @@ inline pipeline::odometry::CommonParameters declare_odometry_common_parameters(r
             node->declare_parameter<double>("imu/buffer_duration_sec", params.imu.buffer_duration_sec);
 
         params.imu.deskew.enable = node->declare_parameter<bool>("imu/deskew/enable", params.imu.deskew.enable);
+        params.imu.deskew.gyro_only =
+            node->declare_parameter<bool>("imu/deskew/gyro_only", params.imu.deskew.gyro_only);
 
         // Stationary-IMU initial roll/pitch alignment
         params.imu.initial_alignment.enable =


### PR DESCRIPTION
## Summary

- add `imu/deskew/gyro_only` as a boolean ROS parameter
- support rotation-only point cloud deskew using bias-corrected gyroscope integration
- omit velocity, gravity, and accelerometer-derived translation when gyro-only mode is enabled
- preserve the LiDAR lever-arm motion induced by rotation through `T_imu_to_lidar`
- keep the existing full SE(3) IMU deskew behavior as the default
- add tests for pure gyro rotation and for ignoring acceleration and initial velocity
- stabilize the single-precision midpoint gyro-bias Jacobian finite-difference test

## Motivation

Translation deskew depends on an estimated initial velocity and double-integrated accelerometer measurements. Their errors can degrade deskew quality, while angular motion is directly observed by the gyroscope. This change allows users to select gyro-only deskew when rotational correction is preferable to uncertain translational correction.

## Configuration

```yaml
imu/deskew/enable: true
imu/deskew/gyro_only: true
```

`gyro_only: false` retains the existing full IMU deskew behavior.

## Validation

- built `test_imu_deskew` and `test_lidar_odometry_imu`
- ran all 25 `test_imu_preintegration` tests successfully
- built ROS 2 packages `sycl_points` and `sycl_points_ros2` with `colcon`
- verified no remaining `IMUDeskewMode` references and no diff whitespace errors

The SYCL-dependent deskew tests could not be executed in the current environment because no requested SYCL device is available; the targets compile successfully.