### PR TITLE
feat: add configurable motion prediction modes for lidar odometry

### DIFF
--- a/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_odometry.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <deque>
 #include <map>
 #include <mutex>
@@ -11,8 +12,8 @@
 #include "sycl_points/algorithms/imu/imu_preintegration.hpp"
 #include "sycl_points/algorithms/imu/imu_velocity_corrector.hpp"
 #include "sycl_points/algorithms/registration/registration_pipeline.hpp"
-#include "sycl_points/pipeline/adaptive_motion_predictor.hpp"
 #include "sycl_points/pipeline/lidar_odometry_params.hpp"
+#include "sycl_points/pipeline/motion_predictor.hpp"
 #include "sycl_points/pipeline/pointcloud_processing.hpp"
 #include "sycl_points/pipeline/submapping.hpp"
 #include "sycl_points/points/point_cloud.hpp"
@@ -227,6 +228,12 @@ public:
                 imu::build_measurement_window(this->imu_buffer_, this->last_imu_reset_timestamp_, timestamp,
                                               this->imu_batch_);
             }
+            constexpr double kTimestampToleranceSec = 1e-6;
+            this->imu_window_complete_ =
+                this->imu_batch_.size() >= 2 &&
+                std::abs(this->imu_batch_.front().timestamp - this->last_imu_reset_timestamp_) <=
+                    kTimestampToleranceSec &&
+                std::abs(this->imu_batch_.back().timestamp - timestamp) <= kTimestampToleranceSec;
             this->imu_preintegration_->integrate_batch(this->imu_batch_);
         }
 
@@ -278,7 +285,7 @@ public:
             this->linear_velocity_ = delta_pose.translation() / this->dt_;
             this->angular_velocity_ = Eigen::AngleAxisf(delta_angle_axis.angle() / this->dt_, delta_angle_axis.axis());
 
-            if (this->imu_preintegration_) {
+            if (this->imu_preintegration_ && this->params_.motion_prediction.mode == MotionPredictionMode::IMU_SE3) {
                 const Eigen::Matrix3f R_world_imu_prev =
                     this->prev_odom_.rotation() * this->params_.imu.T_imu_to_lidar.rotation();
                 this->imu_velocity_corrector_.update(this->odom_.translation() - this->prev_odom_.translation(),
@@ -319,7 +326,7 @@ private:
 
     Parameters params_;
 
-    AdaptiveMotionPredictor::Ptr motion_predictor_ = nullptr;
+    MotionPredictor::Ptr motion_predictor_ = nullptr;
 
     imu::IMUPreintegration::Ptr imu_preintegration_ = nullptr;
     imu::IMUVelocityCorrector imu_velocity_corrector_;
@@ -337,6 +344,7 @@ private:
     Eigen::Matrix3f imu_R_world_at_reset_ = Eigen::Matrix3f::Identity();
     Eigen::Vector3f imu_v_world_at_reset_ = Eigen::Vector3f::Zero();
     std::vector<imu::IMUMeasurement> imu_batch_;  ///< Reusable buffer for per-frame IMU snapshots.
+    bool imu_window_complete_ = false;
 
     std::string error_message_;
 
@@ -435,7 +443,12 @@ private:
 
         // Motion predictor
         {
-            this->motion_predictor_ = std::make_shared<AdaptiveMotionPredictor>(this->params_.motion_prediction);
+            this->motion_predictor_ = std::make_shared<MotionPredictor>(this->params_.motion_prediction);
+            if (!this->params_.imu.enable &&
+                this->params_.motion_prediction.mode == MotionPredictionMode::GYRO_LIDAR_CV) {
+                std::cerr << "[LiDAR Odometry] " << MotionPredictionMode_to_string(this->params_.motion_prediction.mode)
+                          << " requires IMU; falling back to LIDAR_CV." << std::endl;
+            }
         }
 
         // Held IMU bias (mutated by initial alignment; default = configured bias)
@@ -445,15 +458,15 @@ private:
         // R_world_imu is the IMU's rotation in the odom (world) frame at startup.
         // The first-frame block will overwrite this with the post-alignment value
         // (gravity-corrected) before any IMU integration runs.
-        if (this->params_.imu.enable) {
+        if (this->params_.imu.enable && this->params_.motion_prediction.mode != MotionPredictionMode::LIDAR_CV) {
             this->imu_preintegration_ = std::make_shared<imu::IMUPreintegration>(this->params_.imu.preintegration);
             const Eigen::Matrix3f R_world_imu =
                 this->params_.pose.initial.rotation() * this->params_.imu.T_imu_to_lidar.rotation();
             this->imu_preintegration_->reset(this->imu_bias_, Eigen::Matrix<float, 15, 15>::Zero(), R_world_imu);
             this->imu_R_world_at_reset_ = R_world_imu;
             this->imu_v_world_at_reset_ = Eigen::Vector3f::Zero();
-
-            // Initial gravity-aligned alignment estimator
+        }
+        if (this->params_.imu.enable) {
             this->alignment_estimator_ = std::make_shared<imu::InitialAlignmentEstimator>(
                 this->params_.imu.initial_alignment, this->params_.imu.preintegration.gravity,
                 this->params_.imu.T_imu_to_lidar);
@@ -529,21 +542,28 @@ private:
     }
 
     algorithms::registration::RegistrationResult registration() {
-        Eigen::Isometry3f init_T;
         Eigen::Vector3f v_reset = Eigen::Vector3f::Zero();
-        if (this->imu_preintegration_) {
-            if (this->imu_preintegration_->get_dt_total() > 0.0) {
-                init_T = this->imu_motion_prediction();
-            } else {
-                init_T = this->motion_predictor_->predict(this->linear_velocity_, this->angular_velocity_, this->odom_,
-                                                          this->dt_, this->reg_result_, this->registrated_);
+        const bool has_imu_prediction =
+            this->imu_preintegration_ && this->imu_window_complete_ && this->imu_preintegration_->get_dt_total() > 0.0;
+
+        MotionPredictionCandidates candidates;
+        if (has_imu_prediction) {
+            const Eigen::Matrix3f delta_R_imu = this->imu_preintegration_->get_corrected(this->imu_bias_).Delta_R;
+            const Eigen::Matrix3f& R_i2l = this->params_.imu.T_imu_to_lidar.rotation();
+            candidates.gyro_delta_rotation_lidar = R_i2l * delta_R_imu * R_i2l.transpose();
+            if (this->params_.motion_prediction.mode == MotionPredictionMode::IMU_SE3) {
+                candidates.imu_se3_pose = this->imu_motion_prediction();
             }
-            // linear_velocity_ is in the prev_odom_ body frame, so use prev_odom_.rotation() to convert to world frame.
+        }
+
+        const Eigen::Isometry3f init_T =
+            this->motion_predictor_->predict(this->linear_velocity_, this->angular_velocity_, this->odom_, this->dt_,
+                                             this->reg_result_, this->registrated_, candidates);
+
+        if (this->imu_preintegration_ && this->params_.motion_prediction.mode == MotionPredictionMode::IMU_SE3) {
+            // linear_velocity_ is in the previous LiDAR body frame.
             v_reset = this->imu_velocity_corrector_.get_reset_velocity(
                 *this->imu_preintegration_, this->imu_bias_, this->prev_odom_.rotation() * this->linear_velocity_);
-        } else {
-            init_T = this->motion_predictor_->predict(this->linear_velocity_, this->angular_velocity_, this->odom_,
-                                                      this->dt_, this->reg_result_, this->registrated_);
         }
 
         // Provide the previous registration result as a MAP prior so the optimizer

--- a/cpp/include/sycl_points/pipeline/lidar_odometry_params.hpp
+++ b/cpp/include/sycl_points/pipeline/lidar_odometry_params.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "sycl_points/algorithms/registration/registration_pipeline_params.hpp"
-#include "sycl_points/pipeline/adaptive_motion_predictor.hpp"
+#include "sycl_points/pipeline/motion_predictor.hpp"
 #include "sycl_points/pipeline/odometry_common_params.hpp"
 
 namespace sycl_points {
@@ -10,7 +10,7 @@ namespace lidar_odometry {
 
 /// @brief Parameters specific to the LiDAR-only odometry pipeline.
 struct Parameters : public odometry::CommonParameters {
-    using MotionPrediction = AdaptiveMotionPredictor::Params;
+    using MotionPrediction = MotionPredictor::Params;
 
     struct LO {
         struct Registration {

--- a/cpp/include/sycl_points/pipeline/motion_predictor.hpp
+++ b/cpp/include/sycl_points/pipeline/motion_predictor.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <Eigen/Geometry>
+#include <algorithm>
+#include <cctype>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include "sycl_points/pipeline/adaptive_motion_predictor.hpp"
+
+namespace sycl_points {
+namespace pipeline {
+namespace lidar_odometry {
+
+enum class MotionPredictionMode {
+    LIDAR_CV = 0,
+    GYRO_LIDAR_CV,
+    IMU_SE3,
+};
+
+inline MotionPredictionMode MotionPredictionMode_from_string(const std::string& str) {
+    std::string upper = str;
+    std::transform(upper.begin(), upper.end(), upper.begin(), [](unsigned char c) { return std::toupper(c); });
+    if (upper == "LIDAR_CV") return MotionPredictionMode::LIDAR_CV;
+    if (upper == "GYRO_LIDAR_CV") return MotionPredictionMode::GYRO_LIDAR_CV;
+    if (upper == "IMU_SE3") return MotionPredictionMode::IMU_SE3;
+    throw std::runtime_error("[MotionPredictionMode_from_string] Invalid motion prediction mode '" + str + "'");
+}
+
+inline std::string MotionPredictionMode_to_string(const MotionPredictionMode mode) {
+    switch (mode) {
+        case MotionPredictionMode::LIDAR_CV:
+            return "LIDAR_CV";
+        case MotionPredictionMode::GYRO_LIDAR_CV:
+            return "GYRO_LIDAR_CV";
+        case MotionPredictionMode::IMU_SE3:
+            return "IMU_SE3";
+    }
+    throw std::runtime_error("[MotionPredictionMode_to_string] Invalid motion prediction mode");
+}
+
+struct MotionPredictionCandidates {
+    std::optional<Eigen::Matrix3f> gyro_delta_rotation_lidar;
+    std::optional<Eigen::Isometry3f> imu_se3_pose;
+};
+
+/// Selects and combines available initial-pose prediction sources.
+class MotionPredictor {
+public:
+    using Ptr = std::shared_ptr<MotionPredictor>;
+
+    struct Params : AdaptiveMotionPredictor::Params {
+        MotionPredictionMode mode = MotionPredictionMode::GYRO_LIDAR_CV;
+    };
+
+    explicit MotionPredictor(const Params& params) : params_(params), lidar_cv_predictor_(params) {}
+
+    Eigen::Isometry3f predict(const Eigen::Vector3f& linear_velocity, const Eigen::AngleAxisf& angular_velocity,
+                              const Eigen::Isometry3f& odom, float dt,
+                              const algorithms::registration::RegistrationResult::Ptr& reg_result, bool registrated,
+                              const MotionPredictionCandidates& candidates = {}) {
+        if (params_.mode == MotionPredictionMode::IMU_SE3 && candidates.imu_se3_pose) {
+            return *candidates.imu_se3_pose;
+        }
+
+        Eigen::Isometry3f prediction =
+            lidar_cv_predictor_.predict(linear_velocity, angular_velocity, odom, dt, reg_result, registrated);
+        if (params_.mode == MotionPredictionMode::GYRO_LIDAR_CV && candidates.gyro_delta_rotation_lidar) {
+            Eigen::Isometry3f relative = odom.inverse() * prediction;
+            relative.linear() = *candidates.gyro_delta_rotation_lidar;
+            prediction = odom * relative;
+        }
+        return prediction;
+    }
+
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+private:
+    Params params_;
+    AdaptiveMotionPredictor lidar_cv_predictor_;
+};
+
+}  // namespace lidar_odometry
+}  // namespace pipeline
+}  // namespace sycl_points

--- a/cpp/tests/test_lidar_odometry_imu.cpp
+++ b/cpp/tests/test_lidar_odometry_imu.cpp
@@ -90,10 +90,40 @@ static sp::PointCloudShared::Ptr make_flat_cloud(const sp::sycl_utils::DeviceQue
 TEST(LidarOdometryIMU, IMUParamDefaults) {
     lo::Parameters p;
     EXPECT_FALSE(p.imu.enable);
+    EXPECT_EQ(p.motion_prediction.mode, lo::MotionPredictionMode::GYRO_LIDAR_CV);
     EXPECT_TRUE(p.imu.T_imu_to_lidar.isApprox(Eigen::Isometry3f::Identity()));
     EXPECT_NEAR(p.imu.preintegration.gravity.norm(), 9.80665f, 1e-3f);
     EXPECT_TRUE(p.imu.bias.gyro_bias.isZero());
     EXPECT_TRUE(p.imu.bias.accel_bias.isZero());
+}
+
+TEST(LidarOdometryIMU, MotionPredictionModeConversion) {
+    EXPECT_EQ(lo::MotionPredictionMode_from_string("lidar_cv"), lo::MotionPredictionMode::LIDAR_CV);
+    EXPECT_EQ(lo::MotionPredictionMode_from_string("GYRO_LIDAR_CV"), lo::MotionPredictionMode::GYRO_LIDAR_CV);
+    EXPECT_EQ(lo::MotionPredictionMode_from_string("imu_se3"), lo::MotionPredictionMode::IMU_SE3);
+    EXPECT_EQ(lo::MotionPredictionMode_to_string(lo::MotionPredictionMode::GYRO_LIDAR_CV), "GYRO_LIDAR_CV");
+    EXPECT_THROW(lo::MotionPredictionMode_from_string("invalid"), std::runtime_error);
+}
+
+TEST(LidarOdometryIMU, GyroLidarCVFusionKeepsCVTranslation) {
+    lo::MotionPredictor::Params params;
+    params.mode = lo::MotionPredictionMode::GYRO_LIDAR_CV;
+    lo::MotionPredictor predictor(params);
+
+    Eigen::Isometry3f odom = Eigen::Isometry3f::Identity();
+    odom.translation() = Eigen::Vector3f(2.0f, -1.0f, 0.5f);
+
+    const Eigen::Matrix3f delta_R_imu = Eigen::AngleAxisf(0.4f, Eigen::Vector3f::UnitZ()).toRotationMatrix();
+    lo::MotionPredictionCandidates candidates;
+    candidates.gyro_delta_rotation_lidar = delta_R_imu;
+
+    const auto reg_result = std::make_shared<sp::algorithms::registration::RegistrationResult>();
+    const Eigen::Isometry3f fused =
+        predictor.predict(Eigen::Vector3f(1.0f, 2.0f, 3.0f), Eigen::AngleAxisf(0.2f, Eigen::Vector3f::UnitX()), odom,
+                          1.0f, reg_result, false, candidates);
+
+    EXPECT_TRUE(fused.translation().isApprox(odom.translation() + Eigen::Vector3f(1.0f, 2.0f, 3.0f), kEps));
+    EXPECT_TRUE(fused.rotation().isApprox(delta_R_imu, kEps));
 }
 
 // 2. add_imu_measurement() is a no-op when IMU is disabled (guard on null ptr).
@@ -235,6 +265,7 @@ TEST(LidarOdometryIMU, SecondFrameWithIMUEnabled) {
 TEST(LidarOdometryIMU, SecondFrameWithIMUDisabledFallsBack) {
     auto params = make_test_params();
     params.imu.enable = false;
+    params.motion_prediction.mode = lo::MotionPredictionMode::GYRO_LIDAR_CV;
 
     lo::LiDAROdometryPipeline pipeline(params);
 
@@ -248,6 +279,24 @@ TEST(LidarOdometryIMU, SecondFrameWithIMUDisabledFallsBack) {
     {
         const auto r = pipeline.process(scan, 0.2);
         EXPECT_EQ(r, lo::LiDAROdometryPipeline::ResultType::success);
+    }
+}
+
+TEST(LidarOdometryIMU, IMUAvailableWithLidarAndGyroCVModes) {
+    for (const auto mode : {lo::MotionPredictionMode::LIDAR_CV, lo::MotionPredictionMode::GYRO_LIDAR_CV}) {
+        auto params = make_test_params();
+        params.imu.enable = true;
+        params.motion_prediction.mode = mode;
+
+        lo::LiDAROdometryPipeline pipeline(params);
+        const auto scan = make_flat_cloud(*pipeline.get_device_queue(), 20);
+
+        for (const auto& m : make_static_imu(0.0, 0.1, 10)) pipeline.add_imu_measurement(m);
+        EXPECT_EQ(pipeline.process(scan, 0.1), lo::LiDAROdometryPipeline::ResultType::first_frame);
+
+        for (const auto& m : make_static_imu(0.1, 0.1, 10)) pipeline.add_imu_measurement(m);
+        EXPECT_EQ(pipeline.process(scan, 0.2), lo::LiDAROdometryPipeline::ResultType::success)
+            << "mode=" << lo::MotionPredictionMode_to_string(mode);
     }
 }
 

--- a/ros2/sycl_points_ros2/config/lidar_odometry.yaml
+++ b/ros2/sycl_points_ros2/config/lidar_odometry.yaml
@@ -49,11 +49,11 @@ lidar_odometry_node:
     T_imu_to_lidar/qw: 1.0
 
     # IMU
-    imu/enable: false                   # If true, unuse motion_prediction.
+    imu/enable: false                   # Enable IMU buffering and configured IMU consumers.
     imu/accel_unit: "m_s2"              # IMU acceleration unit: "m_s2" (m/s^2) or "G" (1G = 9.80665 m/s^2). Use "G" for Livox built-in IMU.
     imu/buffer_duration_sec: 1.0        # IMU buffering duration
     imu/deskew/enable: true             # IMU-based pre-processing deskew (applied before downsampling and ICP)
-    imu/deskew/gyro_only: false         # If true, use rotation only and omit accelerometer/velocity translation
+    imu/deskew/gyro_only: true           # If true, use rotation only and omit accelerometer/velocity translation
     imu/preintegration/gravity/x: 0.0   # Gravity vector in world frame [m/s^2]
     imu/preintegration/gravity/y: 0.0
     imu/preintegration/gravity/z: -9.80665
@@ -68,7 +68,7 @@ lidar_odometry_node:
     # Assumes the robot is stationary for at least required_duration_sec at startup.
     # Yaw is preserved from initial_base_link_pose; gravity does not constrain it.
     # The first few scans before alignment converges are dropped (waiting_initial_alignment).
-    imu/initial_alignment/enable: true
+    imu/initial_alignment/enable: false
     imu/initial_alignment/required_duration_sec: 0.5  # IMU window length [s]; must be <= imu/buffer_duration_sec
     imu/initial_alignment/max_gyro_std: 0.05          # [rad/s] per-axis stationarity threshold
     imu/initial_alignment/max_accel_std: 0.2          # [m/s^2] per-axis stationarity threshold
@@ -156,7 +156,10 @@ lidar_odometry_node:
     submap/occupancy_grid_map/enable_pruning: true
     submap/occupancy_grid_map/stale_frame_threshold: 600
 
-    # Motion Predict without IMU
+    # Motion prediction
+    # LIDAR_CV: LiDAR constant velocity; GYRO_LIDAR_CV: Gyro rotation + LiDAR translation.
+    # IMU_SE3: full IMU prediction.
+    motion_prediction/mode: "GYRO_LIDAR_CV"
     motion_prediction/verbose: false
     motion_prediction/velocity/ema_alpha: 1.0
     motion_prediction/adaptive/rotation/factor/min: 0.2

--- a/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
+++ b/ros2/sycl_points_ros2/include/sycl_points_ros2/declare_lidar_odometry_params.hpp
@@ -30,6 +30,11 @@ inline pipeline::lidar_odometry::Parameters declare_lidar_odometry_parameters(rc
 
     // Motion prediction without tightly-coupled LIO.
     {
+        const std::string prediction_mode = node->declare_parameter<std::string>(
+            "motion_prediction/mode",
+            pipeline::lidar_odometry::MotionPredictionMode_to_string(params.motion_prediction.mode));
+        params.motion_prediction.mode =
+            pipeline::lidar_odometry::MotionPredictionMode_from_string(prediction_mode);
         params.motion_prediction.verbose =
             node->declare_parameter<bool>("motion_prediction/verbose", params.motion_prediction.verbose);
         params.motion_prediction.velocity_ema_alpha = node->declare_parameter<double>(


### PR DESCRIPTION
## Summary

- add `LIDAR_CV`, `GYRO_LIDAR_CV`, and `IMU_SE3` motion prediction modes
- introduce a `MotionPredictor` facade that selects and combines LiDAR CV, gyro rotation, and full IMU pose candidates
- decouple IMU buffering/deskew from the registration initial-pose prediction source
- fall back to LiDAR CV when IMU is disabled or the IMU window does not fully cover the LiDAR interval
- expose `motion_prediction/mode` as a ROS 2 parameter and add mode/fallback tests

## Motivation

Enabling IMU previously caused LO to use full IMU SE(3) prediction whenever preintegration was available. This prevented configurations that use IMU only for deskew, or use gyro rotation while retaining LiDAR-derived constant-velocity translation.

## Behavior

- `LIDAR_CV`: LiDAR-derived constant-velocity rotation and translation
- `GYRO_LIDAR_CV`: gyro-integrated rotation with LiDAR CV translation
- `IMU_SE3`: full IMU preintegration
- unavailable or incomplete IMU data falls back to `LIDAR_CV`
- `imu/enable` remains the master switch for all IMU consumers

## Validation

- AdaptiveCpp: `test_lidar_odometry_imu` — 12/12 passed
- Intel DPC++: target compiled successfully
- ROS 2: `sycl_points` and `sycl_points_ros2` built successfully