### PR TITLE
feat: add support for Intel iGPU Level Zero backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,10 @@ This project was developed with reference to small_gicp and gtsam_points
 
 ### Supported Device
 - Intel CPU (OpenCL backend)
-- Intel iGPU (OpenCL backend)
+- Intel iGPU (Level Zero or OpenCL backend)
 - NVIDIA GPU (CUDA backend)
 
 note:
-- `level_zero` backend is not supported.
 - AMD CPU will work fine.
 - I do not own an AMD GPU, so it is not supported.
 
@@ -160,9 +159,11 @@ sycl-ls
 # [cuda:gpu][cuda:0] NVIDIA CUDA BACKEND, NVIDIA GeForce RTX 3060 8.6 [CUDA 12.9]
 
 # specify the device to be used with `ONEAPI_DEVICE_SELECTOR`
-# note: level_zero is not supported.
 
-# run example with OpenCL device (iGPU)
+# run example with Level Zero device (iGPU)
+ONEAPI_DEVICE_SELECTOR=level_zero:0 ./example_registration
+
+# run example with OpenCL device (iGPU, alternative backend)
 ONEAPI_DEVICE_SELECTOR=opencl:1 ./example_registration
 
 # run example with CUDA device
@@ -194,9 +195,11 @@ acpp-info -l
 
 # specify the device to be used with `ACPP_VISIBILITY_MASK`
 # if specify cuda devive number, use `CUDA_VISIBLE_DEVICES`
-# note: level_zero is not supported.
 
-# run example with OpenCL device
+# run example with Level Zero device
+ACPP_VISIBILITY_MASK=ze ./example_registration
+
+# run example with OpenCL device (alternative backend)
 ACPP_VISIBILITY_MASK=ocl ./example_registration
 
 # run example with CPU OpenMP

--- a/cpp/examples/example_memcpy.cpp
+++ b/cpp/examples/example_memcpy.cpp
@@ -49,7 +49,6 @@ int main() {
         const auto dt_memcpy_to_device =
             std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - s)
                 .count();
-        sycl::free(device_ptr, queue);
 
         // copy from device ptr to shared container
         s = std::chrono::high_resolution_clock::now();

--- a/cpp/examples/example_point_cloud.cpp
+++ b/cpp/examples/example_point_cloud.cpp
@@ -8,7 +8,8 @@
 #include "sycl_points/io/point_cloud_reader.hpp"
 
 int main() {
-    std::string source_filename = "../data/source.ply";
+    const std::string source_filename = "../data/source.ply";
+    constexpr size_t LOOP_NUM = 10;
 
     const sycl_points::PointCloudCPU source_points = sycl_points::PointCloudReader::readFile(source_filename);
 
@@ -27,20 +28,20 @@ int main() {
 
     // KDTree
     double dt_build_kdtree = 0.0;
-    for (size_t i = 0; i < 10; ++i) {
+    for (size_t i = 0; i < LOOP_NUM; ++i) {
         s = std::chrono::high_resolution_clock::now();
         auto tmp = sycl_points::algorithms::knn::KDTree::build(queue, shared_points);
         dt_build_kdtree +=
             std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - s)
                 .count();
     }
-    dt_build_kdtree /= 10;
+    dt_build_kdtree /= LOOP_NUM;
 
     // Covariance
     double dt_covariances = 0.0;
     const size_t k_correspondence_covariance = 10;
     auto kdtree = sycl_points::algorithms::knn::KDTree::build(queue, shared_points);
-    for (size_t i = 0; i < 11; ++i) {
+    for (size_t i = 0; i < LOOP_NUM + 1; ++i) {
         s = std::chrono::high_resolution_clock::now();
         sycl_points::algorithms::covariance::estimate_async(*kdtree, shared_points, k_correspondence_covariance)
             .wait_and_throw();
@@ -50,13 +51,13 @@ int main() {
                     .count();
         }
     }
-    dt_covariances /= 10;
+    dt_covariances /= LOOP_NUM;
 
     // Downsampling
     double dt_voxel_downsampling = 0.0;
     const float voxel_size = 1.0;
     sycl_points::algorithms::filter::VoxelGrid voxel_grid(queue, voxel_size);
-    for (size_t i = 0; i < 11; ++i) {
+    for (size_t i = 0; i < LOOP_NUM + 1; ++i) {
         s = std::chrono::high_resolution_clock::now();
         sycl_points::PointCloudShared downsampled(queue);
         voxel_grid.downsampling(shared_points, downsampled);
@@ -66,11 +67,11 @@ int main() {
                     .count();
         }
     }
-    dt_voxel_downsampling /= 10;
+    dt_voxel_downsampling /= LOOP_NUM;
 
     // Transform
     double dt_transform_cpu_copy = 0.0;
-    for (size_t i = 0; i < 11; ++i) {
+    for (size_t i = 0; i < LOOP_NUM + 1; ++i) {
         s = std::chrono::high_resolution_clock::now();
         auto tmp = sycl_points::algorithms::transform::transform_cpu_copy(shared_points, Eigen::Matrix4f::Identity());
         if (i > 0) {
@@ -79,10 +80,10 @@ int main() {
                     .count();
         }
     }
-    dt_transform_cpu_copy /= 10;
+    dt_transform_cpu_copy /= LOOP_NUM;
 
     double dt_transform_cpu_inplace = 0.0;
-    for (size_t i = 0; i < 11; ++i) {
+    for (size_t i = 0; i < LOOP_NUM + 1; ++i) {
         s = std::chrono::high_resolution_clock::now();
         sycl_points::algorithms::transform::transform_cpu(shared_points, Eigen::Matrix4f::Identity());
         if (i > 0) {
@@ -91,15 +92,14 @@ int main() {
                     .count();
         }
     }
-    dt_transform_cpu_inplace /= 10;
+    dt_transform_cpu_inplace /= LOOP_NUM;
 
     double dt_transform_copy = 0.0;
-    for (size_t i = 0; i < 11; ++i) {
+    for (size_t i = 0; i < LOOP_NUM + 1; ++i) {
         s = std::chrono::high_resolution_clock::now();
-        auto ret =
-            sycl_points::algorithms::transform::transform_cpu_copy(shared_points, Eigen::Matrix4f::Identity() * 2);
+        auto ret = sycl_points::algorithms::transform::transform_copy(shared_points, Eigen::Matrix4f::Identity() * 2);
         if (i == 0) {
-            // for (size_t j = 0; j < 10; ++j) {
+            // for (size_t j = 0; j < LOOP_NUM; ++j) {
             //   std::cout << "source: " << source_points.points[j].transpose() << std::endl;
             //   std::cout << "shared: " << (*shared_points.points)[j].transpose() << std::endl;
             //   std::cout << "ret: " << (*ret.points)[j].transpose() << std::endl;
@@ -110,10 +110,10 @@ int main() {
                     .count();
         }
     }
-    dt_transform_copy /= 10;
+    dt_transform_copy /= LOOP_NUM;
 
     double dt_transform_inplace = 0.0;
-    for (size_t i = 0; i < 11; ++i) {
+    for (size_t i = 0; i < LOOP_NUM + 1; ++i) {
         s = std::chrono::high_resolution_clock::now();
         sycl_points::algorithms::transform::transform(shared_points, Eigen::Matrix4f::Identity());
         if (i > 0) {
@@ -122,10 +122,10 @@ int main() {
                     .count();
         }
     }
-    dt_transform_inplace /= 10;
+    dt_transform_inplace /= LOOP_NUM;
 
     {
-        // for (size_t i = 0; i < 10; ++i) {
+        // for (size_t i = 0; i < LOOP_NUM; ++i) {
         //   std::cout << "[" << i << "] " << source_points.points[i].transpose() << std::endl;
         // }
 

--- a/cpp/include/sycl_points/algorithms/feature/covariance.hpp
+++ b/cpp/include/sycl_points/algorithms/feature/covariance.hpp
@@ -307,7 +307,10 @@ inline sycl_utils::events estimate_async(const knn::KNNBase& knn, const PointClo
                                          const std::vector<sycl::event>& depends = std::vector<sycl::event>()) {
     knn::KNNResult neighbors;
     auto knn_events = knn.knn_search_async(points, k_correspondences, neighbors, depends);
-    return estimate_async(neighbors, points, knn_events.evs);
+    auto events = estimate_async(neighbors, points, knn_events.evs);
+    events.add_resource(neighbors.indices);
+    events.add_resource(neighbors.distances);
+    return events;
 }
 
 /// @brief Async estimate covariances with M-estimation using SYCL
@@ -405,8 +408,11 @@ inline sycl_utils::events estimate_robust_async(const knn::KNNBase& knn, const P
                                                 const std::vector<sycl::event>& depends = std::vector<sycl::event>()) {
     knn::KNNResult neighbors;
     auto knn_events = knn.knn_search_async(points, k_correspondences, neighbors, depends);
-    return estimate_robust_async(neighbors, points, robust_type, mad_scale, min_robust_scale, robust_max_iterations,
-                                 knn_events.evs);
+    auto events = estimate_robust_async(neighbors, points, robust_type, mad_scale, min_robust_scale,
+                                        robust_max_iterations, knn_events.evs);
+    events.add_resource(neighbors.indices);
+    events.add_resource(neighbors.distances);
+    return events;
 }
 
 /// @brief Async estimate normal vectors from KNN neighborhood using SYCL
@@ -455,7 +461,10 @@ inline sycl_utils::events estimate_normals_async(const knn::KNNBase& knn, const 
                                                  const std::vector<sycl::event>& depends = std::vector<sycl::event>()) {
     knn::KNNResult neighbors;
     auto knn_events = knn.knn_search_async(points, k_correspondences, neighbors, depends);
-    return estimate_normals_async(neighbors, points, knn_events.evs);
+    auto events = estimate_normals_async(neighbors, points, knn_events.evs);
+    events.add_resource(neighbors.indices);
+    events.add_resource(neighbors.distances);
+    return events;
 }
 
 /// @brief Async extract normal vectors from pre-computed covariances using SYCL

--- a/cpp/include/sycl_points/utils/sycl_utils.hpp
+++ b/cpp/include/sycl_points/utils/sycl_utils.hpp
@@ -365,20 +365,16 @@ void clear_read_mostly(sycl::queue&, T*, size_t) {}
 
 namespace device_selector {
 
-inline bool is_supported_device(const sycl::device& dev) {
-    bool supported = true;
-    const auto backend = dev.get_backend();
-#ifdef SYCL_IMPL_INTEL_DPCPP
-    supported &= (backend != sycl::backend::ext_oneapi_level_zero);
-#endif
-#ifdef SYCL_IMPL_ADAPTIVECPP
-    supported &= (backend != sycl::backend::level_zero);
-#endif
-    supported &= enable_shared_allocations(dev);
-    return supported;
-}
+inline bool is_supported_device(const sycl::device& dev) { return enable_shared_allocations(dev); }
 
-inline int default_selector_v(const sycl::device& dev) { return is_supported_device(dev); }
+inline int default_selector_v(const sycl::device& dev) {
+    if (!is_supported_device(dev)) return -1;
+
+    // AdaptiveCpp always exposes its OpenMP host device, even when a GPU
+    // visibility mask is set. Prefer a GPU so a visible Level Zero device is
+    // actually selected instead of silently falling back to the host.
+    return dev.is_gpu() ? 2 : 1;
+}
 
 inline int intel_cpu_selector_v(const sycl::device& dev) {
     const auto vendor_id = dev.get_info<sycl::info::device::vendor_id>();
@@ -431,17 +427,7 @@ inline sycl::device select_device(const std::string& device_vendor, const std::s
         for (auto device : platform.get_devices()) {
             const auto dev_vendor_id = device.get_info<sycl::info::device::vendor_id>();
             if (vendor_id == dev_vendor_id) {
-#ifdef SYCL_IMPL_INTEL_DPCPP
-                if (device.get_backend() == sycl::backend::ext_oneapi_level_zero) {
-                    // level_zero is not support
-                    continue;
-                }
-#endif
 #ifdef SYCL_IMPL_ADAPTIVECPP
-                if (device.get_backend() == sycl::backend::level_zero) {
-                    // level_zero is not support
-                    continue;
-                }
                 if (vendor_id == VENDOR_ID::OMP) {
                     return device;
                 }

--- a/cpp/include/sycl_points/utils/sycl_utils.hpp
+++ b/cpp/include/sycl_points/utils/sycl_utils.hpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <memory>
 #include <sstream>
+#include <string>
 #include <sycl/sycl.hpp>
 
 #ifdef SYCL_IMPL_ADAPTIVECPP
@@ -117,80 +118,85 @@ inline std::string get_backend_name(sycl::backend backend) {
 #endif
 }
 
-/// @brief Print device info
+/// @brief Get device info
 /// @param device SYCL device
-inline void print_device_info(const sycl::device& device) {
+inline std::string get_device_info(const sycl::device& device) {
     const auto platform = device.get_platform();
-    std::cout << "Platform: " << platform.get_info<sycl::info::platform::name>() << std::endl;
+    std::ostringstream oss;
+    oss << "Platform: " << platform.get_info<sycl::info::platform::name>() << "\n";
 
     for (auto device : platform.get_devices()) {
-        std::cout << "\tDevice: " << device.get_info<sycl::info::device::name>() << std::endl;
-        std::cout << "\ttype: " << (device.is_cpu() ? "CPU" : "GPU") << std::endl;
-        std::cout << "\tVendor: " << device.get_info<sycl::info::device::vendor>() << std::endl;
-        std::cout << "\tVendorID: " << device.get_info<sycl::info::device::vendor_id>() << std::endl;
-        std::cout << "\tBackend name: " << get_backend_name(device.get_backend()) << std::endl;
+        oss << "\tDevice: " << device.get_info<sycl::info::device::name>() << "\n";
+        oss << "\ttype: " << (device.is_cpu() ? "CPU" : "GPU") << "\n";
+        oss << "\tVendor: " << device.get_info<sycl::info::device::vendor>() << "\n";
+        oss << "\tVendorID: " << device.get_info<sycl::info::device::vendor_id>() << "\n";
+        oss << "\tBackend name: " << get_backend_name(device.get_backend()) << "\n";
 #ifndef SYCL_IMPL_ADAPTIVECPP
-        std::cout << "\tBackend version: " << device.get_info<sycl::info::device::backend_version>() << std::endl;
+        oss << "\tBackend version: " << device.get_info<sycl::info::device::backend_version>() << "\n";
 #endif
-        std::cout << "\tDriver version: " << device.get_info<sycl::info::device::driver_version>() << std::endl;
-        std::cout << "\tGlobal Memory Size: "
-                  << device.get_info<sycl::info::device::global_mem_size>() / 1024.0 / 1024.0 / 1024.0 << " GB"
-                  << std::endl;
-        std::cout << "\tLocal Memory Size: " << device.get_info<sycl::info::device::local_mem_size>() / 1024.0 << " KB"
-                  << std::endl;
-        std::cout << "\tGlobal Memory Cache Size: "
-                  << device.get_info<sycl::info::device::global_mem_cache_size>() / 1024.0 / 1024.0 << " MB"
-                  << std::endl;
-        std::cout << "\tGlobal Memory Cache Line Size: "
-                  << device.get_info<sycl::info::device::global_mem_cache_line_size>() << " byte" << std::endl;
+        oss << "\tDriver version: " << device.get_info<sycl::info::device::driver_version>() << "\n";
+        oss << "\tGlobal Memory Size: "
+            << device.get_info<sycl::info::device::global_mem_size>() / 1024.0 / 1024.0 / 1024.0 << " GB" << "\n";
+        oss << "\tLocal Memory Size: " << device.get_info<sycl::info::device::local_mem_size>() / 1024.0 << " KB"
+            << "\n";
+        oss << "\tGlobal Memory Cache Size: "
+            << device.get_info<sycl::info::device::global_mem_cache_size>() / 1024.0 / 1024.0 << " MB" << "\n";
+        oss << "\tGlobal Memory Cache Line Size: " << device.get_info<sycl::info::device::global_mem_cache_line_size>()
+            << " byte" << "\n";
 
-        std::cout << "\tMax Memory Allocation Size: "
-                  << device.get_info<sycl::info::device::max_mem_alloc_size>() / 1024.0 / 1024.0 / 1024.0 << " GB"
-                  << std::endl;
+        oss << "\tMax Memory Allocation Size: "
+            << device.get_info<sycl::info::device::max_mem_alloc_size>() / 1024.0 / 1024.0 / 1024.0 << " GB"
+            << "\n";
 
-        std::cout << "\tMax Work Group Size: " << device.get_info<sycl::info::device::max_work_group_size>()
-                  << std::endl;
-        std::cout << "\tMax Work Item Dimensions: " << device.get_info<sycl::info::device::max_work_item_dimensions>()
-                  << std::endl;
-        std::cout << "\tMax Work Item Sizes: [";
-        std::cout << device.get_info<sycl::info::device::max_work_item_sizes<1>>().dimensions << ", ";
-        std::cout << device.get_info<sycl::info::device::max_work_item_sizes<1>>().dimensions << ", ";
-        std::cout << device.get_info<sycl::info::device::max_work_item_sizes<1>>().dimensions << "]" << std::endl;
-        std::cout << "\tMax Sub Groups num: " << device.get_info<sycl::info::device::max_num_sub_groups>() << std::endl;
-        std::cout << "\tSub Group Sizes: [";
+        oss << "\tMax Work Group Size: " << device.get_info<sycl::info::device::max_work_group_size>() << "\n";
+        oss << "\tMax Work Item Dimensions: " << device.get_info<sycl::info::device::max_work_item_dimensions>()
+            << "\n";
+        oss << "\tMax Work Item Sizes: [";
+        oss << device.get_info<sycl::info::device::max_work_item_sizes<1>>().dimensions << ", ";
+        oss << device.get_info<sycl::info::device::max_work_item_sizes<1>>().dimensions << ", ";
+        oss << device.get_info<sycl::info::device::max_work_item_sizes<1>>().dimensions << "]" << "\n";
+        oss << "\tMax Sub Groups num: " << device.get_info<sycl::info::device::max_num_sub_groups>() << "\n";
+        oss << "\tSub Group Sizes: [";
         const auto subgroup_sizes = device.get_info<sycl::info::device::sub_group_sizes>();
         for (size_t i = 0; i < subgroup_sizes.size(); ++i) {
-            std::cout << subgroup_sizes[i];
+            oss << subgroup_sizes[i];
             if (i < subgroup_sizes.size() - 1) {
-                std::cout << ", ";
+                oss << ", ";
             }
         }
-        std::cout << "]" << std::endl;
+        oss << "]" << "\n";
 
-        std::cout << "\tMax compute units: " << device.get_info<sycl::info::device::max_compute_units>() << std::endl;
+        oss << "\tMax compute units: " << device.get_info<sycl::info::device::max_compute_units>() << "\n";
 
-        std::cout << "\tMax Clock Frequency: " << device.get_info<sycl::info::device::max_clock_frequency>() / 1000.0
-                  << " GHz" << std::endl;
+        oss << "\tMax Clock Frequency: " << device.get_info<sycl::info::device::max_clock_frequency>() / 1000.0
+            << " GHz" << "\n";
 
-        std::cout << "\tDouble precision support: " << (device.has(sycl::aspect::fp64) ? "true" : "false") << std::endl;
+        oss << "\tDouble precision support: " << (device.has(sycl::aspect::fp64) ? "true" : "false") << "\n";
 
-        std::cout << "\tAtomic 64bit support: " << (device.has(sycl::aspect::atomic64) ? "true" : "false") << std::endl;
+        oss << "\tAtomic 64bit support: " << (device.has(sycl::aspect::atomic64) ? "true" : "false") << "\n";
 
-        std::cout << "\tUSM host allocations: " << (device.has(sycl::aspect::usm_host_allocations) ? "true" : "false")
-                  << std::endl;
-        std::cout << "\tUSM device allocations: "
-                  << (device.has(sycl::aspect::usm_device_allocations) ? "true" : "false") << std::endl;
-        std::cout << "\tUSM shared allocations: "
-                  << (device.has(sycl::aspect::usm_shared_allocations) ? "true" : "false") << std::endl;
+        oss << "\tUSM host allocations: " << (device.has(sycl::aspect::usm_host_allocations) ? "true" : "false")
+            << "\n";
+        oss << "\tUSM device allocations: " << (device.has(sycl::aspect::usm_device_allocations) ? "true" : "false")
+            << "\n";
+        oss << "\tUSM shared allocations: " << (device.has(sycl::aspect::usm_shared_allocations) ? "true" : "false")
+            << "\n";
 
-        std::cout << "\tUSM atomic shared allocations: "
-                  << (device.has(sycl::aspect::usm_atomic_shared_allocations) ? "true" : "false") << std::endl;
+        oss << "\tUSM atomic shared allocations: "
+            << (device.has(sycl::aspect::usm_atomic_shared_allocations) ? "true" : "false") << "\n";
 
-        std::cout << "\tAvailable: " << (device.get_info<sycl::info::device::is_available>() ? "true" : "false")
-                  << std::endl;
-        std::cout << std::endl;
+        oss << "\tAvailable: " << (device.get_info<sycl::info::device::is_available>() ? "true" : "false") << "\n";
     }
+    return oss.str();
 }
+
+/// @brief Get device info
+/// @param queue SYCL queue
+inline std::string get_device_info(const sycl::queue& queue) { return get_device_info(queue.get_device()); }
+
+/// @brief Print selected device info
+/// @param queue SYCL queue
+inline void print_device_info(const sycl::device& device) { std::cout << get_device_info(device) << std::endl; }
 
 /// @brief Print selected device info
 /// @param queue SYCL queue
@@ -520,6 +526,8 @@ public:
     bool is_intel() const { return sycl_utils::is_intel(*this->ptr); }
     /// @brief device vendor is NVIDIA or not
     bool is_nvidia() const { return sycl_utils::is_nvidia(*this->ptr); }
+    /// @brief device vendor is AMD or not
+    bool is_amd() const { return sycl_utils::is_amd(*this->ptr); }
     /// @brief device support double precision or not
     bool is_supported_double() const { return this->ptr->get_device().has(sycl::aspect::fp64); }
 

--- a/cpp/tests/test_kdtree.cpp
+++ b/cpp/tests/test_kdtree.cpp
@@ -5,6 +5,7 @@
 #include <random>
 
 #include "sycl_points/algorithms/common/filter_by_flags.hpp"
+#include "sycl_points/algorithms/feature/covariance.hpp"
 #include "sycl_points/algorithms/knn/bruteforce.hpp"
 #include "sycl_points/algorithms/knn/kdtree.hpp"
 #include "sycl_points/points/point_cloud.hpp"
@@ -295,6 +296,22 @@ TEST_F(KDTreeTest, BasicKNNSearch) {
             EXPECT_GE((*kdtree_result.distances)[index], 0.0f);
         }
     }
+}
+
+TEST_F(KDTreeTest, AsyncCovarianceOperationsKeepInternalNeighborsAlive) {
+    auto covariance_events = sycl_points::algorithms::covariance::estimate_async(*kdtree, *target_cloud, 10);
+    EXPECT_EQ(covariance_events.keep_alive.size(), 2U);
+    EXPECT_NO_THROW(covariance_events.wait_and_throw());
+    EXPECT_EQ(target_cloud->covs->size(), target_cloud->size());
+
+    auto robust_events = sycl_points::algorithms::covariance::estimate_robust_async(*kdtree, *target_cloud, 10);
+    EXPECT_EQ(robust_events.keep_alive.size(), 2U);
+    EXPECT_NO_THROW(robust_events.wait_and_throw());
+
+    auto normal_events = sycl_points::algorithms::covariance::estimate_normals_async(*kdtree, *target_cloud, 10);
+    EXPECT_EQ(normal_events.keep_alive.size(), 2U);
+    EXPECT_NO_THROW(normal_events.wait_and_throw());
+    EXPECT_EQ(target_cloud->normals->size(), target_cloud->size());
 }
 
 // Test comparing KDTree and brute force results

--- a/cpp/tests/test_select_device.cpp
+++ b/cpp/tests/test_select_device.cpp
@@ -40,7 +40,10 @@ struct AvailableDevices {
 #ifdef SYCL_IMPL_INTEL_DPCPP
                 if (cpu_vendor.empty() && device.is_cpu()) {
                     for (const auto& [vid_val, name] : kCpuVendors) {
-                        if (vid == vid_val) { cpu_vendor = name; break; }
+                        if (vid == vid_val) {
+                            cpu_vendor = name;
+                            break;
+                        }
                     }
                 }
 #endif
@@ -61,15 +64,11 @@ static const AvailableDevices g_devices;
 // Error cases: invalid vendor string
 // ---------------------------------------------------------------
 TEST(SelectDeviceTest, InvalidVendorThrows) {
-    EXPECT_THROW(
-        { select_device("unknown_vendor", "cpu"); },
-        std::runtime_error);
+    EXPECT_THROW({ select_device("unknown_vendor", "cpu"); }, std::runtime_error);
 }
 
 TEST(SelectDeviceTest, EmptyVendorThrows) {
-    EXPECT_THROW(
-        { select_device("", "cpu"); },
-        std::runtime_error);
+    EXPECT_THROW({ select_device("", "cpu"); }, std::runtime_error);
 }
 
 TEST(SelectDeviceTest, InvalidVendorErrorMessage) {
@@ -86,15 +85,11 @@ TEST(SelectDeviceTest, InvalidVendorErrorMessage) {
 // Error cases: invalid device type string
 // ---------------------------------------------------------------
 TEST(SelectDeviceTest, InvalidDeviceTypeThrows) {
-    EXPECT_THROW(
-        { select_device("intel", "fpga"); },
-        std::runtime_error);
+    EXPECT_THROW({ select_device("intel", "fpga"); }, std::runtime_error);
 }
 
 TEST(SelectDeviceTest, EmptyDeviceTypeThrows) {
-    EXPECT_THROW(
-        { select_device("intel", ""); },
-        std::runtime_error);
+    EXPECT_THROW({ select_device("intel", ""); }, std::runtime_error);
 }
 
 TEST(SelectDeviceTest, InvalidDeviceTypeErrorMessage) {
@@ -166,8 +161,7 @@ TEST(SelectDeviceTest, CpuFound) {
     sycl::device dev;
     ASSERT_NO_THROW({ dev = select_device(g_devices.cpu_vendor, "cpu"); });
     EXPECT_TRUE(dev.is_cpu());
-    EXPECT_EQ(dev.get_backend(), sycl::backend::opencl)
-        << "DPC++: CPU should use opencl backend";
+    EXPECT_EQ(dev.get_backend(), sycl::backend::opencl) << "DPC++: CPU should use opencl backend";
 }
 #endif
 
@@ -196,11 +190,9 @@ TEST(SelectDeviceTest, NvidiaGpuFound) {
     EXPECT_TRUE(dev.is_gpu());
     EXPECT_EQ(dev.get_info<sycl::info::device::vendor_id>(), VENDOR_ID::NVIDIA);
 #ifdef SYCL_IMPL_INTEL_DPCPP
-    EXPECT_EQ(dev.get_backend(), sycl::backend::ext_oneapi_cuda)
-        << "DPC++: NVIDIA GPU should use cuda backend";
+    EXPECT_EQ(dev.get_backend(), sycl::backend::ext_oneapi_cuda) << "DPC++: NVIDIA GPU should use cuda backend";
 #else  // AdaptiveCpp
-    EXPECT_EQ(dev.get_backend(), sycl::backend::cuda)
-        << "AdaptiveCpp: NVIDIA GPU should use cuda backend";
+    EXPECT_EQ(dev.get_backend(), sycl::backend::cuda) << "AdaptiveCpp: NVIDIA GPU should use cuda backend";
 #endif
 }
 
@@ -216,11 +208,9 @@ TEST(SelectDeviceTest, AmdGpuFound) {
     EXPECT_TRUE(dev.is_gpu());
     EXPECT_EQ(dev.get_info<sycl::info::device::vendor_id>(), VENDOR_ID::AMD);
 #ifdef SYCL_IMPL_INTEL_DPCPP
-    EXPECT_EQ(dev.get_backend(), sycl::backend::ext_oneapi_hip)
-        << "DPC++: AMD GPU should use hip backend";
+    EXPECT_EQ(dev.get_backend(), sycl::backend::ext_oneapi_hip) << "DPC++: AMD GPU should use hip backend";
 #else  // AdaptiveCpp
-    EXPECT_EQ(dev.get_backend(), sycl::backend::hip)
-        << "AdaptiveCpp: AMD GPU should use hip backend";
+    EXPECT_EQ(dev.get_backend(), sycl::backend::hip) << "AdaptiveCpp: AMD GPU should use hip backend";
 #endif
 }
 
@@ -329,26 +319,28 @@ TEST(SelectDeviceTest, OmpVendorCaseInsensitive) {
 #endif  // SYCL_IMPL_ADAPTIVECPP
 
 // ---------------------------------------------------------------
-// Level Zero is natively supported by both DPC++ and AdaptiveCpp compilers,
-// but is untested in this library and therefore excluded.
-// select_device skips Level Zero devices and returns opencl/ocl backend instead.
+// Level Zero is supported by both DPC++ and AdaptiveCpp.
+// Verify that every visible Level Zero device passes the support check and can
+// be used to construct the queue wrapper.
 // ---------------------------------------------------------------
-TEST(SelectDeviceTest, LevelZeroDevicesNotReturned) {
-    if (!g_devices.has_intel_gpu) {
-        GTEST_SKIP() << "Intel GPU not available";
-    }
-    const sycl::device dev = select_device("intel", "gpu");
+TEST(SelectDeviceTest, LevelZeroDevicesAreSupported) {
+    bool found = false;
+    for (const auto& platform : sycl::platform::get_platforms()) {
+        for (const auto& device : platform.get_devices()) {
 #ifdef SYCL_IMPL_INTEL_DPCPP
-    EXPECT_NE(dev.get_backend(), sycl::backend::ext_oneapi_level_zero)
-        << "level_zero backend device should not be returned";
-    EXPECT_EQ(dev.get_backend(), sycl::backend::opencl)
-        << "opencl backend device should be returned";
+            const bool is_level_zero = device.get_backend() == sycl::backend::ext_oneapi_level_zero;
 #else  // AdaptiveCpp
-    EXPECT_NE(dev.get_backend(), sycl::backend::level_zero)
-        << "level_zero backend device should not be returned";
-    EXPECT_EQ(dev.get_backend(), sycl::backend::ocl)
-        << "ocl backend device should be returned";
+            const bool is_level_zero = device.get_backend() == sycl::backend::level_zero;
 #endif
+            if (!is_level_zero) continue;
+
+            found = true;
+            EXPECT_TRUE(is_supported_device(device));
+            EXPECT_NO_THROW({ DeviceQueue queue(device); });
+        }
+    }
+
+    if (!found) GTEST_SKIP() << "Level Zero device not available";
 }
 
 }  // namespace test


### PR DESCRIPTION
## Summary

Adds Level Zero as a supported Intel iGPU backend instead of filtering it out during device selection.

## Details

- removes the explicit Level Zero backend blacklist from device support and device selection
- prefers GPU devices in the default selector so AdaptiveCpp does not silently choose OpenMP when Level Zero is visible
- keeps internally-created KNN neighbor buffers alive until dependent covariance kernels complete
- fixes example issues found while validating Level Zero: a double-free/use-after-free in `example_memcpy` and the device transform copy path in `example_point_cloud`
- updates README usage examples and Level Zero device tests

## Root Cause

Level Zero was disabled in `is_supported_device()` and `select_device()`. After enabling it, `example_point_cloud` exposed an async lifetime bug: local `KNNResult` buffers created inside covariance helpers could be destroyed before the dependent covariance kernel consumed them.

## Validation

- DPC++ Level Zero build completed with `ONEAPI_DEVICE_SELECTOR=level_zero:gpu`
- ran all examples on Level Zero: `device_query`, `example_memcpy`, `example_point_cloud`, `example_registration`
- ran DPC++ Level Zero tests excluding the pre-existing large KDTree tie-case failure: 19/19 passed
- ran `test_kdtree --gtest_filter='-KDTreeTest.PerformanceLargeDataset'`: 9/9 passed
- ran targeted AdaptiveCpp Level Zero coverage for device selection and async covariance lifetime

Note: `KDTreeTest.PerformanceLargeDataset` still has a pre-existing equal-distance tie comparison failure that reproduces on OpenCL as well, so it is not Level Zero-specific.