### PR TITLE
fix(cmake): remove automatic NVIDIA GPU detection and simplify CMake setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,13 +33,6 @@
 
 build/*
 build_test/*
-cpp/build/*
-cpp/build_test/*
-cpp/build_dpcpp/*
-cpp/build_acpp/*
-cpp/build_cuda/*
-cpp/build_hip/*
-cpp/build_omp/*
 cpp/build*
 .vscode/*
 .claude/*

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@
 
 build/*
 build_test/*
-cpp/build*
+cpp/build*/
 .vscode/*
 .claude/*
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ cpp/build_acpp/*
 cpp/build_cuda/*
 cpp/build_hip/*
 cpp/build_omp/*
+cpp/build*
 .vscode/*
 .claude/*
 CLAUDE.md

--- a/cmake/SYCLSetup.cmake
+++ b/cmake/SYCLSetup.cmake
@@ -28,15 +28,22 @@ if(SYCL_IMPL STREQUAL "IntelDPCPP")
 
   set(SYCL_TARGET_FLAGS "spir64")
 
-  # Check for Intel oneAPI NVIDIA GPU support
+  # Check for Intel oneAPI NVIDIA GPU support robustly without spawning bash
   function(check_oneapi_nvidia_support RESULT_VAR)
+    find_program(SYCL_LS_PATH sycl-ls)
+    if(NOT SYCL_LS_PATH)
+      set(${RESULT_VAR} FALSE PARENT_SCOPE)
+      return()
+    endif()
+
     execute_process(
-      COMMAND bash -c "sycl-ls | grep -q NVIDIA"
-      RESULT_VARIABLE EXIT_CODE
-      OUTPUT_QUIET
+      COMMAND ${SYCL_LS_PATH}
+      OUTPUT_VARIABLE _sycl_devices
       ERROR_QUIET
+      RESULT_VARIABLE _sycl_result
     )
-    if(EXIT_CODE EQUAL 0)
+
+    if(_sycl_result EQUAL 0 AND _sycl_devices MATCHES "NVIDIA")
       set(${RESULT_VAR} TRUE PARENT_SCOPE)
     else()
       set(${RESULT_VAR} FALSE PARENT_SCOPE)

--- a/cmake/SYCLSetup.cmake
+++ b/cmake/SYCLSetup.cmake
@@ -4,7 +4,7 @@
 #   - find_package for the chosen implementation
 #   - SYCL_IMPL_INTEL_DPCPP / SYCL_IMPL_ADAPTIVECPP compile definition
 #   - SYCL_TARGET_FLAGS (IntelDPCPP only)
-#   - ACPP_TARGETS auto-detection (AdaptiveCpp only)
+#   - ACPP_TARGETS default (AdaptiveCpp only)
 #   - apply_sycl_settings(TARGET) macro
 
 if(CMAKE_PROJECT_NAME) # project() 実行後のみ動作するようにガード
@@ -54,39 +54,14 @@ if(SYCL_IMPL STREQUAL "IntelDPCPP")
   message(STATUS "SYCL_IMPL: IntelDPCPP (targets: ${SYCL_TARGET_FLAGS})")
 
 elseif(SYCL_IMPL STREQUAL "AdaptiveCpp")
-  # Auto-detect ACPP_TARGETS from available hardware if not specified by user
+  # Default ACPP_TARGETS to "generic" (SSCP/JIT) if not specified by user.
+  # The generic flow JIT-compiles for the device available at runtime
+  # (CPU, Intel GPU, NVIDIA GPU, ...) and is the flow recommended by AdaptiveCpp.
+  # Explicit AOT targets (e.g. -DACPP_TARGETS="generic;cuda:sm_90") use the legacy
+  # cuda/hip flows, which AdaptiveCpp discourages outside specific use cases
+  # (acpp emits a warning unless --acpp-no-warn-legacy-flows is given).
   if(NOT ACPP_TARGETS)
-    # Base target is always "generic" (SSCP/JIT) to support CPU and Intel GPU at runtime
-    set(_acpp_auto_targets "generic")
-
-    # Detect NVIDIA GPUs via nvidia-smi and add cuda:sm_XX targets
-    execute_process(
-      COMMAND nvidia-smi --query-gpu=compute_cap --format=csv,noheader
-      OUTPUT_VARIABLE _nvidia_compute_caps
-      RESULT_VARIABLE _nvidia_result
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      ERROR_QUIET
-    )
-    if(_nvidia_result EQUAL 0 AND _nvidia_compute_caps)
-      string(REPLACE "\n" ";" _cap_list "${_nvidia_compute_caps}")
-      set(_cuda_targets "")
-      foreach(_cap IN LISTS _cap_list)
-        string(STRIP "${_cap}" _cap)
-        if(_cap)
-          string(REPLACE "." "" _sm "${_cap}")
-          list(APPEND _cuda_targets "cuda:sm_${_sm}")
-        endif()
-      endforeach()
-      list(REMOVE_DUPLICATES _cuda_targets)
-      foreach(_t IN LISTS _cuda_targets)
-        string(APPEND _acpp_auto_targets ";${_t}")
-      endforeach()
-      message(STATUS "AdaptiveCpp: detected NVIDIA GPU(s): ${_cuda_targets}")
-    else()
-      message(STATUS "AdaptiveCpp: no NVIDIA GPU detected")
-    endif()
-
-    set(ACPP_TARGETS "${_acpp_auto_targets}" CACHE STRING "AdaptiveCpp compilation targets" FORCE)
+    set(ACPP_TARGETS "generic" CACHE STRING "AdaptiveCpp compilation targets" FORCE)
     message(STATUS "AdaptiveCpp: auto-set ACPP_TARGETS=${ACPP_TARGETS}")
   endif()
 

--- a/docs/install_adaptive_cpp.md
+++ b/docs/install_adaptive_cpp.md
@@ -14,13 +14,19 @@ Intel 内蔵 GPU (OpenCL & Level Zero) および NVIDIA GPU (CUDA) の両方に�
 | CPU | x86_64 (20コア) |
 | Intel GPU | Intel(R) Graphics (内蔵 GPU) |
 | NVIDIA GPU | NVIDIA GeForce RTX 5060 Ti |
-| NVIDIA ドライバ | 570.172.08 |
+| NVIDIA ドライバ | 570.172.08 ※ |
 | CUDA | 12.8 (`/usr/local/cuda`) |
 | LLVM / Clang | 20.1.2 |
 | Boost | 1.83 |
 | Level Zero | 1.24.1 |
 | CMake | 3.28.3 |
 | AdaptiveCpp | v25.10.0 |
+
+※ NVIDIA ドライバ のバージョンについて
+
+- **595**系では処理速度が異常に遅くなる現象を確認しています。
+  - USM Sharedメモリのホストデバイスからのアクセス速度が遅くなっているようです。
+- **570**, **580**系では正常に動作することを確認しています。
 
 ---
 

--- a/docs/install_adaptive_cpp.md
+++ b/docs/install_adaptive_cpp.md
@@ -3,12 +3,13 @@
 Intel 内蔵 GPU (OpenCL & Level Zero) および NVIDIA GPU (CUDA) の両方に対応した AdaptiveCpp のビルド手順です。
 
 最新情報は公式ドキュメントを参照してください:
-- https://github.com/AdaptiveCpp/AdaptiveCpp/blob/develop/doc/installing.md
+
+- <https://github.com/AdaptiveCpp/AdaptiveCpp/blob/develop/doc/installing.md>
 
 ## 動作確認環境
 
 | 項目 | バージョン / 値 |
-|------|----------------|
+| ------ | ---------------- |
 | OS | Ubuntu 24.04 |
 | CPU | x86_64 (20コア) |
 | Intel GPU | Intel(R) Graphics (内蔵 GPU) |
@@ -37,8 +38,9 @@ sudo apt-get install -y \
 
 
 # OpenCL・Level Zero
-# (intel-opencl-icd, libze-dev, libze-intel-gpu1, libze1 がインストール済みであること)
+# (ocl-icd-opencl-dev, intel-opencl-icd, libze-dev, libze-intel-gpu1, libze1 がインストール済みであること)
 sudo apt-get install -y \
+    ocl-icd-opencl-dev \
     intel-opencl-icd \
     libze-dev \
     libze-intel-gpu1 \
@@ -93,7 +95,7 @@ cmake .. \
 ### 主要な CMake オプションの説明
 
 | オプション | 値 | 説明 |
-|-----------|-----|------|
+| ----------- | ----- | ------ |
 | `CMAKE_BUILD_TYPE` | `Release` | リリースビルド (最適化あり) |
 | `CMAKE_CXX_COMPILER` | `clang++-20` | C++ コンパイラに Clang 20 を指定 |
 | `LLVM_DIR` | `/usr/lib/llvm-20/lib/cmake/llvm` | LLVM 20 の cmake 設定ディレクトリ |


### PR DESCRIPTION
## 概要

CMake の SYCL 設定と .gitignore の改善を行いました。

## 変更内容

- **cmake/SYCLSetup.cmake**: AdaptiveCPP ターゲット向けの自動 NVIDIA GPU 検出を削除し、設定を簡略化
- **.gitignore**: ビルドディレクトリのパターンを統合・簡略化
- **docs/install_adaptive_cpp.md**: AdaptiveCpp インストールガイドを最新化