### PR TITLE
fix(utils): cap SLM work-group size and align to sub-group size

### DIFF
--- a/cpp/include/sycl_points/algorithms/mapping/occupancy_grid_map.hpp
+++ b/cpp/include/sycl_points/algorithms/mapping/occupancy_grid_map.hpp
@@ -1639,19 +1639,7 @@ private:
     }
 
     size_t compute_work_group_size() const {
-        const size_t max_work_group_size =
-            this->queue_.get_device().get_info<sycl::info::device::max_work_group_size>();
-        const size_t compute_units = this->queue_.get_device().get_info<sycl::info::device::max_compute_units>();
-        if (this->queue_.is_nvidia()) {
-            return std::min(max_work_group_size, size_t{64});
-        }
-        if (this->queue_.is_intel() && this->queue_.is_gpu()) {
-            return std::min(max_work_group_size, compute_units * size_t{8});
-        }
-        if (this->queue_.is_cpu()) {
-            return std::min(max_work_group_size, compute_units * size_t{100});
-        }
-        return std::min<size_t>(128, max_work_group_size);
+        return sycl_utils::compute_work_group_size_for_slm(this->queue_, sizeof(VoxelLocalData));
     }
 
     sycl_utils::DeviceQueue queue_;

--- a/cpp/include/sycl_points/algorithms/mapping/occupancy_grid_map.hpp
+++ b/cpp/include/sycl_points/algorithms/mapping/occupancy_grid_map.hpp
@@ -1639,7 +1639,7 @@ private:
     }
 
     size_t compute_work_group_size() const {
-        return sycl_utils::compute_work_group_size_for_slm(this->queue_, sizeof(VoxelLocalData));
+        return sycl_utils::compute_work_group_size_for_slm(this->queue_.get_device(), sizeof(VoxelLocalData));
     }
 
     sycl_utils::DeviceQueue queue_;

--- a/cpp/include/sycl_points/algorithms/mapping/voxel_hash_map.hpp
+++ b/cpp/include/sycl_points/algorithms/mapping/voxel_hash_map.hpp
@@ -545,7 +545,7 @@ private:
     }
 
     size_t compute_wg_size_add_point_cloud() const {
-        return sycl_utils::compute_work_group_size_for_slm(this->queue_, sizeof(VoxelLocalData));
+        return sycl_utils::compute_work_group_size_for_slm(this->queue_.get_device(), sizeof(VoxelLocalData));
     }
 
     size_t compute_local_size_for_add_point_cloud(bool has_cov) const {

--- a/cpp/include/sycl_points/algorithms/mapping/voxel_hash_map.hpp
+++ b/cpp/include/sycl_points/algorithms/mapping/voxel_hash_map.hpp
@@ -545,20 +545,7 @@ private:
     }
 
     size_t compute_wg_size_add_point_cloud() const {
-        const size_t max_work_group_size =
-            this->queue_.get_device().get_info<sycl::info::device::max_work_group_size>();
-        const size_t compute_units = this->queue_.get_device().get_info<sycl::info::device::max_compute_units>();
-        if (this->queue_.is_nvidia()) {
-            // NVIDIA:
-            return std::min(max_work_group_size, 64UL);
-        } else if (this->queue_.is_intel() && this->queue_.is_gpu()) {
-            // Intel iGPU:
-            return std::min(max_work_group_size, compute_units * 8UL);
-        } else if (this->queue_.is_cpu()) {
-            // CPU:
-            return std::min(max_work_group_size, compute_units * 100UL);
-        }
-        return 128UL;
+        return sycl_utils::compute_work_group_size_for_slm(this->queue_, sizeof(VoxelLocalData));
     }
 
     size_t compute_local_size_for_add_point_cloud(bool has_cov) const {

--- a/cpp/include/sycl_points/utils/device_utils.hpp
+++ b/cpp/include/sycl_points/utils/device_utils.hpp
@@ -1,0 +1,265 @@
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <sycl/sycl.hpp>
+
+namespace sycl_points {
+
+namespace sycl_utils {
+
+namespace VENDOR_ID {
+constexpr uint32_t INTEL = 0x8086;   // 32902
+constexpr uint32_t NVIDIA = 0x10de;  // 4318
+constexpr uint32_t AMD = 0x1002;     // 4098
+#ifdef SYCL_IMPL_ADAPTIVECPP
+constexpr uint32_t OMP = 0xffffffff;  // 4294967295
+#endif
+};  // namespace VENDOR_ID
+
+/// @brief Get backend name as string
+/// @param backend sycl::backend value
+/// @return backend name string
+inline std::string get_backend_name(sycl::backend backend) {
+#ifdef SYCL_IMPL_ADAPTIVECPP
+    // hipsycl::rt::backend_id: cuda=0, hip=1, level_zero=2, ocl=3, omp=4
+    static constexpr const char* BackendNames[] = {"CUDA", "HIP", "Level Zero", "OpenCL", "OpenMP"};
+    const auto idx = static_cast<int>(backend);
+    if (idx >= 0 && idx < static_cast<int>(sizeof(BackendNames) / sizeof(BackendNames[0]))) {
+        return BackendNames[idx];
+    }
+    return "Unknown";
+#else
+    std::ostringstream oss;
+    oss << backend;
+    return oss.str();
+#endif
+}
+
+/// @brief Get device info
+/// @param device SYCL device
+inline std::string get_device_info(const sycl::device& device) {
+    const auto platform = device.get_platform();
+    std::ostringstream oss;
+    oss << "Platform: " << platform.get_info<sycl::info::platform::name>() << "\n";
+
+    for (auto device : platform.get_devices()) {
+        oss << "\tDevice: " << device.get_info<sycl::info::device::name>() << "\n";
+        oss << "\ttype: " << (device.is_cpu() ? "CPU" : "GPU") << "\n";
+        oss << "\tVendor: " << device.get_info<sycl::info::device::vendor>() << "\n";
+        oss << "\tVendorID: " << device.get_info<sycl::info::device::vendor_id>() << "\n";
+        oss << "\tBackend name: " << get_backend_name(device.get_backend()) << "\n";
+#ifndef SYCL_IMPL_ADAPTIVECPP
+        oss << "\tBackend version: " << device.get_info<sycl::info::device::backend_version>() << "\n";
+#endif
+        // NOTE: driver_version cannot be obtained on the Level Zero backend (AdaptiveCpp bug:
+        // uninitialized ze_driver_properties_t is passed to zeDriverGetProperties, causing SEGV).
+        // oss << "\tDriver version: " << device.get_info<sycl::info::device::driver_version>() << "\n";
+        oss << "\tGlobal Memory Size: "
+            << device.get_info<sycl::info::device::global_mem_size>() / 1024.0 / 1024.0 / 1024.0 << " GB" << "\n";
+        oss << "\tLocal Memory Size: " << device.get_info<sycl::info::device::local_mem_size>() / 1024.0 << " KB"
+            << "\n";
+        oss << "\tGlobal Memory Cache Size: "
+            << device.get_info<sycl::info::device::global_mem_cache_size>() / 1024.0 / 1024.0 << " MB" << "\n";
+        oss << "\tGlobal Memory Cache Line Size: " << device.get_info<sycl::info::device::global_mem_cache_line_size>()
+            << " byte" << "\n";
+
+        oss << "\tMax Memory Allocation Size: "
+            << device.get_info<sycl::info::device::max_mem_alloc_size>() / 1024.0 / 1024.0 / 1024.0 << " GB"
+            << "\n";
+
+        oss << "\tMax Work Group Size: " << device.get_info<sycl::info::device::max_work_group_size>() << "\n";
+        oss << "\tMax Work Item Dimensions: " << device.get_info<sycl::info::device::max_work_item_dimensions>()
+            << "\n";
+        oss << "\tMax Work Item Sizes: [";
+        oss << device.get_info<sycl::info::device::max_work_item_sizes<1>>().dimensions << ", ";
+        oss << device.get_info<sycl::info::device::max_work_item_sizes<1>>().dimensions << ", ";
+        oss << device.get_info<sycl::info::device::max_work_item_sizes<1>>().dimensions << "]" << "\n";
+        oss << "\tMax Sub Groups num: " << device.get_info<sycl::info::device::max_num_sub_groups>() << "\n";
+        oss << "\tSub Group Sizes: [";
+        const auto subgroup_sizes = device.get_info<sycl::info::device::sub_group_sizes>();
+        for (size_t i = 0; i < subgroup_sizes.size(); ++i) {
+            oss << subgroup_sizes[i];
+            if (i < subgroup_sizes.size() - 1) {
+                oss << ", ";
+            }
+        }
+        oss << "]" << "\n";
+
+        oss << "\tMax compute units: " << device.get_info<sycl::info::device::max_compute_units>() << "\n";
+
+        oss << "\tMax Clock Frequency: " << device.get_info<sycl::info::device::max_clock_frequency>() / 1000.0
+            << " GHz" << "\n";
+
+        oss << "\tDouble precision support: " << (device.has(sycl::aspect::fp64) ? "true" : "false") << "\n";
+
+        oss << "\tAtomic 64bit support: " << (device.has(sycl::aspect::atomic64) ? "true" : "false") << "\n";
+
+        oss << "\tUSM host allocations: " << (device.has(sycl::aspect::usm_host_allocations) ? "true" : "false")
+            << "\n";
+        oss << "\tUSM device allocations: " << (device.has(sycl::aspect::usm_device_allocations) ? "true" : "false")
+            << "\n";
+        oss << "\tUSM shared allocations: " << (device.has(sycl::aspect::usm_shared_allocations) ? "true" : "false")
+            << "\n";
+
+        oss << "\tUSM atomic shared allocations: "
+            << (device.has(sycl::aspect::usm_atomic_shared_allocations) ? "true" : "false") << "\n";
+
+        oss << "\tAvailable: " << (device.get_info<sycl::info::device::is_available>() ? "true" : "false") << "\n";
+    }
+    return oss.str();
+}
+
+/// @brief Get device info
+/// @param queue SYCL queue
+inline std::string get_device_info(const sycl::queue& queue) { return get_device_info(queue.get_device()); }
+
+/// @brief Print selected device info
+/// @param queue SYCL queue
+inline void print_device_info(const sycl::device& device) { std::cout << get_device_info(device) << std::endl; }
+
+/// @brief Print selected device info
+/// @param queue SYCL queue
+inline void print_device_info(const sycl::queue& queue) { print_device_info(queue.get_device()); }
+
+/// @brief device is CPU or not
+inline bool is_cpu(const sycl::device& device) { return device.is_cpu(); }
+inline bool is_cpu(const sycl::queue& queue) { return is_cpu(queue.get_device()); }
+
+/// @brief device is iGPU/dGPU or not
+inline bool is_gpu(const sycl::device& device) { return device.is_gpu(); }
+inline bool is_gpu(const sycl::queue& queue) { return queue.get_device().is_gpu(); }
+
+/// @brief device is FPGA or not
+inline bool is_accelerator(const sycl::queue& queue) { return queue.get_device().is_accelerator(); }
+
+/// @brief device vendor is NVIDIA or not
+inline bool is_nvidia(const sycl::device& device) {
+    const auto vendor_id = device.get_info<sycl::info::device::vendor_id>();
+    return vendor_id == VENDOR_ID::NVIDIA;
+}
+inline bool is_nvidia(const sycl::queue& queue) {
+    const auto device = queue.get_device();
+    return is_nvidia(device);
+}
+
+/// @brief device vendor is Intel or not
+inline bool is_intel(const sycl::device& device) {
+    const auto vendor_id = device.get_info<sycl::info::device::vendor_id>();
+    return vendor_id == VENDOR_ID::INTEL;
+}
+inline bool is_intel(const sycl::queue& queue) {
+    const auto device = queue.get_device();
+    return is_intel(device);
+}
+
+/// @brief device vendor is AMD or not
+inline bool is_amd(const sycl::device& device) {
+    const auto vendor_id = device.get_info<sycl::info::device::vendor_id>();
+    return vendor_id == VENDOR_ID::AMD;
+}
+inline bool is_amd(const sycl::queue& queue) {
+    const auto device = queue.get_device();
+    return is_amd(device);
+}
+
+inline bool enable_shared_allocations(const sycl::device& device) {
+    return device.has(sycl::aspect::usm_shared_allocations);
+}
+
+namespace device_selector {
+
+inline bool is_supported_device(const sycl::device& dev) { return enable_shared_allocations(dev); }
+
+inline int default_selector_v(const sycl::device& dev) {
+    if (!is_supported_device(dev)) return -1;
+
+    // AdaptiveCpp always exposes its OpenMP host device, even when a GPU
+    // visibility mask is set. Prefer a GPU so a visible Level Zero device is
+    // actually selected instead of silently falling back to the host.
+    return dev.is_gpu() ? 2 : 1;
+}
+
+inline int intel_cpu_selector_v(const sycl::device& dev) {
+    const auto vendor_id = dev.get_info<sycl::info::device::vendor_id>();
+    return dev.is_cpu() && (vendor_id == VENDOR_ID::INTEL) && is_supported_device(dev);
+}
+
+inline int intel_gpu_selector_v(const sycl::device& dev) {
+    const auto vendor_id = dev.get_info<sycl::info::device::vendor_id>();
+    return dev.is_gpu() && (vendor_id == VENDOR_ID::INTEL) && is_supported_device(dev);
+}
+
+inline int nvidia_gpu_selector_v(const sycl::device& dev) {
+    const auto vendor_id = dev.get_info<sycl::info::device::vendor_id>();
+    return dev.is_gpu() && (vendor_id == VENDOR_ID::NVIDIA) && is_supported_device(dev);
+}
+
+inline sycl::device select_device(const std::string& device_vendor, const std::string& device_type) {
+    std::string device_vendor_upper = device_vendor;
+    std::transform(device_vendor_upper.begin(), device_vendor_upper.end(), device_vendor_upper.begin(),
+                   [](u_char c) { return std::toupper(c); });
+    std::string device_type_upper = device_type;
+    std::transform(device_type_upper.begin(), device_type_upper.end(), device_type_upper.begin(),
+                   [](u_char c) { return std::toupper(c); });
+
+    uint32_t vendor_id = 0;
+    if (device_vendor_upper == "INTEL") {
+        vendor_id = VENDOR_ID::INTEL;
+    } else if (device_vendor_upper == "NVIDIA") {
+        vendor_id = VENDOR_ID::NVIDIA;
+    } else if (device_vendor_upper == "AMD") {
+        vendor_id = VENDOR_ID::AMD;
+#ifdef SYCL_IMPL_ADAPTIVECPP
+    } else if (device_vendor_upper == "OMP") {
+        vendor_id = VENDOR_ID::OMP;
+#endif
+    } else if (device_vendor_upper == "DEFAULT") {
+        const auto device_selector = sycl_points::sycl_utils::device_selector::default_selector_v;
+        return sycl::device{device_selector};
+    } else {
+        throw std::runtime_error("[device_selector::select_device] invalid device vendor: " + device_vendor);
+    }
+
+    const bool select_cpu = device_type_upper == "CPU" ? true : false;
+    const bool select_gpu = device_type_upper == "GPU" ? true : false;
+    if (!select_cpu && !select_gpu) {
+        throw std::runtime_error("[device_selector::select_device] not support device type: " + device_type);
+    }
+
+    for (auto platform : sycl::platform::get_platforms()) {
+        for (auto device : platform.get_devices()) {
+            const auto dev_vendor_id = device.get_info<sycl::info::device::vendor_id>();
+            if (vendor_id == dev_vendor_id) {
+#ifdef SYCL_IMPL_ADAPTIVECPP
+                if (vendor_id == VENDOR_ID::OMP) {
+                    return device;
+                }
+#endif
+                if (select_cpu && device.is_cpu()) {
+                    return device;
+                }
+                if (select_gpu && device.is_gpu()) {
+                    return device;
+                }
+            }
+#ifdef SYCL_IMPL_ADAPTIVECPP
+            // AdaptiveCpp: any CPU vendor is exposed via OMP backend
+            else if (select_cpu && dev_vendor_id == VENDOR_ID::OMP) {
+                return device;
+            }
+#endif
+        }
+    }
+    throw std::runtime_error("[device_selector::select_device] not found device: " + device_vendor + "/" + device_type);
+}
+
+}  // namespace device_selector
+
+}  // namespace sycl_utils
+
+}  // namespace sycl_points

--- a/cpp/include/sycl_points/utils/sycl_utils.hpp
+++ b/cpp/include/sycl_points/utils/sycl_utils.hpp
@@ -655,16 +655,12 @@ inline size_t compute_work_group_size_for_slm(const DeviceQueue& queue, const si
     const sycl::device& device = queue.get_device();
     const size_t max_work_group_size = device.get_info<sycl::info::device::max_work_group_size>();
     const size_t compute_units = static_cast<size_t>(device.get_info<sycl::info::device::max_compute_units>());
-    const bool is_cpu = device.is_cpu();
-
-    const auto vendor_id = device.get_info<sycl::info::device::vendor_id>();
-    const bool is_nvidia_device = (vendor_id == VENDOR_ID::NVIDIA);
-    const bool is_intel_device = (vendor_id == VENDOR_ID::INTEL);
+    const bool is_cpu = queue.is_cpu();
 
     size_t wg_size = std::min<size_t>(128, max_work_group_size);
-    if (is_nvidia_device) {
+    if (queue.is_nvidia()) {
         wg_size = std::min(max_work_group_size, size_t{64});
-    } else if (is_intel_device && !is_cpu) {
+    } else if (queue.is_intel() && !is_cpu) {
         wg_size = std::min(max_work_group_size, compute_units * size_t{8});
     } else if (is_cpu) {
         wg_size = std::min(max_work_group_size, compute_units * size_t{100});

--- a/cpp/include/sycl_points/utils/sycl_utils.hpp
+++ b/cpp/include/sycl_points/utils/sycl_utils.hpp
@@ -667,9 +667,13 @@ inline size_t compute_work_group_size_for_slm(const DeviceQueue& queue, const si
     }
 
     // Cap the work-group size so the local reduction buffer fits in SLM.
+    // The kernel consumes additional SLM beyond the accessor (e.g. for barriers and
+    // sub-group shuffles). Measured overhead on Intel GPUs is ~1 KB, so reserve a
+    // 2 KB safety margin below the device limit.
     const size_t local_mem_size = device.get_info<sycl::info::device::local_mem_size>();
-    if (local_mem_size > 0UL) {
-        const size_t max_by_slm = std::max<size_t>(1UL, local_mem_size / slm_entry_size);
+    const size_t slm_margin = 2UL * 1024UL;
+    if (local_mem_size > slm_margin) {
+        const size_t max_by_slm = std::max<size_t>(1UL, (local_mem_size - slm_margin) / slm_entry_size);
         wg_size = std::min(wg_size, max_by_slm);
     }
 

--- a/cpp/include/sycl_points/utils/sycl_utils.hpp
+++ b/cpp/include/sycl_points/utils/sycl_utils.hpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <sycl/sycl.hpp>
 
+#include "device_utils.hpp"
+
 #ifdef SYCL_IMPL_ADAPTIVECPP
 #ifndef SYCL_EXTERNAL
 #define SYCL_EXTERNAL
@@ -19,15 +21,6 @@
 namespace sycl_points {
 
 namespace sycl_utils {
-
-namespace VENDOR_ID {
-constexpr uint32_t INTEL = 0x8086;   // 32902
-constexpr uint32_t NVIDIA = 0x10de;  // 4318
-constexpr uint32_t AMD = 0x1002;     // 4098
-#ifdef SYCL_IMPL_ADAPTIVECPP
-constexpr uint32_t OMP = 0xffffffff;  // 4294967295
-#endif
-};  // namespace VENDOR_ID
 
 /// @brief get device optimized work_group_size
 /// @param device SYCL device
@@ -105,6 +98,46 @@ inline size_t get_global_size(size_t N, size_t work_group_size) {
     return ((N + work_group_size - 1) / work_group_size) * work_group_size;
 }
 
+/// @brief Compute a work-group size for kernels that allocate a local (SLM) reduction buffer.
+/// @param device SYCL device.
+/// @param slm_entry_size Size in bytes of the per work-item local memory entry.
+/// @return Work-group size that fits in the device's shared local memory and is aligned
+///         to a multiple of the maximum supported sub-group size.
+/// @note The work-group size is first derived from a device heuristic (vendor and compute unit
+///       count) and then capped so that `wg_size * slm_entry_size` does not exceed the device's
+///       local memory. A work-group requesting more SLM than available is rejected by the JIT
+///       compiler (e.g. Level Zero returns ZE_RESULT_ERROR_INVALID_ARGUMENT at zeModuleCreate).
+inline size_t compute_work_group_size_for_slm(const sycl::device& device, const size_t slm_entry_size) {
+    const size_t max_work_group_size = device.get_info<sycl::info::device::max_work_group_size>();
+    const size_t compute_units = static_cast<size_t>(device.get_info<sycl::info::device::max_compute_units>());
+    const bool cpu = is_cpu(device);
+
+    size_t wg_size = std::min<size_t>(128, max_work_group_size);
+    if (is_nvidia(device)) {
+        wg_size = std::min(max_work_group_size, size_t{64});
+    } else if (is_intel(device) && !cpu) {
+        wg_size = std::min(max_work_group_size, compute_units * size_t{8});
+    } else if (cpu) {
+        wg_size = std::min(max_work_group_size, compute_units * size_t{100});
+    }
+
+    // Cap the work-group size so the local reduction buffer fits in SLM.
+    // The kernel consumes additional SLM beyond the accessor (e.g. for barriers and
+    // sub-group shuffles). Measured overhead on Intel GPUs is ~1 KB, so reserve a
+    // 2 KB safety margin below the device limit.
+    const size_t local_mem_size = device.get_info<sycl::info::device::local_mem_size>();
+    const size_t slm_margin = 2UL * 1024UL;
+    if (local_mem_size > slm_margin) {
+        const size_t max_by_slm = std::max<size_t>(1UL, (local_mem_size - slm_margin) / slm_entry_size);
+        wg_size = std::min(wg_size, max_by_slm);
+    }
+
+    // Align the work-group size down to a multiple of the sub-group size.
+    const size_t sub_group_size = std::max<size_t>(1UL, get_max_sub_group_size(device));
+    wg_size -= wg_size % sub_group_size;
+    return std::max<size_t>(1UL, wg_size);
+}
+
 /// @brief free with nullptr check
 /// @param data_ptr pointer of data
 /// @param queue SYCL queue
@@ -112,145 +145,6 @@ inline void free(void* data_ptr, const sycl::queue& queue) {
     if (data_ptr != nullptr) {
         sycl::free(data_ptr, queue);
     }
-}
-
-/// @brief Get backend name as string
-/// @param backend sycl::backend value
-/// @return backend name string
-inline std::string get_backend_name(sycl::backend backend) {
-#ifdef SYCL_IMPL_ADAPTIVECPP
-    // hipsycl::rt::backend_id: cuda=0, hip=1, level_zero=2, ocl=3, omp=4
-    static constexpr const char* BackendNames[] = {"CUDA", "HIP", "Level Zero", "OpenCL", "OpenMP"};
-    const auto idx = static_cast<int>(backend);
-    if (idx >= 0 && idx < static_cast<int>(sizeof(BackendNames) / sizeof(BackendNames[0]))) {
-        return BackendNames[idx];
-    }
-    return "Unknown";
-#else
-    std::ostringstream oss;
-    oss << backend;
-    return oss.str();
-#endif
-}
-
-/// @brief Get device info
-/// @param device SYCL device
-inline std::string get_device_info(const sycl::device& device) {
-    const auto platform = device.get_platform();
-    std::ostringstream oss;
-    oss << "Platform: " << platform.get_info<sycl::info::platform::name>() << "\n";
-
-    for (auto device : platform.get_devices()) {
-        oss << "\tDevice: " << device.get_info<sycl::info::device::name>() << "\n";
-        oss << "\ttype: " << (device.is_cpu() ? "CPU" : "GPU") << "\n";
-        oss << "\tVendor: " << device.get_info<sycl::info::device::vendor>() << "\n";
-        oss << "\tVendorID: " << device.get_info<sycl::info::device::vendor_id>() << "\n";
-        oss << "\tBackend name: " << get_backend_name(device.get_backend()) << "\n";
-#ifndef SYCL_IMPL_ADAPTIVECPP
-        oss << "\tBackend version: " << device.get_info<sycl::info::device::backend_version>() << "\n";
-#endif
-        // NOTE: driver_version cannot be obtained on the Level Zero backend (AdaptiveCpp bug:
-        // uninitialized ze_driver_properties_t is passed to zeDriverGetProperties, causing SEGV).
-        // oss << "\tDriver version: " << device.get_info<sycl::info::device::driver_version>() << "\n";
-        oss << "\tGlobal Memory Size: "
-            << device.get_info<sycl::info::device::global_mem_size>() / 1024.0 / 1024.0 / 1024.0 << " GB" << "\n";
-        oss << "\tLocal Memory Size: " << device.get_info<sycl::info::device::local_mem_size>() / 1024.0 << " KB"
-            << "\n";
-        oss << "\tGlobal Memory Cache Size: "
-            << device.get_info<sycl::info::device::global_mem_cache_size>() / 1024.0 / 1024.0 << " MB" << "\n";
-        oss << "\tGlobal Memory Cache Line Size: " << device.get_info<sycl::info::device::global_mem_cache_line_size>()
-            << " byte" << "\n";
-
-        oss << "\tMax Memory Allocation Size: "
-            << device.get_info<sycl::info::device::max_mem_alloc_size>() / 1024.0 / 1024.0 / 1024.0 << " GB"
-            << "\n";
-
-        oss << "\tMax Work Group Size: " << device.get_info<sycl::info::device::max_work_group_size>() << "\n";
-        oss << "\tMax Work Item Dimensions: " << device.get_info<sycl::info::device::max_work_item_dimensions>()
-            << "\n";
-        oss << "\tMax Work Item Sizes: [";
-        oss << device.get_info<sycl::info::device::max_work_item_sizes<1>>().dimensions << ", ";
-        oss << device.get_info<sycl::info::device::max_work_item_sizes<1>>().dimensions << ", ";
-        oss << device.get_info<sycl::info::device::max_work_item_sizes<1>>().dimensions << "]" << "\n";
-        oss << "\tMax Sub Groups num: " << device.get_info<sycl::info::device::max_num_sub_groups>() << "\n";
-        oss << "\tSub Group Sizes: [";
-        const auto subgroup_sizes = device.get_info<sycl::info::device::sub_group_sizes>();
-        for (size_t i = 0; i < subgroup_sizes.size(); ++i) {
-            oss << subgroup_sizes[i];
-            if (i < subgroup_sizes.size() - 1) {
-                oss << ", ";
-            }
-        }
-        oss << "]" << "\n";
-
-        oss << "\tMax compute units: " << device.get_info<sycl::info::device::max_compute_units>() << "\n";
-
-        oss << "\tMax Clock Frequency: " << device.get_info<sycl::info::device::max_clock_frequency>() / 1000.0
-            << " GHz" << "\n";
-
-        oss << "\tDouble precision support: " << (device.has(sycl::aspect::fp64) ? "true" : "false") << "\n";
-
-        oss << "\tAtomic 64bit support: " << (device.has(sycl::aspect::atomic64) ? "true" : "false") << "\n";
-
-        oss << "\tUSM host allocations: " << (device.has(sycl::aspect::usm_host_allocations) ? "true" : "false")
-            << "\n";
-        oss << "\tUSM device allocations: " << (device.has(sycl::aspect::usm_device_allocations) ? "true" : "false")
-            << "\n";
-        oss << "\tUSM shared allocations: " << (device.has(sycl::aspect::usm_shared_allocations) ? "true" : "false")
-            << "\n";
-
-        oss << "\tUSM atomic shared allocations: "
-            << (device.has(sycl::aspect::usm_atomic_shared_allocations) ? "true" : "false") << "\n";
-
-        oss << "\tAvailable: " << (device.get_info<sycl::info::device::is_available>() ? "true" : "false") << "\n";
-    }
-    return oss.str();
-}
-
-/// @brief Get device info
-/// @param queue SYCL queue
-inline std::string get_device_info(const sycl::queue& queue) { return get_device_info(queue.get_device()); }
-
-/// @brief Print selected device info
-/// @param queue SYCL queue
-inline void print_device_info(const sycl::device& device) { std::cout << get_device_info(device) << std::endl; }
-
-/// @brief Print selected device info
-/// @param queue SYCL queue
-inline void print_device_info(const sycl::queue& queue) { print_device_info(queue.get_device()); }
-
-/// @brief device is CPU or not
-inline bool is_cpu(const sycl::queue& queue) { return queue.get_device().is_cpu(); }
-
-/// @brief device is iGPU/dGPU or not
-inline bool is_gpu(const sycl::queue& queue) { return queue.get_device().is_gpu(); }
-
-/// @brief device is FPGA or not
-inline bool is_accelerator(const sycl::queue& queue) { return queue.get_device().is_accelerator(); }
-
-/// @brief device vendor is NVIDIA or not
-inline bool is_nvidia(const sycl::queue& queue) {
-    const auto device = queue.get_device();
-    const auto vendor_id = device.get_info<sycl::info::device::vendor_id>();
-    return vendor_id == VENDOR_ID::NVIDIA;
-}
-
-/// @brief device vendor is Intel or not
-inline bool is_intel(const sycl::queue& queue) {
-    const auto device = queue.get_device();
-    const auto vendor_id = device.get_info<sycl::info::device::vendor_id>();
-    return vendor_id == VENDOR_ID::INTEL;
-}
-
-/// @brief device vendor is AMD or not
-inline bool is_amd(const sycl::queue& queue) {
-    const auto device = queue.get_device();
-    const auto vendor_id = device.get_info<sycl::info::device::vendor_id>();
-    return vendor_id == VENDOR_ID::AMD;
-}
-
-inline bool enable_shared_allocations(const sycl::device& device) {
-    return device.has(sycl::aspect::usm_shared_allocations);
 }
 
 /// @brief sycl::event container
@@ -385,95 +279,6 @@ void clear_read_mostly(sycl::queue&, T*, size_t) {}
 #endif  // SYCL_IMPL_INTEL_DPCPP
 
 }  // namespace mem_advise
-
-namespace device_selector {
-
-inline bool is_supported_device(const sycl::device& dev) { return enable_shared_allocations(dev); }
-
-inline int default_selector_v(const sycl::device& dev) {
-    if (!is_supported_device(dev)) return -1;
-
-    // AdaptiveCpp always exposes its OpenMP host device, even when a GPU
-    // visibility mask is set. Prefer a GPU so a visible Level Zero device is
-    // actually selected instead of silently falling back to the host.
-    return dev.is_gpu() ? 2 : 1;
-}
-
-inline int intel_cpu_selector_v(const sycl::device& dev) {
-    const auto vendor_id = dev.get_info<sycl::info::device::vendor_id>();
-    return dev.is_cpu() && (vendor_id == VENDOR_ID::INTEL) && is_supported_device(dev);
-}
-
-inline int intel_gpu_selector_v(const sycl::device& dev) {
-    const auto vendor_id = dev.get_info<sycl::info::device::vendor_id>();
-    return dev.is_gpu() && (vendor_id == VENDOR_ID::INTEL) && is_supported_device(dev);
-}
-
-inline int nvidia_gpu_selector_v(const sycl::device& dev) {
-    const auto vendor_id = dev.get_info<sycl::info::device::vendor_id>();
-    return dev.is_gpu() && (vendor_id == VENDOR_ID::NVIDIA) && is_supported_device(dev);
-}
-
-inline sycl::device select_device(const std::string& device_vendor, const std::string& device_type) {
-    std::string device_vendor_upper = device_vendor;
-    std::transform(device_vendor_upper.begin(), device_vendor_upper.end(), device_vendor_upper.begin(),
-                   [](u_char c) { return std::toupper(c); });
-    std::string device_type_upper = device_type;
-    std::transform(device_type_upper.begin(), device_type_upper.end(), device_type_upper.begin(),
-                   [](u_char c) { return std::toupper(c); });
-
-    uint32_t vendor_id = 0;
-    if (device_vendor_upper == "INTEL") {
-        vendor_id = VENDOR_ID::INTEL;
-    } else if (device_vendor_upper == "NVIDIA") {
-        vendor_id = VENDOR_ID::NVIDIA;
-    } else if (device_vendor_upper == "AMD") {
-        vendor_id = VENDOR_ID::AMD;
-#ifdef SYCL_IMPL_ADAPTIVECPP
-    } else if (device_vendor_upper == "OMP") {
-        vendor_id = VENDOR_ID::OMP;
-#endif
-    } else if (device_vendor_upper == "DEFAULT") {
-        const auto device_selector = sycl_points::sycl_utils::device_selector::default_selector_v;
-        return sycl::device{device_selector};
-    } else {
-        throw std::runtime_error("[device_selector::select_device] invalid device vendor: " + device_vendor);
-    }
-
-    const bool select_cpu = device_type_upper == "CPU" ? true : false;
-    const bool select_gpu = device_type_upper == "GPU" ? true : false;
-    if (!select_cpu && !select_gpu) {
-        throw std::runtime_error("[device_selector::select_device] not support device type: " + device_type);
-    }
-
-    for (auto platform : sycl::platform::get_platforms()) {
-        for (auto device : platform.get_devices()) {
-            const auto dev_vendor_id = device.get_info<sycl::info::device::vendor_id>();
-            if (vendor_id == dev_vendor_id) {
-#ifdef SYCL_IMPL_ADAPTIVECPP
-                if (vendor_id == VENDOR_ID::OMP) {
-                    return device;
-                }
-#endif
-                if (select_cpu && device.is_cpu()) {
-                    return device;
-                }
-                if (select_gpu && device.is_gpu()) {
-                    return device;
-                }
-            }
-#ifdef SYCL_IMPL_ADAPTIVECPP
-            // AdaptiveCpp: any CPU vendor is exposed via OMP backend
-            else if (select_cpu && dev_vendor_id == VENDOR_ID::OMP) {
-                return device;
-            }
-#endif
-        }
-    }
-    throw std::runtime_error("[device_selector::select_device] not found device: " + device_vendor + "/" + device_type);
-}
-
-}  // namespace device_selector
 
 /// @brief Submit a host-side callable with event dependencies.
 /// @details For Intel DPC++: uses handler::host_task for proper SYCL event integration.
@@ -641,47 +446,6 @@ public:
         sycl_utils::mem_advise::clear_read_mostly<T>(*this->ptr, data_ptr, N);
     }
 };
-
-/// @brief Compute a work-group size for kernels that allocate a local (SLM) reduction buffer.
-/// @param queue Device queue carrying the cached device properties.
-/// @param slm_entry_size Size in bytes of the per work-item local memory entry.
-/// @return Work-group size that fits in the device's shared local memory and is aligned
-///         to a multiple of the maximum supported sub-group size.
-/// @note The work-group size is first derived from a device heuristic (vendor and compute unit
-///       count) and then capped so that `wg_size * slm_entry_size` does not exceed the device's
-///       local memory. A work-group requesting more SLM than available is rejected by the JIT
-///       compiler (e.g. Level Zero returns ZE_RESULT_ERROR_INVALID_ARGUMENT at zeModuleCreate).
-inline size_t compute_work_group_size_for_slm(const DeviceQueue& queue, const size_t slm_entry_size) {
-    const sycl::device& device = queue.get_device();
-    const size_t max_work_group_size = device.get_info<sycl::info::device::max_work_group_size>();
-    const size_t compute_units = static_cast<size_t>(device.get_info<sycl::info::device::max_compute_units>());
-    const bool is_cpu = queue.is_cpu();
-
-    size_t wg_size = std::min<size_t>(128, max_work_group_size);
-    if (queue.is_nvidia()) {
-        wg_size = std::min(max_work_group_size, size_t{64});
-    } else if (queue.is_intel() && !is_cpu) {
-        wg_size = std::min(max_work_group_size, compute_units * size_t{8});
-    } else if (is_cpu) {
-        wg_size = std::min(max_work_group_size, compute_units * size_t{100});
-    }
-
-    // Cap the work-group size so the local reduction buffer fits in SLM.
-    // The kernel consumes additional SLM beyond the accessor (e.g. for barriers and
-    // sub-group shuffles). Measured overhead on Intel GPUs is ~1 KB, so reserve a
-    // 2 KB safety margin below the device limit.
-    const size_t local_mem_size = device.get_info<sycl::info::device::local_mem_size>();
-    const size_t slm_margin = 2UL * 1024UL;
-    if (local_mem_size > slm_margin) {
-        const size_t max_by_slm = std::max<size_t>(1UL, (local_mem_size - slm_margin) / slm_entry_size);
-        wg_size = std::min(wg_size, max_by_slm);
-    }
-
-    // Align the work-group size down to a multiple of the sub-group size.
-    const size_t sub_group_size = std::max<size_t>(1UL, queue.get_max_sub_group_size());
-    wg_size -= wg_size % sub_group_size;
-    return std::max<size_t>(1UL, wg_size);
-}
 
 }  // namespace sycl_utils
 

--- a/cpp/include/sycl_points/utils/sycl_utils.hpp
+++ b/cpp/include/sycl_points/utils/sycl_utils.hpp
@@ -82,6 +82,21 @@ inline size_t get_work_group_size_for_parallel_reduction(const sycl::queue& queu
     return get_work_group_size_for_parallel_reduction(queue.get_device(), work_group_size);
 }
 
+/// @brief Get the maximum supported sub-group size of a device.
+/// @param device SYCL device
+/// @return Maximum supported sub-group size, or 1 when the device does not report any.
+inline size_t get_max_sub_group_size(const sycl::device& device) {
+    try {
+        const auto sub_group_sizes = device.get_info<sycl::info::device::sub_group_sizes>();
+        if (!sub_group_sizes.empty()) {
+            return *std::max_element(sub_group_sizes.begin(), sub_group_sizes.end());
+        }
+    } catch (...) {
+        // sub_group_sizes is not supported on every backend; fall back to 1.
+    }
+    return 1UL;
+}
+
 /// @brief Calculate global_size for a kernel execution based on total number of elements and work_group_size.
 /// @param N total number of elements to process.
 /// @param work_group_size size of each work group.
@@ -486,6 +501,7 @@ class DeviceQueue {
 private:
     size_t work_group_size;
     size_t work_group_size_for_parallel_reduction;
+    size_t max_sub_group_size;
 
 public:
     using Ptr = std::shared_ptr<DeviceQueue>;
@@ -514,6 +530,7 @@ public:
         }
         this->work_group_size = sycl_utils::get_work_group_size(device);
         this->work_group_size_for_parallel_reduction = sycl_utils::get_work_group_size_for_parallel_reduction(device);
+        this->max_sub_group_size = sycl_utils::get_max_sub_group_size(device);
     }
 
     /// @brief Print device info
@@ -546,6 +563,10 @@ public:
     /// @brief get work group size for parallel reduction
     /// @return work group size for parallel reduction
     size_t get_work_group_size_for_parallel_reduction() const { return this->work_group_size_for_parallel_reduction; }
+
+    /// @brief Get the maximum supported sub-group size of the device.
+    /// @return maximum supported sub-group size
+    size_t get_max_sub_group_size() const { return this->max_sub_group_size; }
 
     /// @brief set work group size for parallel reduction
     /// @param wg_size work group size
@@ -620,6 +641,47 @@ public:
         sycl_utils::mem_advise::clear_read_mostly<T>(*this->ptr, data_ptr, N);
     }
 };
+
+/// @brief Compute a work-group size for kernels that allocate a local (SLM) reduction buffer.
+/// @param queue Device queue carrying the cached device properties.
+/// @param slm_entry_size Size in bytes of the per work-item local memory entry.
+/// @return Work-group size that fits in the device's shared local memory and is aligned
+///         to a multiple of the maximum supported sub-group size.
+/// @note The work-group size is first derived from a device heuristic (vendor and compute unit
+///       count) and then capped so that `wg_size * slm_entry_size` does not exceed the device's
+///       local memory. A work-group requesting more SLM than available is rejected by the JIT
+///       compiler (e.g. Level Zero returns ZE_RESULT_ERROR_INVALID_ARGUMENT at zeModuleCreate).
+inline size_t compute_work_group_size_for_slm(const DeviceQueue& queue, const size_t slm_entry_size) {
+    const sycl::device& device = queue.get_device();
+    const size_t max_work_group_size = device.get_info<sycl::info::device::max_work_group_size>();
+    const size_t compute_units = static_cast<size_t>(device.get_info<sycl::info::device::max_compute_units>());
+    const bool is_cpu = device.is_cpu();
+
+    const auto vendor_id = device.get_info<sycl::info::device::vendor_id>();
+    const bool is_nvidia_device = (vendor_id == VENDOR_ID::NVIDIA);
+    const bool is_intel_device = (vendor_id == VENDOR_ID::INTEL);
+
+    size_t wg_size = std::min<size_t>(128, max_work_group_size);
+    if (is_nvidia_device) {
+        wg_size = std::min(max_work_group_size, size_t{64});
+    } else if (is_intel_device && !is_cpu) {
+        wg_size = std::min(max_work_group_size, compute_units * size_t{8});
+    } else if (is_cpu) {
+        wg_size = std::min(max_work_group_size, compute_units * size_t{100});
+    }
+
+    // Cap the work-group size so the local reduction buffer fits in SLM.
+    const size_t local_mem_size = device.get_info<sycl::info::device::local_mem_size>();
+    if (local_mem_size > 0UL) {
+        const size_t max_by_slm = std::max<size_t>(1UL, local_mem_size / slm_entry_size);
+        wg_size = std::min(wg_size, max_by_slm);
+    }
+
+    // Align the work-group size down to a multiple of the sub-group size.
+    const size_t sub_group_size = std::max<size_t>(1UL, queue.get_max_sub_group_size());
+    wg_size -= wg_size % sub_group_size;
+    return std::max<size_t>(1UL, wg_size);
+}
 
 }  // namespace sycl_utils
 


### PR DESCRIPTION
Move work-group size computation into sycl_utils::compute_work_group_size_for_slm. The computed size is capped so wg_size * slm_entry_size stays within the device local memory and aligned down to a multiple of the max supported sub-group size. Fixes ZE_RESULT_ERROR_INVALID_ARGUMENT at zeModuleCreate for kernels whose per-item local buffer would exceed the 64KB SLM limit (e.g. OGM on Arc A310).